### PR TITLE
Cambios en WSAddUserToGroup para suscribir el usuario a un grupo y a sus cursos y sesiones pertenecientes

### DIFF
--- a/main/webservices/registration.soap.php
+++ b/main/webservices/registration.soap.php
@@ -6720,7 +6720,8 @@ $server->wsdl->addComplexType(
     array(
         'secret_key'   => array('name' => 'secret_key', 'type' => 'xsd:string'),
         'user_id' => array('name' => 'user_id', 'type' => 'xsd:string'),
-        'group_id' => array('name' => 'group_id', 'type' => 'xsd:string')
+        'group_id' => array('name' => 'group_id', 'type' => 'xsd:string'),
+        'relation_type' => array('name' => 'relation_type', 'type' => 'xsd:string')
     )
 );
 
@@ -6744,7 +6745,12 @@ function WSAddUserToGroup($params)
 
     $userGroup = new UserGroup();
 
-    return $userGroup->add_user_to_group($params['user_id'], $params['group_id']);
+    return $userGroup->subscribe_users_to_usergroup(
+        $params['group_id'],
+        array(0 => $params['user_id']),
+        false,
+        $params['relation_type']
+    );
 }
 
 /* Add user to group Web Service end */


### PR DESCRIPTION
Usando el WSAddUserToGroup hemos visto que solo añadía el usuario al grupo cuando en realidad lo correcto sería añadir el usuario al grupo y a los cursos y sesiones pertenecientes de ese grupo, a parte siempre añade el usuario con una relation_type de 2 y eso hace que siempre sea de grupo tipo social.

Se ha modificado el WSAddUserToGroup para poder añadir el usuario al grupo y a sus respectivos cursos y sesiones, también hemos añadido un campo más que sería el tipo de relation_type y eso permitirá de que tipo será ese usuario en el grupo. 