### PR TITLE
Redirect to 'buycourses' plugin after the registration form

### DIFF
--- a/main/auth/inscription.php
+++ b/main/auth/inscription.php
@@ -719,7 +719,7 @@ if ($form->validate()) {
         }
     }
 
-    if(!empty($_SESSION['urlReturn'])){
+    if (!empty($_SESSION['urlReturn'])) {
         $form_data['action'] = api_get_path(WEB_PATH).$_SESSION['urlReturn'];
         Session::erase('urlReturn');
     }

--- a/main/auth/inscription.php
+++ b/main/auth/inscription.php
@@ -719,6 +719,11 @@ if ($form->validate()) {
         }
     }
 
+    if(!empty($_SESSION['urlReturn'])){
+        $form_data['action'] = api_get_path(WEB_PATH).$_SESSION['urlReturn'];
+        Session::erase('urlReturn');
+    }
+
     $form_data = CourseManager::redirectToCourse($form_data);
 
     $form_register = new FormValidator('form_register', 'post', $form_data['action']);

--- a/plugin/buycourses/src/process.php
+++ b/plugin/buycourses/src/process.php
@@ -8,10 +8,12 @@
  * Initialization
  */
 require_once '../config.php';
+use ChamiloSession as Session;
 
 $currentUserId = api_get_user_id();
 
 if (empty($currentUserId)) {
+    Session::write('urlReturn', $_SERVER['REQUEST_URI']);
     header('Location: ' . api_get_path(WEB_CODE_PATH) . 'auth/inscription.php');
     exit;
 }

--- a/plugin/buycourses/src/process.php
+++ b/plugin/buycourses/src/process.php
@@ -13,7 +13,7 @@ use ChamiloSession as Session;
 $currentUserId = api_get_user_id();
 
 if (empty($currentUserId)) {
-    Session::write('urlReturn', $_SERVER['REQUEST_URI']);
+    Session::write('urlReturn', Security :: remove_XSS($_SERVER['REQUEST_URI']));
     header('Location: ' . api_get_path(WEB_CODE_PATH) . 'auth/inscription.php');
     exit;
 }

--- a/plugin/buycourses/view/catalog.tpl
+++ b/plugin/buycourses/view/catalog.tpl
@@ -42,10 +42,10 @@
                                                 </div>
                                             {% elseif course.enrolled == "NO" %}
                                                 <div class="text-center">
-                                                    <a class="ajax btn btn-primary" title="" href="{{ course_description_url }}" data-title="{{ course.title }}">
+                                                    <a class="ajax btn btn-primary btn-sm" title="" href="{{ course_description_url }}" data-title="{{ course.title }}">
                                                         <em class="fa fa-file-text"></em> {{ 'SeeDescription'|get_plugin_lang('BuyCoursesPlugin') }}
                                                     </a>
-                                                    <a class="btn btn-success" title="" href="{{ _p.web_plugin ~ 'buycourses/src/process.php?' ~ {'i': course.id, 't': 1}|url_encode() }}">
+                                                    <a class="btn btn-success btn-sm" title="" href="{{ _p.web_plugin ~ 'buycourses/src/process.php?' ~ {'i': course.id, 't': 1}|url_encode() }}">
                                                         <em class="fa fa-shopping-cart"></em> {{ 'Buy'|get_plugin_lang('BuyCoursesPlugin') }}
                                                     </a>
                                                 </div>
@@ -92,7 +92,7 @@
                                                 </div>
                                             {% elseif session.enrolled == "NO" %}
                                                 <div class="text-center">
-                                                    <a class="btn btn-success" href="{{ _p.web_plugin ~ 'buycourses/src/process.php?' ~ {'i': session.id, 't': 2}|url_encode() }}">
+                                                    <a class="btn btn-success btn-sm" href="{{ _p.web_plugin ~ 'buycourses/src/process.php?' ~ {'i': session.id, 't': 2}|url_encode() }}">
                                                         <em class="fa fa-shopping-cart"></em> {{ 'Buy'|get_plugin_lang('BuyCoursesPlugin') }}
                                                     </a>
                                                 </div>


### PR DESCRIPTION
Problema: En el proceso de compra de un curso de un usuario que no tiene registro en la plataforma, tras ir al formulario de inscripción y completarlo el proceso no vuelve al plugin de venta de cursos lo que genera confusión en la venta.

Propuesta: Creación de una variable de sesión 'urlReturn' que sea la url de regreso. Esta variable podría ser utilizada en la creación de nuevos plugin que requieran el proceso del formulario de inscripción.

