### PR TITLE
Recent messages from a social network group should be the first to show

### DIFF
--- a/main/inc/lib/message.lib.php
+++ b/main/inc/lib/message.lib.php
@@ -763,7 +763,7 @@ class MessageManager
                 WHERE
                     group_id= $group_id AND
                     msg_status NOT IN ('".MESSAGE_STATUS_OUTBOX."', '".MESSAGE_STATUS_DELETED."')
-                ORDER BY id";
+                ORDER BY id DESC";
         $rs = Database::query($sql);
         $data = array();
         if (Database::num_rows($rs) > 0) {


### PR DESCRIPTION
Cuando visualizas los mensajes de la red social, si hay muchos mensajes y están listados en varias páginas debes de ir a la última para ver el más reciente. Creo que es más lógico ir mostrando los mensajes recientes los primeros del listado.