### PR TITLE
Show custom plugins tabs in the public part of the platform

### DIFF
--- a/main/inc/lib/banner.lib.php
+++ b/main/inc/lib/banner.lib.php
@@ -394,6 +394,25 @@ function return_navigation_array()
                 }
             }
         }
+    }else{
+        // Custom tabs public
+        $customTabs = getCustomTabs();
+        if (!empty($customTabs)) {
+            foreach ($customTabs as $tab) {
+                if (api_get_setting($tab['variable'], $tab['subkey']) == 'true' &&
+                    isset($possible_tabs[$tab['subkey']]) && 
+                    api_get_plugin_setting(strtolower(str_replace('Tabs', '', $tab['subkeytext'])), 'public_main_menu_tab') == 'true'
+                ) {
+                    $possible_tabs[$tab['subkey']]['url'] = api_get_path(WEB_PATH).$possible_tabs[$tab['subkey']]['url'];
+                    $navigation[$tab['subkey']] = $possible_tabs[$tab['subkey']];
+                } else {
+                    if (isset($possible_tabs[$tab['subkey']])) {
+                        $possible_tabs[$tab['subkey']]['url'] = api_get_path(WEB_PATH).$possible_tabs[$tab['subkey']]['url'];
+                        $menu_navigation[$tab['subkey']] = $possible_tabs[$tab['subkey']];
+                    }
+                }
+            }
+        }
     }
 
     return array(

--- a/plugin/buycourses/lang/english.php
+++ b/plugin/buycourses/lang/english.php
@@ -3,6 +3,7 @@ $strings['plugin_title'] = "Sell courses";
 $strings['plugin_comment'] = "Sell courses directly through your Chamilo portal, using a PayPal account to receive funds. Neither the Chamilo association nor the developers involved could be considered responsible of any issue you might suffer using this plugin.";
 $strings['show_main_menu_tab'] = "Show tab in main menu";
 $strings['show_main_menu_tab_help'] = "In case of not wanting to show the tab, you can create this link in your Chamilo homepage : %s";
+$strings['public_main_menu_tab'] = "Show tab public main menu";
 $strings['include_sessions'] = "Include sessions";
 $strings['paypal_enable'] = "Enable PayPal";
 $strings['commissions_enable'] = "Enable Commissions";

--- a/plugin/buycourses/lang/spanish.php
+++ b/plugin/buycourses/lang/spanish.php
@@ -3,6 +3,7 @@ $strings['plugin_title'] = "Venta de cursos";
 $strings['plugin_comment'] = "Vender cursos a través de PayPal directamente desde su portal Chamilo. La asociación Chamilo y los desarrolladores involucrados no pueden ser considerados responsables de cualquier inconveniente que se presente.";
 $strings['show_main_menu_tab'] = "Mostrar pestaña en el menu principal";
 $strings['show_main_menu_tab_help'] = "En caso de no querer mostrar la pestaña, puede agregar el siguiente enlace a su portal Chamilo: %s";
+$strings['public_main_menu_tab'] = "Mostrar pestaña sin login";
 $strings['include_sessions'] = "Incluir sesiones";
 $strings['paypal_enable'] = "Habilitar PayPal";
 $strings['commissions_enable'] = "Habilitar Comisiones";

--- a/plugin/buycourses/src/buy_course_plugin.class.php
+++ b/plugin/buycourses/src/buy_course_plugin.class.php
@@ -54,6 +54,7 @@ class BuyCoursesPlugin extends Plugin
             ",
             array(
                 'show_main_menu_tab' => 'boolean',
+                'public_main_menu_tab' => 'boolean',
                 'include_sessions' => 'boolean',
                 'paypal_enable' => 'boolean',
                 'transfer_enable' => 'boolean',


### PR DESCRIPTION
En el plugin de BuyCourses cuando indicas que se muestre en el menú de navegación no aparece cuando no estas logueado. Una mejora sería crear una variable en la configuración del plugin 'public_main_menu_tab' del tipo booleano para indicar si se muestra en el menú de navegación de la página principal sin realizar login.
