### PR TITLE
re-activate ldap user search feature using new ldap libs

### DIFF
--- a/main/admin/index.php
+++ b/main/admin/index.php
@@ -120,7 +120,7 @@ if (api_is_platform_admin()) {
         $items[] = array('url'=>'group_add.php', 	'label' => get_lang('AddGroups'));
         $items[] = array('url'=>'group_list.php', 	'label' => get_lang('GroupList'));
     }
-    if (isset($extAuthSource) && isset($extAuthSource['ldap']) && count($extAuthSource['ldap']) > 0) {
+    if (isset($extAuthSource) && isset($extAuthSource['extldap']) && count($extAuthSource['extldap']) > 0) {
         $items[] = array('url'=>'ldap_users_list.php', 	'label' => get_lang('ImportLDAPUsersIntoPlatform'));
     }
     $items[] = array('url'=>'user_fields.php', 	'label' => get_lang('ManageUserFields'));

--- a/main/admin/ldap_users_list.php
+++ b/main/admin/ldap_users_list.php
@@ -17,11 +17,11 @@ $this_section = SECTION_PLATFORM_ADMIN;
 
 api_protect_admin_script();
 
-$action = $_GET["action"];
-$login_as_user_id = $_GET["user_id"];
+$action = @$_GET["action"] ?: null;
+$login_as_user_id = @$_GET["user_id"] ?: null;
 
 // Login as ...
-if ($_GET['action'] == "login_as" && isset ($login_as_user_id))
+if ($action == "login_as" && !empty ($login_as_user_id))
 {
 	login_user($login_as_user_id);
 }
@@ -200,10 +200,10 @@ $form->display();
 
 
 
-$parameters['keyword_username'] = $_GET['keyword_username'];
-$parameters['keyword_firstname'] = $_GET['keyword_firstname'];
-$parameters['keyword_lastname'] = $_GET['keyword_lastname'];
-$parameters['keyword_email'] = $_GET['keyword_email'];
+$parameters['keyword_username'] = @$_GET['keyword_username'] ?: null;
+$parameters['keyword_firstname'] = @$_GET['keyword_firstname'] ?: null;
+$parameters['keyword_lastname'] = @$_GET['keyword_lastname'] ?: null;
+$parameters['keyword_email'] = @$_GET['keyword_email'] ?: null;
 if (isset($_GET['id_session']))
 	$parameters['id_session'] = $_GET['id_session'];
 // Create a sortable table with user-data

--- a/main/auth/ldap/ldap_var.inc.php
+++ b/main/auth/ldap/ldap_var.inc.php
@@ -23,24 +23,24 @@
  * Configuration settings
  */
 // your ldap server
-$ldap_host = api_get_setting('ldap_main_server_address');
+$ldap_host = $extldap_config['host'][0];
 // your ldap server's port number
-$ldap_port = api_get_setting('ldap_main_server_port');
+$ldap_port = @$extldap_config['port'] ?: null;
 //domain
-$ldap_basedn = api_get_setting('ldap_domain');
+$ldap_basedn = $extldap_config['base_dn'];
 
 //search term for students
-$ldap_search_dn = api_get_setting('ldap_search_string');
+$ldap_search_dn = $extldap_config['user_search'];
 
 //additional server params for use of replica in case of problems
-$ldap_host2 = api_get_setting('ldap_replicate_server_address');
-$ldap_port2 = api_get_setting('ldap_replicate_server_port');
+$ldap_host2 = count($extldap_config['host']) > 1 ? $extldap_config['host'][1] : null;
+$ldap_port2 = $extldap_config['port'];
 
 //protocol version - set to 3 for LDAP 3
-$ldap_version = api_get_setting('ldap_version');
+$ldap_version = $extldap_config['protocol_version'];
 
 //non-anonymous LDAP mode
-$ldap_rdn = api_get_setting('ldap_authentication_login');
-$ldap_pass = api_get_setting('ldap_authentication_password');
+$ldap_rdn = $extldap_config['admin_dn'];
+$ldap_pass = $extldap_config['admin_password'];
 
 $ldap_pass_placeholder = "PLACEHOLDER";


### PR DESCRIPTION
Here is a pull request to re-activate the old admin's feature allowing to search a user from ldap directory and import him in Chamilo.
I guess it would have been a better way to rewrite the full feature since the code is quite old but I miss time for that.
Anyway : it works fine now and every php notices has been removed too.