### PR TITLE
Añadir opción de imprimir cabecera por defecto en un pdf

### DIFF
--- a/main/inc/lib/pdf.lib.php
+++ b/main/inc/lib/pdf.lib.php
@@ -354,6 +354,7 @@ class PDF
      * @param string $fileToSave
      * @param bool   $returnHtml
      * @param bool   $addDefaultCss
+     * @param bool   $completeHeader
      *
      * 'I' (print on standard output),
      * 'D' (download file) (this is the default value),
@@ -371,7 +372,8 @@ class PDF
         $saveInFile = false,
         $fileToSave = null,
         $returnHtml = false,
-        $addDefaultCss = false
+        $addDefaultCss = false,
+        $completeHeader = true
     ) {
         $urlAppend = api_get_configuration_value('url_append');
 
@@ -388,7 +390,7 @@ class PDF
         // Formatting the pdf
         $course_data = api_get_course_info($course_code);
 
-        self::format_pdf($course_data);
+        self::format_pdf($course_data, $completeHeader);
 
         $document_html = preg_replace($clean_search, '', $document_html);
 

--- a/main/inc/lib/pdf.lib.php
+++ b/main/inc/lib/pdf.lib.php
@@ -344,12 +344,12 @@ class PDF
     /**
      * Converts an html string to PDF.
      *
-     * @param string $document_html valid html
-     * @param string $css           CSS content of a CSS file
-     * @param string $pdf_name      pdf name
-     * @param string $course_code   course code
-     *                              (if you are using html that are located in the document tool you must provide this)
-     * @param string $outputMode    the MPDF output mode can be:
+     * @param string $document_html  valid html
+     * @param string $css            CSS content of a CSS file
+     * @param string $pdf_name       pdf name
+     * @param string $course_code    course code
+     *                               (if you are using html that are located in the document tool you must provide this)
+     * @param string $outputMode     the MPDF output mode can be:
      * @param bool   $saveInFile
      * @param string $fileToSave
      * @param bool   $returnHtml


### PR DESCRIPTION
Por defecto al usar la función **_content_to_pdf_** inserta en la cabecera del PDF el logo de la plataforma y el nombre del profesor. En la creación de un pdf por parte de algún plugin puede que no se requiera imprimir está cabecera pero que al usar la api de Chamilo (pdf.lib.php) no deja alternativa a ocultarla.
Está modificación no altera el funcionamiento de Chamilo.