### PR TITLE
Use pChart 2.0.3 to support PHP 7.1 - refs #1725

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -75,7 +75,7 @@
         "zendframework/zend-http": "2.5.1",
 
         "ezyang/htmlpurifier": "4.6.0",
-        "szymach/c-pchart": "2.0.3",
+        "szymach/c-pchart": "2.0.4",
         "aferrandini/phpqrcode": "1.0.1",
         "mpdf/mpdf": "6.1.*",
         "studio-42/elfinder": "2.1.*",

--- a/composer.json
+++ b/composer.json
@@ -75,7 +75,7 @@
         "zendframework/zend-http": "2.5.1",
 
         "ezyang/htmlpurifier": "4.6.0",
-        "szymach/c-pchart": "1.*",
+        "szymach/c-pchart": "2.0.3",
         "aferrandini/phpqrcode": "1.0.1",
         "mpdf/mpdf": "6.1.*",
         "studio-42/elfinder": "2.1.*",

--- a/main/gradebook/lib/fe/flatviewtable.class.php
+++ b/main/gradebook/lib/fe/flatviewtable.class.php
@@ -3,9 +3,9 @@
 
 set_time_limit(0);
 
-use CpChart\Classes\pCache as pCache;
-use CpChart\Classes\pData as pData;
-use CpChart\Classes\pImage as pImage;
+use CpChart\Chart\Cache as pCache;
+use CpChart\Chart\Data as pData;
+use CpChart\Chart\Image as pImage;
 
 /**
  * Class FlatViewTable

--- a/main/gradebook/lib/fe/gradebooktable.class.php
+++ b/main/gradebook/lib/fe/gradebooktable.class.php
@@ -2,9 +2,9 @@
 /* For licensing terms, see license.txt */
 
 use ChamiloSession as Session;
-use CpChart\Classes\pCache as pCache;
-use CpChart\Classes\pData as pData;
-use CpChart\Classes\pImage as pImage;
+use CpChart\Chart\Cache as pCache;
+use CpChart\Chart\Data as pData;
+use CpChart\Chart\Image as pImage;
 
 /**
  * GradebookTable Class

--- a/main/inc/lib/myspace.lib.php
+++ b/main/inc/lib/myspace.lib.php
@@ -1,9 +1,9 @@
 <?php
 /* For licensing terms, see /license.txt */
 
-use CpChart\Classes\pCache as pCache;
-use CpChart\Classes\pData as pData;
-use CpChart\Classes\pImage as pImage;
+use CpChart\Chart\Cache as pCache;
+use CpChart\Chart\Data as pData;
+use CpChart\Chart\Image as pImage;
 
 /**
  * Class MySpace

--- a/main/inc/lib/tracking.lib.php
+++ b/main/inc/lib/tracking.lib.php
@@ -2,9 +2,9 @@
 /* For licensing terms, see /license.txt */
 
 use Chamilo\CoreBundle\Entity\ExtraField as EntityExtraField;
-use CpChart\Classes\pCache as pCache;
-use CpChart\Classes\pData as pData;
-use CpChart\Classes\pImage as pImage;
+use CpChart\Chart\Cache as pCache;
+use CpChart\Chart\Data as pData;
+use CpChart\Chart\Image as pImage;
 use Chamilo\UserBundle\Entity\User;
 use Chamilo\CoreBundle\Entity\Course;
 use Chamilo\CoreBundle\Entity\Session;

--- a/plugin/dashboard/block_evaluation_graph/block_evaluation_graph.class.php
+++ b/plugin/dashboard/block_evaluation_graph/block_evaluation_graph.class.php
@@ -1,9 +1,9 @@
 <?php
 /* For licensing terms, see /license.txt */
 
-use CpChart\Classes\pData as pData;
-use CpChart\Classes\pImage as pImage;
-use CpChart\Classes\pCache as pCache;
+use CpChart\Chart\Data as pData;
+use CpChart\Chart\Image as pImage;
+use CpChart\Chart\Cache as pCache;
 
 
 /**

--- a/plugin/dashboard/block_student_graph/block_student_graph.class.php
+++ b/plugin/dashboard/block_student_graph/block_student_graph.class.php
@@ -9,9 +9,9 @@
  * @author Julio Montoya <gugli100@gmail.com>
  */
 
-use CpChart\Classes\pData as pData;
-use CpChart\Classes\pImage as pImage;
-use CpChart\Classes\pCache as pCache;
+use CpChart\Chart\Data as pData;
+use CpChart\Chart\Image as pImage;
+use CpChart\Chart\Cache as pCache;
 
 /**
  * This class is used like controller for student graph block plugin,

--- a/plugin/dashboard/block_teacher_graph/block_teacher_graph.class.php
+++ b/plugin/dashboard/block_teacher_graph/block_teacher_graph.class.php
@@ -10,9 +10,9 @@
  * required files for getting data
  */
 
-use CpChart\Classes\pData as pData;
-use CpChart\Classes\pImage as pImage;
-use CpChart\Classes\pCache as pCache;
+use CpChart\Chart\Data as pData;
+use CpChart\Chart\Image as pImage;
+use CpChart\Chart\Cache as pCache;
 
 /**
  * This class is used like controller for teacher graph block plugin,


### PR DESCRIPTION
This PR fixes the support for PHP 7.1. However, it also removes support for PHP 5.4, of which the development has stopped in 2014 and support has stopped in 2015. So not sure we could not boost the requirement a bit here and move it to PHP 5.5...
@jmontoyaa any opinion on the matter?

In a sense, with this change we have to decide: either we support 7.1 or we support 5.4, but not both at the same time.