### PR TITLE
Use of the api_sort_by_first_name function in export all certificates

### DIFF
--- a/main/gradebook/lib/GradebookUtils.php
+++ b/main/gradebook/lib/GradebookUtils.php
@@ -796,7 +796,7 @@ class GradebookUtils
             $userListCondition = implode("','", $userList);
             $sql .= " AND u.user_id IN ('$userListCondition')";
         }
-        $sql .= ' ORDER BY u.firstname';
+        $sql .= ' ORDER BY '.(api_sort_by_first_name() ? 'u.firstname' : 'u.lastname');
         $rs = Database::query($sql);
 
         $list_users = [];


### PR DESCRIPTION
Uso de la función api_sort_by_first_name() para mostrar el orden de los estudiantes en certificados en relación al idioma 