### PR TITLE
DatePicker.php was deleted by composer update.

### DIFF
--- a/main/announcements/announcements.php
+++ b/main/announcements/announcements.php
@@ -485,7 +485,7 @@ switch ($action) {
 
         $defaults['email_ann'] = true;
 
-        $form->addElement('text', 'title', get_lang('EmailTitle'));
+        $form->addElement('text', 'title', get_lang('EmailTitle'),  array( "onkeypress" => "return event.keyCode != 13;") ); //do not submit on enter
         $form->addRule('title', get_lang('ThisFieldIsRequired'), 'required');
         $form->addElement('hidden', 'id');
         $htmlTags = "<b>".get_lang('Tags')."</b><br /><br />";

--- a/src/Chamilo/CoreBundle/Composer/ScriptHandler.php
+++ b/src/Chamilo/CoreBundle/Composer/ScriptHandler.php
@@ -173,7 +173,6 @@ class ScriptHandler
             __DIR__.'/../../../../main/install/install.class.php',
             __DIR__.'/../../../../main/inc/latex.php',
             __DIR__.'/../../../../main/inc/lib/formvalidator/Element/calendar_popup.php',
-            __DIR__.'/../../../../main/inc/lib/formvalidator/Element/datepicker.php',
             __DIR__.'/../../../../main/inc/lib/formvalidator/Element/datepickerdate.php',
             __DIR__.'/../../../../main/inc/lib/formvalidator/Element/html_editor.php',
             __DIR__.'/../../../../main/inc/lib/formvalidator/Element/select_language.php',


### PR DESCRIPTION
https://github.com/chamilo/chamilo-lms/issues/1694
Every time you do a composer update, the DatePicker.php was removed and not added to the autoloader files generated by 
` composer dump-autoload -o`
(on Mac and windows php unlink will remove DatePicker.php even when datepicker.php is written lowercase)
