### PR TITLE
Add config variables for smtp: SMTP_DEBUG and SMTP_SECURE

### DIFF
--- a/app/config/mail.conf.dist.php
+++ b/app/config/mail.conf.dist.php
@@ -17,3 +17,5 @@ $platform_email['SMTP_USER'] = '';
 $platform_email['SMTP_PASS'] = '';
 $platform_email['SMTP_CHARSET'] = 'UTF-8';
 $platform_email['SMTP_UNIQUE_SENDER'] = 0; // to send all mails from the same user
+$platform_email['SMTP_DEBUG'] = 0; // change to 1 to enable smtp debug
+$platform_email['SMTP_SECURE'] = 'tls'; // if you're using SSL: ssl; or TLS: tls. (only used if SMTP_AUTH==1)

--- a/main/inc/lib/api.lib.php
+++ b/main/inc/lib/api.lib.php
@@ -7877,7 +7877,11 @@ function api_mail_html(
         $mail->SMTPAuth = 1;
         $mail->Username = $platform_email['SMTP_USER'];
         $mail->Password = $platform_email['SMTP_PASS'];
+        if (isset($platform_email['SMTP_SECURE'])) {
+            $mail->SMTPSecure = $platform_email['SMTP_SECURE'];
+        }
     }
+    $mail->SMTPDebug = isset($platform_email['SMTP_DEBUG'])?$platform_email['SMTP_DEBUG']:0;
 
     // 5 = low, 1 = high
     $mail->Priority = 3;


### PR DESCRIPTION
SMTP_SECURE parameter needed if you use Amazon e-mail service, for example. 
Added SMTP_DEBUG in mail config file to enable debug as well.