### PR TITLE
fix function return value

### DIFF
--- a/main/inc/lib/AnnouncementManager.php
+++ b/main/inc/lib/AnnouncementManager.php
@@ -1329,7 +1329,7 @@ class AnnouncementManager
             $file_name = $file ['name'];
 
             if (!filter_extension($new_file_name)) {
-                $return - 1;
+                $return = -1;
                 Display :: display_error_message(get_lang('UplUnableToSaveFileFilteredExtension'));
             } else {
                 $new_file_name = uniqid('');


### PR DESCRIPTION
Expression "$return - 1;" has not effect.

Anyway return value of function "edit_announcement_attachment_file" is not checked, but  It may be useful in the future.

This possible defect found by AppChecker.