### PR TITLE
Allow erase video-conference records that do not have session recording

### DIFF
--- a/plugin/bbb/lib/bbb.lib.php
+++ b/plugin/bbb/lib/bbb.lib.php
@@ -610,6 +610,33 @@ class bbb
                 $actionLinks = $this->getActionLinks($meetingDB, $record, $isGlobal, $isAdminReport);
                 $item['show_links']  = $recordLink;
                 $item['action_links'] = implode(PHP_EOL, $actionLinks);
+            }else{
+            	$isVisible = $meetingDB['visibility'] != 0;
+            	$linkVisibility = $isVisible
+                    ? Display::url(
+                        Display::return_icon('visible.png', get_lang('MakeInvisible')),
+                        $this->unPublishUrl($meetingDB)
+                    )
+                    : Display::url(
+                        Display::return_icon('invisible.png', get_lang('MakeVisible')),
+                        $this->publishUrl($meetingDB)
+                    );
+                $links = [];
+
+                if (!$isAdminReport) {
+                    $links[] = Display::url(
+                        Display::return_icon('delete.png', get_lang('Delete')),
+                        $this->deleteRecordUrl($meetingDB)
+                    );
+                    $links[] = $linkVisibility;
+                } else {
+                    $links[] = Display::url(
+                        Display::return_icon('course_home.png', get_lang('GoToCourse')),
+                        $this->getListingUrl()
+                    );
+                }
+                $item['show_links'] = get_lang('NoRecording');
+                $item['action_links'] = implode(PHP_EOL, $links);
             }
 
             $item['created_at'] = api_convert_and_format_date($meetingDB['created_at']);
@@ -1113,6 +1140,10 @@ class bbb
 
         if (empty($recordInfo)) {
             if (!$isAdminReport) {
+                $links[] = Display::url(
+                    Display::return_icon('delete.png', get_lang('Delete')),
+                    $this->deleteRecordUrl($meetingInfo)
+                );
                 $links[] = $linkVisibility;
 
                 return $links;

--- a/plugin/bbb/listing.tpl
+++ b/plugin/bbb/listing.tpl
@@ -46,6 +46,8 @@
                     {% if meeting.record == 1 %}
                         {# Record list #}
                         {{ meeting.show_links }}
+                    {% else %}
+                        {{ 'NoRecording'|get_lang }}
                     {% endif %}
                 </td>
 


### PR DESCRIPTION
Las sesiones de la videoconferencia que no tienen grabación no se pueden borrar del listado, incluso si en la configuración de la videoconferencia en el curso está marcado "no grabar las sesiones" en el listado de sesiones no te deja ninguna opción ni de borrar ni de ocultar.

