### PR TITLE
Fix Hook load, hooks notify and update comments - refs BT#9092

### DIFF
--- a/main/admin/index.php
+++ b/main/admin/index.php
@@ -396,9 +396,9 @@ if (api_is_platform_admin()) {
 
     // Check Hook Event for Admin Block Object
     if (!empty($hook)) {
-        // If not empty, then notify Pre process to Hook Observers for Admin Block
+        // If not empty, then notify Post process to Hook Observers for Admin Block
         $hook->setEventData(array('blocks' => $blocks));
-        $data = $hook->notifyAdminBlock(HOOK_EVENT_TYPE_PRE);
+        $data = $hook->notifyAdminBlock(HOOK_EVENT_TYPE_POST);
         // Check if blocks data is not null
         if (isset($data['blocks'])) {
             // Get modified blocks

--- a/main/inc/lib/hook/HookAdminBlock.php
+++ b/main/inc/lib/hook/HookAdminBlock.php
@@ -22,7 +22,7 @@ class HookAdminBlock extends HookEvent implements HookAdminBlockEventInterface {
 
     /**
      * Notify Hook observers for Admin Block event
-     * @param int $type Set the type of hook event called. 0: HOOK_TYPE_PRE, 1: HOOK_TYPE_POST
+     * @param int $type Set the type of hook event called. 0: HOOK_EVENT_TYPE_PRE, 1: HOOK_EVENT_TYPE_POST
      * @return array|int
      */
     public function notifyAdminBlock($type)

--- a/main/inc/lib/hook/HookEvent.php
+++ b/main/inc/lib/hook/HookEvent.php
@@ -31,6 +31,7 @@ abstract class HookEvent implements HookEventInterface
         $this->eventName = $eventName;
         $this->eventData = array();
         $this->manager = HookManagement::create();
+        $this->loadAttachments();
     }
 
     /**
@@ -150,5 +151,30 @@ abstract class HookEvent implements HookEventInterface
     public function clearAttachments()
     {
         $this->observers->removeAll($this->observers);
+    }
+
+    /**
+     * Load all hook observer already registered from Session or Database
+     * @return $this
+     */
+    public function loadAttachments()
+    {
+        if (isset(self::$hook[$this->eventName]) && is_array(self::$hook[$this->eventName])) {
+            foreach (self::$hook[$this->eventName] as $hookObserver => $val) {
+                $hookObserverInstance = $hookObserver::create();
+                $this->observers->attach($hookObserverInstance);
+            }
+        } else {
+            // Load from Database and save into global name
+            self::$hook[$this->eventName] = $this->manager->listHookObservers($this->eventName);
+            if (isset(self::$hook[$this->eventName]) && is_array(self::$hook[$this->eventName])) {
+                foreach (self::$hook[$this->eventName] as $hookObserver => $val) {
+                    $hookObserverInstance = $hookObserver::create();
+                    $this->observers->attach($hookObserverInstance);
+                }
+            }
+        }
+
+        return $this;
     }
 }

--- a/main/inc/lib/hook/HookWSRegistration.php
+++ b/main/inc/lib/hook/HookWSRegistration.php
@@ -25,7 +25,7 @@ class HookWSRegistration extends HookEvent implements HookWSRegistrationEventInt
      * Notify all Hook observer for WS Registration.
      * This save "server" (soap server) and send to Hook observer to be modified
      * (e.g. add more registration webservice)
-     * @param int $type Set the type of hook event called. 0: HOOK_TYPE_PRE, 1: HOOK_TYPE_POST
+     * @param int $type Set the type of hook event called. 0: HOOK_EVENT_TYPE_PRE, 1: HOOK_EVENT_TYPE_POST
      * @return int
      */
     public function notifyWSRegistration($type)

--- a/main/inc/lib/notification.lib.php
+++ b/main/inc/lib/notification.lib.php
@@ -147,7 +147,7 @@ class Notification extends Model
         $hook = HookNotificationTitle::create();
         if (!empty($hook)) {
             $hook->setEventData(array('title' => $title));
-            $data = $hook->notifyNotificationTitle(HOOK_TYPE_PRE);
+            $data = $hook->notifyNotificationTitle(HOOK_EVENT_TYPE_PRE);
             if (isset($data['title'])) {
                 $title = $data['title'];
             }
@@ -194,7 +194,7 @@ class Notification extends Model
 
         if (!empty($hook)) {
             $hook->setEventData(array('title' => $newTitle));
-            $data = $hook->notifyNotificationTitle(HOOK_TYPE_POST);
+            $data = $hook->notifyNotificationTitle(HOOK_EVENT_TYPE_POST);
             if (isset($data['title'])) {
                 $newTitle = $data['title'];
             }
@@ -328,7 +328,7 @@ class Notification extends Model
         $hook = HookNotificationContent::create();
         if (!empty($hook)) {
             $hook->setEventData(array('content' => $content));
-            $data = $hook->notifyNotificationContent(HOOK_TYPE_PRE);
+            $data = $hook->notifyNotificationContent(HOOK_EVENT_TYPE_PRE);
             if (isset($data['content'])) {
                 $content = $data['content'];
             }
@@ -408,7 +408,7 @@ class Notification extends Model
 
         if (!empty($hook)) {
             $hook->setEventData(array('content' => $content));
-            $data = $hook->notifyNotificationContent(HOOK_TYPE_POST);
+            $data = $hook->notifyNotificationContent(HOOK_EVENT_TYPE_POST);
             if (isset($data['content'])) {
                 $content = $data['content'];
             }


### PR DESCRIPTION
Fix:
Add loadAttachment() method from Hook event class, to register observers
Update use of constants when calling hooks notify 