### PR TITLE
Remove hardcoded headers to enable course content caching

### DIFF
--- a/main/inc/lib/document.lib.php
+++ b/main/inc/lib/document.lib.php
@@ -364,8 +364,10 @@ class DocumentManager
             $content_type = self::file_get_mime_type($filename);
             $lpFixedEncoding = api_get_configuration_value('lp_fixed_encoding');
 
-            header('Expires: Wed, 01 Jan 1990 00:00:00 GMT');
-            header('Last-Modified: ' . gmdate('D, d M Y H:i:s') . ' GMT');
+            // Comented to let courses content to be cached in order to improve performance:
+            //header('Expires: Wed, 01 Jan 1990 00:00:00 GMT');
+            //header('Last-Modified: ' . gmdate('D, d M Y H:i:s') . ' GMT');
+
             // Commented to avoid double caching declaration when playing with IE and HTTPS
             //header('Cache-Control: no-cache, must-revalidate');
             //header('Pragma: no-cache');


### PR DESCRIPTION
We were having problems with some courses that were running very slow, after some analysis we found out that the courses were requesting a lot of content (mainly swf files) that were not cached by the web server although it was configured so.
We found out that the content download was directed through a rewrite rule always to the function file_send_for_download in main/inc/lib/document.lib.php, which hardcoded the following headers in the response:
            header('Expires: Wed, 01 Jan 1990 00:00:00 GMT');
            header('Last-Modified: ' . gmdate('D, d M Y H:i:s') . ' GMT');

I have been looking for some reason this was done so, but in the git history I haven't found when or why these lines were introduced.

I don't know if this change can arose other issues as it seems that all or many files downloads may be running this code.

We need to enable caching for the course content because we have some courses which launch a lot of requests and we cannot improve this because the courses were made by external suppliers. We have notice that removing these two lines improves a lot the performance of the course as it lets the content to be cached.

Can you review the change to see if it may cause other issues and give me a hint to understand why this headers were set this way?

Thank you in advance.
