### PR TITLE
 add a path for overriding templates

### DIFF
--- a/main/inc/lib/template.lib.php
+++ b/main/inc/lib/template.lib.php
@@ -66,7 +66,7 @@ class Template
         $this->load_plugins     = $load_plugins;
 
         $template_paths = array(
-            api_get_path(SYS_PATH) . 'overrides', // user defined templates
+            api_get_path(SYS_CODE_PATH) . 'overrides', // user defined templates
             api_get_path(SYS_CODE_PATH).'template', //template folder
             api_get_path(SYS_PLUGIN_PATH) //plugin folder
         );

--- a/main/inc/lib/template.lib.php
+++ b/main/inc/lib/template.lib.php
@@ -66,7 +66,7 @@ class Template
         $this->load_plugins     = $load_plugins;
 
         $template_paths = array(
-            api_get_path(SYS_CODE_PATH) . 'overrides', // user defined templates
+            api_get_path(SYS_CODE_PATH) . 'template/overrides', // user defined templates
             api_get_path(SYS_CODE_PATH).'template', //template folder
             api_get_path(SYS_PLUGIN_PATH) //plugin folder
         );

--- a/main/inc/lib/template.lib.php
+++ b/main/inc/lib/template.lib.php
@@ -66,7 +66,7 @@ class Template
         $this->load_plugins     = $load_plugins;
 
         $template_paths = array(
-            api_get_path(SYS_PATH) . 'custompages', // custom pages folder
+            api_get_path(SYS_PATH) . 'overrides', // user defined templates
             api_get_path(SYS_CODE_PATH).'template', //template folder
             api_get_path(SYS_PLUGIN_PATH) //plugin folder
         );

--- a/main/template/overrides/README.md
+++ b/main/template/overrides/README.md
@@ -1,0 +1,9 @@
+This directory is the right place for override an existing template.
+
+Just copy the orginal template with the same relative path.
+ex:
+```
+default/layout/head.tpl
+
+the_plugin_dirnae_name/path/of/template/in/plugins.tpl
+```

--- a/main/template/overrides/README.md
+++ b/main/template/overrides/README.md
@@ -1,6 +1,6 @@
 This directory is the right place for override an existing template.
 
-Just copy the orginal template with the same relative path.
+Just copy the orignal template with the same relative path.
 ex:
 ```
 default/layout/head.tpl


### PR DESCRIPTION
add the possibility to override all templates by adding a new one with the same relative paths and name in /main/template/overrides/ directory

This is useful when you want customize a view and keep all change at the next upgrade (without putting your shoes in the bathtub)