### PR TITLE
Fixes a visual bug with radio buttons when selecting prerequisites.

### DIFF
--- a/main/lp/learnpath.class.php
+++ b/main/lp/learnpath.class.php
@@ -8657,8 +8657,8 @@ class learnpath
 
             $return .= '<tr>';
             $return .= '<td class="radio"' . (($item['item_type'] != TOOL_QUIZ && $item['item_type'] != TOOL_HOTPOTATOES) ? ' colspan="3"' : '') . '>';
-            $return .= '<label for="id' . $item['id'] . '">';
             $return .= '<input' . (in_array($prerequisiteId, array($item['id'], $item['ref'])) ? ' checked="checked" ' : '') . ($item['item_type'] == 'dir' ? ' disabled="disabled" ' : ' ') . 'id="id' . $item['id'] . '" name="prerequisites" style="margin-left:' . $item['depth'] * 10 . 'px; margin-right:10px;" type="radio" value="' . $item['id'] . '" />';
+            $return .= '<label for="id' . $item['id'] . '">';
             $icon_name = str_replace(' ', '', $item['item_type']);
 
             if (file_exists('../img/lp_' . $icon_name . '.png')) {


### PR DESCRIPTION
The label was misplaced. Radiobutton was on top of the icone and not
aligned with the 'none' option.

### Before:
![before](https://cloud.githubusercontent.com/assets/19304198/23827794/962aaf20-06bc-11e7-989c-ab42b1bb1c18.png)
### After:
![after](https://cloud.githubusercontent.com/assets/19304198/23827795/997910fe-06bc-11e7-87c8-be497f8250fa.png)

(@moy)
