### PR TITLE
Exportar certificados por orden alfabético de apellidos

### DIFF
--- a/main/gradebook/lib/GradebookUtils.php
+++ b/main/gradebook/lib/GradebookUtils.php
@@ -796,7 +796,13 @@ class GradebookUtils
             $userListCondition = implode("','", $userList);
             $sql .= " AND u.user_id IN ('$userListCondition')";
         }
-        $sql .= ' ORDER BY u.firstname';
+        $sortLastname = api_get_configuration_value('sort_lastname_export_certificates');
+        if ($sortLastname) {
+            $sql .= ' ORDER BY u.lastname';
+        } else {
+            $sql .= ' ORDER BY u.firstname';
+        }
+        
         $rs = Database::query($sql);
 
         $list_users = [];

--- a/main/install/configuration.dist.php
+++ b/main/install/configuration.dist.php
@@ -813,3 +813,6 @@ INSERT INTO settings_current(variable, subkey, type, category, selected_value, t
 // You need add a new option called "confirmation" to the registration settings
 //INSERT INTO settings_options (variable, value, display_text) VALUES ('allow_registration', 'confirmation', 'MailConfirmation');
 // ------ (End) Custom DB changes
+
+// Sort by lastname in export all certificates.
+// $_configuration['sort_lastname_export_certificates'] = false;


### PR DESCRIPTION
Posibilidad de ordenar los diplomas por apellidos, a través de una variable de configuración para habilitar esta opción.