### PR TITLE
Fix FormValidator Css span required visual bug effect - NoRefs

### DIFF
--- a/app/Resources/public/css/base.css
+++ b/app/Resources/public/css/base.css
@@ -1652,7 +1652,7 @@ div.admin_section h4 {
 .toolbar-groups{
     margin-bottom: 30px;
 }
-.form-group  label span{
+#group_edit .form-group label span{
     display: block;
     font-size: 12px;
 }


### PR DESCRIPTION
This fix this visual bug (i can't explain it with words so an image speaks a thousand words)

![visualbugformvalidator](https://cloud.githubusercontent.com/assets/12191804/13886802/afd9a1c2-ed06-11e5-90e1-9eacb5d5c55c.png)
