### PR TITLE
Hide icon when teachers list is empty.

### DIFF
--- a/main/template/default/user_portal/classic_courses_without_category.tpl
+++ b/main/template/default/user_portal/classic_courses_without_category.tpl
@@ -57,15 +57,17 @@
                         </h4>
                         <div class="course-items-session">
                             <div class="list-teachers">
-                                {{ 'teacher.png' | img(16, 'Professor'|get_lang ) }}
-                                {% for teacher in item.teachers %}
-                                    {% set counter = counter + 1 %}
-                                    {% if counter > 1 %} | {% endif %}
-                                    <a href="{{ teacher.url }}" class="ajax"
-                                       data-title="{{ teacher.firstname }} {{ teacher.lastname }}">
-                                        {{ teacher.firstname }} {{ teacher.lastname }}
-                                    </a>
-                                {% endfor %}
+                                {% if item.teachers|length > 0 %}
+                                    {{ 'teacher.png' | img(16, 'Professor'|get_lang ) }}
+                                    {% for teacher in item.teachers %}
+                                        {% set counter = counter + 1 %}
+                                        {% if counter > 1 %} | {% endif %}
+                                        <a href="{{ teacher.url }}" class="ajax"
+                                        data-title="{{ teacher.firstname }} {{ teacher.lastname }}">
+                                            {{ teacher.firstname }} {{ teacher.lastname }}
+                                        </a>
+                                    {% endfor %}
+                                {% endif %}
                             </div>
 
                             {% if item.student_info %}


### PR DESCRIPTION
I wanted to add this feature but it's already present, though I fix the icons. (#1843)
Icon were still displayed when the teachers list is disabled by admin or when the teachers list is empty. 

### Before: 
![screenshot from 2017-04-19 14-38-01](https://cloud.githubusercontent.com/assets/19304198/25180639/0efdb710-250f-11e7-9732-3eebacb709f0.png)
### After:
![screenshot from 2017-04-19 14-38-36](https://cloud.githubusercontent.com/assets/19304198/25180649/1332481e-250f-11e7-9fe4-d11c0bb7bc72.png)