### PR TITLE
Replaced picture_url by picture_uri in user update

### DIFF
--- a/main/admin/user_update_import.php
+++ b/main/admin/user_update_import.php
@@ -168,7 +168,7 @@ function updateUsers($users)
             $status = isset($user['Status']) ? $user['Status'] : $userInfo['status'];
             $officialCode = isset($user['OfficialCode']) ? $user['OfficialCode'] : $userInfo['official_code'];
             $phone = isset($user['PhoneNumber']) ? $user['PhoneNumber'] : $userInfo['phone'];
-            $pictureUrl = isset($user['PictureUri']) ? $user['PictureUri'] : $userInfo['picture_url'];
+            $pictureUrl = isset($user['PictureUri']) ? $user['PictureUri'] : $userInfo['picture_uri'];
             $expirationDate = isset($user['ExpiryDate']) ? $user['ExpiryDate'] : $userInfo['expiration_date'];
             $active = isset($user['Active']) ? $user['Active'] : $userInfo['active'];
             $creatorId = $userInfo['creator_id'];


### PR DESCRIPTION
Fixed the picture_uri value from the database for user_import_update. 

The value was not found and the field set blank, "deleting" all the pictures.

Updated : Also affects 1.10.x