### PR TITLE
Remove Delete Button From Works

### DIFF
--- a/main/work/work.lib.php
+++ b/main/work/work.lib.php
@@ -1591,20 +1591,24 @@ function getWorkListTeacher(
                     '#'
                 );
             }
-            $deleteUrl = api_get_path(WEB_CODE_PATH).'work/work.php?id='.$workId.'&action=delete_dir&'.api_get_cidreq();
-            $deleteLink = '<a href="#" onclick="showConfirmationPopup(this, \'' . $deleteUrl . '\' ) " >' .
-                Display::return_icon(
-                    'delete.png',
-                    get_lang('Delete'),
-                    array(),
-                    ICON_SIZE_SMALL
-                ) . '</a>';
+            // Remove Delete Work Button from action List
+            // Because removeXSS "removes" the onClick JS Event to do the action (See model.ajax.php - Line 1639)
+            // But still can use the another jqgrid button to remove works (trash icon) 
+            //
+            // $deleteUrl = api_get_path(WEB_CODE_PATH).'work/work.php?id='.$workId.'&action=delete_dir&'.api_get_cidreq();
+            // $deleteLink = '<a href="#" onclick="showConfirmationPopup(this, \'' . $deleteUrl . '\' ) " >' .
+            //     Display::return_icon(
+            //         'delete.png',
+            //         get_lang('Delete'),
+            //         array(),
+            //         ICON_SIZE_SMALL
+            //     ) . '</a>';
 
             if (!api_is_allowed_to_edit()) {
-                $deleteLink = null;
+                // $deleteLink = null;
                 $editLink = null;
             }
-            $work['actions'] = $visibilityLink.$correctionLink.$downloadLink.$editLink.$deleteLink;
+            $work['actions'] = $visibilityLink.$correctionLink.$downloadLink.$editLink;
             $works[] = $work;
         }
     }


### PR DESCRIPTION
Temporalmente este cambio es para quitar el boton de Eliminar Tarea, el problema está en que dentro de work.lib.php - linea 1594 se añade al link del boton un evento onclick para llamar a la función correspondiente de validar la acción del usuario (en pocas palabras llama al pop up de confirmación), estas acciones se guardan en html y pasan por una funcion de removeXSS (ver model.ajax.php - Linea 1639) el cual elimina el evento y hace que el boton quede inutilizable.
Aún se puede usar el boton del icono trash para eliminar tb las tareas.