### PR TITLE
In reports: add new line to show followed student' superiors. Also fix some bugs.

### DIFF
--- a/main/inc/lib/tracking.lib.php
+++ b/main/inc/lib/tracking.lib.php
@@ -1125,6 +1125,26 @@ class Tracking
                 $students[] = $studentData['user_id'];
             }
 
+            $studentBossesList = SessionManager::getAllUsersFromCoursesFromAllSessionFromStatus(
+                'drh_all',
+                $userId,
+                false,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                array(),
+                array(),
+                STUDENT_BOSS
+            );
+            $studentBosses = array();
+            foreach ($studentBossesList as $studentBossData) {
+                $studentBosses[] = $studentBossData['user_id'];
+            }
+
             $teacherList = SessionManager::getAllUsersFromCoursesFromAllSessionFromStatus(
                 'drh_all',
                 $userId,
@@ -1198,6 +1218,25 @@ class Tracking
             $students = array();
             foreach ($studentList as $studentData) {
                 $students[] = $studentData['user_id'];
+            }
+
+            $studentBossesList = UserManager::getUsersFollowedByUser(
+                $userId,
+                STUDENT_BOSS,
+                false,
+                false,
+                false,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                COURSEMANAGER
+            );
+            $studentBosses = array();
+            foreach ($studentBossesList as $studentBossData) {
+                $studentBosses[] = $studentBossData['user_id'];
             }
 
             $teacherList = UserManager::getUsersFollowedByUser(
@@ -1275,6 +1314,7 @@ class Tracking
             'drh' => $humanResourcesList,
             'teachers' => $teachers,
             'students' => $students,
+            'studentBosses' => $studentBosses,
             'courses' => $courses,
             'sessions' => $sessions,
             'assignedCourses' => $assignedCourses

--- a/main/lang/catalan/trad4all.inc.php
+++ b/main/lang/catalan/trad4all.inc.php
@@ -111,7 +111,6 @@ $TheTextYouEnteredDoesNotMatchThePicture = "El text introduït no correspon a la
 $RemoveOldRelationships = "Elimina relacions prèvies";
 $ImportSessionDrhList = "Importa llista de directors de RRHH a les sessions";
 $FollowedStudents = "Estudiants seguits";
-$FollowedStudentBosses = "Superiors d'estudiant seguits";
 $FollowedTeachers = "Professors seguits";
 $AllowOnlyFiles = "Només arxius";
 $AllowOnlyText = "Només resposta en línia";

--- a/main/lang/catalan/trad4all.inc.php
+++ b/main/lang/catalan/trad4all.inc.php
@@ -111,6 +111,7 @@ $TheTextYouEnteredDoesNotMatchThePicture = "El text introduït no correspon a la
 $RemoveOldRelationships = "Elimina relacions prèvies";
 $ImportSessionDrhList = "Importa llista de directors de RRHH a les sessions";
 $FollowedStudents = "Estudiants seguits";
+$FollowedStudentBosses = "Superiors d'estudiant seguits";
 $FollowedTeachers = "Professors seguits";
 $AllowOnlyFiles = "Només arxius";
 $AllowOnlyText = "Només resposta en línia";

--- a/main/lang/english/trad4all.inc.php
+++ b/main/lang/english/trad4all.inc.php
@@ -246,6 +246,7 @@ $TheTextYouEnteredDoesNotMatchThePicture = "The text you entered doesn't match t
 $RemoveOldRelationships = "Remove previous relationships";
 $ImportSessionDrhList = "Import list of HR directors into sessions";
 $FollowedStudents = "Followed students";
+$FollowedStudentBosses = "Followed student' superiors";
 $FollowedTeachers = "Followed teachers";
 $AllowOnlyFiles = "Allow only files";
 $AllowOnlyText = "Allow only text";

--- a/main/lang/english/trad4all.inc.php
+++ b/main/lang/english/trad4all.inc.php
@@ -246,7 +246,6 @@ $TheTextYouEnteredDoesNotMatchThePicture = "The text you entered doesn't match t
 $RemoveOldRelationships = "Remove previous relationships";
 $ImportSessionDrhList = "Import list of HR directors into sessions";
 $FollowedStudents = "Followed students";
-$FollowedStudentBosses = "Followed student' superiors";
 $FollowedTeachers = "Followed teachers";
 $AllowOnlyFiles = "Allow only files";
 $AllowOnlyText = "Allow only text";
@@ -7622,4 +7621,9 @@ $MessagingGDCProjectNumberComment = "You need register a project on <a href=\"ht
 $MessagingGDCApiKeyTitle = "API Key of Google Developer Console for Google Cloud Messaging";
 $MessagingGDCApiKeyComment = "You need enable the Google Cloud Messaging API and create one credential for Android";
 $Overwrite = "Overwrite";
+$TheLogoMustBeSizeXAndFormatY = "The logo must be of %s px in size and in %s format";
+$ResetToTheOriginalLogo = "Original logo recovered";
+$NewLogoUpdated = "New logo uploaded";
+$CurrentLogo = "Current logo";
+$UpdateLogo = "Update logo";
 ?>

--- a/main/lang/spanish/trad4all.inc.php
+++ b/main/lang/spanish/trad4all.inc.php
@@ -246,7 +246,6 @@ $TheTextYouEnteredDoesNotMatchThePicture = "El texto introducido no corresponde 
 $RemoveOldRelationships = "Eliminar relaciones previas";
 $ImportSessionDrhList = "Importar lista de directores RRHH en las sesiones";
 $FollowedStudents = "Estudiantes seguidos";
-$FollowedStudentBosses = "Superiores de estudiante seguidos";
 $FollowedTeachers = "Profesores seguidos";
 $AllowOnlyFiles = "Solo archivos";
 $AllowOnlyText = "Solo respuesta online";
@@ -7647,4 +7646,9 @@ $MessagingGDCProjectNumberComment = "Necesita registrar un proyecto en <a href=\
 $MessagingGDCApiKeyTitle = "API key de Google Developer Console para Google Cloud Messaging";
 $MessagingGDCApiKeyComment = "Necesita habilitar la API de Google Cloud Messaging y crear una credencial para Android";
 $Overwrite = "Sobreescribir";
+$TheLogoMustBeSizeXAndFormatY = "El logo debe ser de un tamaño de %s px y en el formato %s";
+$ResetToTheOriginalLogo = "Reseteado al logo original";
+$NewLogoUpdated = "Nuevo logo subido";
+$CurrentLogo = "Logo activo";
+$UpdateLogo = "Cambiar el logo";
 ?>

--- a/main/lang/spanish/trad4all.inc.php
+++ b/main/lang/spanish/trad4all.inc.php
@@ -246,6 +246,7 @@ $TheTextYouEnteredDoesNotMatchThePicture = "El texto introducido no corresponde 
 $RemoveOldRelationships = "Eliminar relaciones previas";
 $ImportSessionDrhList = "Importar lista de directores RRHH en las sesiones";
 $FollowedStudents = "Estudiantes seguidos";
+$FollowedStudentBosses = "Superiores de estudiante seguidos";
 $FollowedTeachers = "Profesores seguidos";
 $AllowOnlyFiles = "Solo archivos";
 $AllowOnlyText = "Solo respuesta online";

--- a/main/mySpace/index.php
+++ b/main/mySpace/index.php
@@ -189,6 +189,7 @@ $userId  = api_get_user_id();
 $stats = Tracking::getStats($userId);
 
 $students = $stats['students'];
+$studentBosses = $stats['studentBosses'];
 $teachers = $stats['teachers'];
 $humanResourcesUsers = $stats['drh'];
 $assignedCourses = $stats['assignedCourses'];
@@ -218,6 +219,7 @@ $nb_posts = $nb_assignments = 0;
 $inactiveTime = time() - (3600 * 24 * 7);
 $nb_students = 0;
 $numberTeachers = 0;
+$numberStudentBosses = 0;
 $countHumanResourcesUsers = 0;
 $daysAgo = 7;
 $studentIds = array();
@@ -228,13 +230,19 @@ if (!empty($students)) {
     $progress  = Tracking::get_avg_student_progress($studentIds);
     $countAssignments = Tracking::count_student_assignments($studentIds);
     $studentIds = array_values($students);
-    $countHumanResourcesUsers = count($humanResourcesUsers);
 
     // average progress
     $avg_total_progress = $progress / $nb_students;
     // average assignments
     $nb_assignments = $countAssignments / $nb_students;
     $avg_courses_per_student = $count_courses / $nb_students;
+}
+
+if (!empty($studentBosses)) {
+    $numberStudentBosses = count($studentBosses);
+}
+if (!empty($humanResourcesUsers)) {
+    $countHumanResourcesUsers = count($humanResourcesUsers);
 }
 
 if (!empty($teachers)) {
@@ -290,6 +298,15 @@ echo '<div class="report_section">
                 ).'</td>
                 <td align="right">'.$nb_students.'</td>
             </tr>
+
+            <tr>
+                <td>'.Display::url(
+                    get_lang('FollowedStudentBosses'),
+                    api_get_path(WEB_CODE_PATH).'mySpace/users.php?status='.STUDENT_BOSS
+                ).'</td>
+                <td align="right">'.$numberStudentBosses.'</td>
+            </tr>
+
             <tr>
                 <td>'.Display::url(
                     get_lang('FollowedTeachers'),
@@ -312,7 +329,7 @@ echo '<div class="report_section">
                 api_get_path(WEB_CODE_PATH).'mySpace/users.php'
             ).
             '</td>
-                <td align="right">'.($nb_students + $numberTeachers + $countHumanResourcesUsers).$linkAddUser.'</td>
+                <td align="right">'.($nb_students + $numberStudentBosses + $numberTeachers + $countHumanResourcesUsers).$linkAddUser.'</td>
             </tr>
             <tr>
                 <td>'.Display::url(


### PR DESCRIPTION
- In reports, add new line to show followed student' superiors.
- Fix bug showing total number of users followed, as well as number of rrhh resp. followed (when no students were followed the number of rrhh resp. was always zero).
- Add new text label: $FollowedStudentBosses (translated to catalan, spanish and english)