### PR TITLE
Fix: black background in uploaded images

### DIFF
--- a/main/inc/lib/image.lib.php
+++ b/main/inc/lib/image.lib.php
@@ -519,6 +519,8 @@ class GDWrapper extends ImageWrapper
                 break;
             case 'png':
                 $src = @imagecreatefrompng($this->path);
+                @imagealphablending($dest, false);
+                @imagesavealpha($dest, true);
                 @imagecopy($dest, $src, 0, 0, $x, $y, $src_width, $src_height);
                 @imagepng($dest, $this->path);
                 break;


### PR DESCRIPTION
Al subir en el formulario imágenes png en algunos casos sustituye el fondo transparente por un fondo negro. 
Se soluciona usando las funciones imagealphablending y imagesavealpha de PHP