### PR TITLE
Remove some extrage "hello" in lp_view.php

### DIFF
--- a/main/newscorm/lp_view.php
+++ b/main/newscorm/lp_view.php
@@ -93,9 +93,6 @@ $(document).ready(function() {
 var chamilo_xajax_handler = window.oxajax;
 </script>';
 
-if ($_SESSION['oLP']->mode == 'embedframe' || $_SESSION['oLP']->get_hide_toc_frame() == 1) {
-    $htmlHeadXtra[] = 'hello';
-}
 
 //Impress js
 if ($_SESSION['oLP']->mode == 'impress') {


### PR DESCRIPTION
this commit : https://github.com/chamilo/chamilo-lms/commit/cd9840a186f7ed2714870ef9fbe972ff5a52988a

leave a "hello" in the html head, the previous code :

`$htmlHeadXtra[] = '<script>
    $(document).ready(function() {
        toggle_minipanel();
    });
    </script>';`

it was for the lp if a forum exist to show tabs but, it was changed here https://github.com/chamilo/chamilo-lms/pull/959/files

so i think its safe delete this "hello" just for now 