### PR TITLE
add a path for custom templates

### DIFF
--- a/main/inc/lib/template.lib.php
+++ b/main/inc/lib/template.lib.php
@@ -66,6 +66,7 @@ class Template
         $this->load_plugins     = $load_plugins;
 
         $template_paths = array(
+       	    api_get_path(SYS_PATH) . 'custompages', // custom pages folder
             api_get_path(SYS_CODE_PATH).'template', //template folder
             api_get_path(SYS_PLUGIN_PATH) //plugin folder
         );

--- a/main/inc/lib/template.lib.php
+++ b/main/inc/lib/template.lib.php
@@ -66,7 +66,7 @@ class Template
         $this->load_plugins     = $load_plugins;
 
         $template_paths = array(
-       	    api_get_path(SYS_PATH) . 'custompages', // custom pages folder
+            api_get_path(SYS_PATH) . 'custompages', // custom pages folder
             api_get_path(SYS_CODE_PATH).'template', //template folder
             api_get_path(SYS_PLUGIN_PATH) //plugin folder
         );


### PR DESCRIPTION
add the possibility to override all templates by adding a new one with the same name in /custompages directory
This is useful when you want customize a view and keep all change at the next upgrade