### PR TITLE
Error with query construction, missing "( )"

### DIFF
--- a/main/auth/ldap/authldap.php
+++ b/main/auth/ldap/authldap.php
@@ -387,7 +387,7 @@ function ldap_get_users() {
         }
         $str_query.=" )";
     } else {
-        $str_query= count($ldap_query) > 0 ? $ldap_query[0] : null;
+        $str_query= count($ldap_query) > 0 ? "(".$ldap_query[0].")" : null;
     }
 
     $ds = ldap_connect($ldap_host, $ldap_port);


### PR DESCRIPTION
error when the user search string in auth.conf.php for the LDAP search to import users

adding the extra "( )" englobes the full query and renders it correct as a LDAP filter.