### PR TITLE
Actualización de la guía en castellano

### DIFF
--- a/documentation/installation_guide_es_ES.html
+++ b/documentation/installation_guide_es_ES.html
@@ -1,17 +1,21 @@
+<!DOCTYPE html>
 <html lang="es">
 <head>
-    <meta charset="utf-8" />
+    <meta charset="UTF-8">
 	<title>Guia de Instalación de Chamilo 1.11</title>
-    <link rel="stylesheet" href="../web/assets/bootstrap/dist/css/bootstrap.css" type="text/css" media="screen,projection" />
-    <link rel="stylesheet" href="default.css" type="text/css" media="screen,projection" />
-    <link rel="stylesheet" href="default.css" type="text/css" media="screen,projection" />
+    <link rel="stylesheet" href="../web/assets/bootstrap/dist/css/bootstrap.css" type="text/css" media="screen" />
+    <link rel="stylesheet" href="../web/assets/fontawesome/css/font-awesome.min.css" type="text/css" media="screen" />
+    <link rel="stylesheet" href="default.css" type="text/css" media="screen" />
+    <link rel="stylesheet" href="default.css" type="text/css" media="screen" />
 </head>
-
 <body>
 <nav class="navbar navbar-default navbar-fixed-top">
     <div class="container">
         <div class="navbar-header">
-            <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#bs-example-navbar-collapse-1">
+            <button type="button"
+                class="navbar-toggle collapsed"
+                data-toggle="collapse"
+                data-target="#bs-example-navbar-collapse-1">
                 <span class="sr-only">Toggle navigation</span>
                 <span class="icon-bar"></span>
                 <span class="icon-bar"></span>
@@ -19,7 +23,6 @@
             </button>
             <a class="navbar-brand" href="#">Chamilo - Documentation</a>
         </div>
-
         <div class="collapse navbar-collapse">
             <ul class="nav navbar-nav">
                 <li class="active"><a href="index.html">Home</a></li>
@@ -48,337 +51,503 @@
   <li>Prueba Chamilo en <a href="http://campus.chamilo.org">nuesto Campus libre</a></li>
 </ul>
 
-
 <p>Esta guía explica como instalar Chamilo LMS. Por favor, léala completamente antes de proceder con la instalación.</p>
 <p>English: Get back to the <a href="installation_guide.html">English version of the installation guide</a>.</p>
 <p>French: Vous pouvez aussi lire <a href="installation_guide_fr_FR.html">ce guide d'installation en français</a>.</p>
 <p>Italian: You can also read <a href="installation_guide_it_IT.html">this guide in Italian</a>.</p>
 
-
-
 <h2><b>Contenidos</b></h2>
-
 <ol>
-
   <li><a href="#1._Pre-requisites">Prerrequisitos</a></li>
   <li><a href="#2._Installation_of_Chamilo_LMS">Instalación de Chamilo LMS</a></li>
   <li><a href="#3._Upgrade_from_a_previous_version_of">Actualizar desde una versión previa de Chamilo o Dok€os</a></li>
   <li><a href="#4._Troubleshooting">Resolución de problemas</a></li>
   <li><a href="#5._Administration_section">Sección de administración</a></li>
   <li><a href="#6._LDAP">LDAP</a></li>
-  <li><a href="#7._Mathematical_formulas">Fórmulas Matemáticas con LaTeX</a></li>
-  <li><a href="#8._ASCIIMathML_mathematical_formulas">Fórmulas Matemáticas con ASCIIMathML</a></li>
   <li><a href="#9._WIRIS_mathematical_formulas">Fórmulas Matemáticas con WIRIS</a></li>
   <li><a href="#10._xapian">Indexación de texto completo con Xapian</a></li>
   <li><a href="#11._rapid">Chamilo Rapid - sistema conversion PPT</a></li>
   <li><a href="#12._cron">Configuración de tareas programadas</a></li>
   <li><a href="#13._name_order">Cambiando el orden del nombre/apellido en el idioma</a></li>
-  <li><a href="#14._alter_conf">Configuraciones opcionales para Apache y Nginx</a></li>
+  <li><a href="#14._Improving_files_download">Mejora de la eficacia de descarga de archivos</a></li>
+  <li><a href="#15._Videoconference">Videoconferencia</a></li>
+  <li><a href="#16._Rewrite">Rewrite</a></li>
+  <li><a href="#17._Git_Upgrade">Actualización de Git</a></li>
 </ol>
-
-
-<br />
-
 <hr style="width: 100%; height: 2px;" />
-<h2><a name="1._Pre-requisites"></a>1. Prerrequisitos</h2>
 
+<h2><a id="1._Pre-requisites"></a>1. Prerrequisitos</h2>
 <p>
-Chamilo puede ser instalado indiferentemente en servidores Windows, Linux, Mac OS X y UNIX. Sin embargo, nosotros recomendamos el uso de un servidor Linux para una óptima flexibilidad, control remoto y escalabilidad.
+  Chamilo puede ser instalado indiferentemente en servidores Windows, Linux, Mac OS X y UNIX.
+  Sin embargo, nosotros recomendamos el uso de un servidor Linux para una óptima flexibilidad,
+  control remoto y escalabilidad.
 </p>
 <p>
-Chamilo es fundamentalmente un LMS que se ejecuta con:
+  Chamilo es fundamentalmente un LMS que se ejecuta con:
 </p>
 <ul>
-    <li><span style="font-weight: bold;">Apache 2.2+</span></li>
-    <li><span style="font-weight: bold;">MySQL 5.6+ o MariaDB 5+</span></li>
-    <li><span style="font-weight: bold;">PHP 5.5+ (7.1 recomendado)</span></li>
+  <li><span style="font-weight: bold;">Apache 2.2+</span></li>
+  <li><span style="font-weight: bold;">MySQL 5.6+ o MariaDB 5+</span></li>
+  <li><span style="font-weight: bold;">PHP 5.5+ (7.2 recomendado para mayor eficiencia)</span></li>
 </ul>
 <p>
-Todo este software es software de código abierto y está disponible libremente.
+  Todo este software es software de código abierto y está disponible libremente.
 </p>
 <div>
-Para ejecutar Chamilo LMS en su servidor, necesita instalar WAMP, LAMP o MAMP:
-<ul>
-<li>Para instalar WAMP (AMP en Windows), recomendamos el instalador <a href="http://www.apachefriends.org/en/xampp.html">XAMPP</a>.exe</li>
-<li>Para instalar LAMP (AMP en Linux), use el administrador de paquetes de su distribución favorita (Synaptic, RPMFinder etc.). Por ejemplo, en un servidor Ubuntu, use Shell o Synaptic siguiendo la <a href="http://ubuntuguide.org/wiki/Ubuntu:Feisty#Apache_HTTP_Server">Ubuntuguide on Apache</a> y las secciones siguientes.</li>
-<li>Para instalar MAMP (AMP en Mac OS X), referirse al sitio web dedicado a <a href="http://www.mamp.info/en/index.html">MAMP</a></li>
-<li>Asegúrese de revisar la página Dependencias, si necesita saber los requisitos de una manera más precisa.</li>
-</ul>
+  Para ejecutar Chamilo LMS en su servidor, necesita instalar WAMP, LAMP o MAMP:
+  <ul>
+    <li>
+      Para instalar WAMP (AMP en Windows), recomendamos el instalador
+      <a href="http://www.apachefriends.org/en/xampp.html">XAMPP</a>.exe
+    </li>
+	<li>
+	  Para instalar LAMP (AMP en Linux), use el administrador de paquetes de su distribución favorita
+	  (Synaptic, RPMFinder etc.). Por ejemplo, en un servidor Ubuntu, use Shell o Synaptic siguiendo la
+	  <a href="http://ubuntuguide.org/wiki/Ubuntu:Feisty#Apache_HTTP_Server">Ubuntuguide on Apache</a>
+	  y las secciones siguientes.
+	</li>
+	<li>
+	  Para instalar MAMP (AMP en Mac OS X), referirse al sitio web dedicado a
+	  <a href="http://www.mamp.info/en/index.html">MAMP</a>
+	</li>
+	<li>Asegúrese de revisar la página Dependencias, si necesita saber los requisitos de una manera más precisa.</li>
+  </ul>
 </div>
 
 <h3><span style="font-weight: bold;">Servidor de Base de Datos MySQL</span></h3>
-
-    <p>Usted necesitará un nombre de usuario y contraseña que le permita administrar <em>y borrar+crear una base de datos</em>.
-    Por lo general, la configuración predeterminada en los equipos locales es permitir que usted conecte
-    como root con una contraseña vacía. Se recomienda cambiar la contraseña y definir un usuario con acceso
-    sólo a una base de datos específica. Por favor, consulte la documentación de MySQL o MariaDB con el fin de hacer esto. </p>
+<p>
+  Usted necesitará un nombre de usuario y contraseña que le permita administrar <em>y borrar+crear una base de datos</em>.
+  Por lo general, la configuración predeterminada en los equipos locales es permitir que usted conecte
+  como root con una contraseña vacía. Se recomienda cambiar la contraseña y definir un usuario con acceso
+  sólo a una base de datos específica. Por favor, consulte la documentación de MySQL o MariaDB con el fin de hacer esto.
+</p>
 <span class="text-muted">
-Nota:Esto se ha simplificado en gran medida desde la versión 1.9, ya que antes era necesario elegir entre
-    múltiples bases de datos y un modo obsoleto de una sola base de datos.
+  Nota:Esto se ha simplificado en gran medida desde la versión 1.9, ya que antes era necesario elegir entre
+  múltiples bases de datos y un modo obsoleto de una sola base de datos.
 </span><br />
-<span class="text-muted">Si no tiene permisos para borrar y crear la base de datos seleccionada, la instalación de
-    Chamilo no funcionará porque, para mantener la base de datos limpia de todos restos de otras instalaciones,
-    intentará borrar (drop) la base de datos antes de volverla a crear. Eso se explica en cierto detalle en <a href="https://github.com/chamilo/chamilo-lms/issues/2172">este reporte</a></span><br />
+<span class="text-muted">
+  Si no tiene permisos para borrar y crear la base de datos seleccionada, la instalación de
+  Chamilo no funcionará porque, para mantener la base de datos limpia de todos restos de otras instalaciones,
+  intentará borrar (drop) la base de datos antes de volverla a crear. Eso se explica en cierto detalle en
+  <a href="https://github.com/chamilo/chamilo-lms/issues/2172">este reporte</a>
+</span><br />
 
-
-    <h3><span style="font-weight: bold;">Redirecciones de Apache</span></h3>
-<div>
-    Desde su versión 1.10, Chamilo requiere del servidor web que pueda gestionar redirecciones. Es algo muy comunes entre todos los sistemas web (ya sean CMS, LMS, ERP, etc) que permite, entre otras cosas, el uso inteligente y amigable de las URLs.<br />
-    Si no usa Apache, debería consultar la sección "Configuraciones opcionales para Apache y Nginx" al fin de este documento.<br />
-    Si usa Apache, configurar las redirecciones consta de dos pasos:
-    <ul>
-        <li>Activar el módulo "rewrite" de Apache (en línea de comando con "<i>sudo a2enmod rewrite</i>")</li>
-        <li>Configurar el VirtualHost de Apache para que incluya el bloque siguiente, autorizando la interpretación de los archivos .htaccess</li>
-    </ul>
-    Para Apache <=2.2 (remplace /var/www/chamilo/ por la ruta de su carpeta Chamilo en el servidor):
-    <pre>
-    &lt;Directory /&gt;
-        AllowOverride All
-        Order allow,deny
-        allow from all
-    &lt;/Directory&gt;
-    &lt;Directory /var/www/chamilo/&gt;
-        AllowOverride All
-        Order allow,deny
-        allow from all
-    &lt;/Directory&gt;
-    </pre>
-    y para Apache >=2.4:
-    <pre>
-    &lt;Directory /&gt;
-        AllowOverride All
-        Require all granted
-    &lt;/Directory&gt;
-    &lt;Directory /var/www/chamilo/&gt;
-        AllowOverride All
-        Require all granted
-    &lt;/Directory&gt;
-    </pre>
-    <br />
-    Una vez configurada esta parte (que quizás ya esté configurada por su proveedor), basta con reiniciar el servidor web para activar el cambio.
-</div>
-
-<hr style="width: 100%; height: 2px;" />
-<h2><a name="2._Installation_of_Chamilo_LMS"></a><span style="font-weight: bold;">2. Instalación de Chamilo LMS</span></h2>
-
-<div>
-    Antes de inciar la instalación de Chamilo LMS, debe entender que, como proveemos Chamilo como
-    un paquete de software libre, diversos proveedores (oficiales y no-oficiales) han podido
-    desarrollar extensiones de Chamilo, las cuales han hecho posible la instalación de Chamilo
-    de muchas maneras distintas:<br />
+<h3><span style="font-weight: bold;">Redirecciones de Apache</span></h3>
+<p>
+  Desde su versión 1.10, Chamilo requiere del servidor web que pueda gestionar redirecciones.
+  Es algo muy comunes entre todos los sistemas web (ya sean CMS, LMS, ERP, etc) que permite,
+  entre otras cosas, el uso inteligente y amigable de las URLs.<br />
+  Si no usa Apache, debería consultar la sección "Configuraciones opcionales para Apache y
+  Nginx" al fin de este documento.<br />
+  Si usa Apache, configurar las redirecciones consta de dos pasos:
+</p>
 <ul>
-    <li>Como un solo paquete a través de un proveedor oficial certificado por la Asociación Chamilo </li>
-    <li>Como una solución instalable en unos de muchos proveedores de alojamiento que soportan cPanel con Scriptaculous</li>
-    <li>Con vuestro proveedor de alojamiento preferido, usando instladores a distancia como el Installatron</li>
-    <li>En vuestro propio servidor, descargando e instalando Chamilo manualmente</li>
-    <li>En vuestra computadora, en casa o en la oficina, solo para probarlo o desarrollarlo</li>
+  <li>Activar el módulo "rewrite" de Apache (en línea de comando con "<i>sudo a2enmod rewrite</i>")</li>
+  <li>
+    Configurar el VirtualHost de Apache para que incluya el bloque siguiente, autorizando la interpretación
+    de los archivos .htaccess
+  </li>
 </ul>
-Esta guía solo cubre los dos últimos métodos. Para los demás, siempre podeis consultar las posibilidades con vuestro proveedor.
+Para Apache &lt;=2.2 (remplace /var/www/chamilo/ por la ruta de su carpeta Chamilo en el servidor):
+<pre>
+&lt;Directory /&gt;
+  AllowOverride All
+  Order allow,deny
+  allow from all
+&lt;/Directory&gt;
+&lt;Directory /var/www/chamilo/&gt;
+    AllowOverride All
+    Order allow,deny
+    allow from all
+&lt;/Directory&gt;
+</pre>
+y para Apache >=2.4:
+<pre>
+&lt;Directory /&gt;
+  AllowOverride All
+  Require all granted
+&lt;/Directory&gt;
+&lt;Directory /var/www/chamilo/&gt;
+  AllowOverride All
+  Require all granted
+&lt;/Directory&gt;
+</pre>
+<br />
+Una vez configurada esta parte (que quizás ya esté configurada por su proveedor), basta con reiniciar el servidor web para activar el cambio.
+<hr style="width: 100%; height: 2px;" />
 
+<h2><a id="2._Installation_of_Chamilo_LMS"></a><span style="font-weight: bold;">2. Instalación de Chamilo LMS</span></h2>
+<p>
+  Antes de inciar la instalación de Chamilo LMS, debe entender que, como proveemos Chamilo como
+  un paquete de software libre, diversos proveedores (oficiales y no-oficiales) han podido
+  desarrollar extensiones de Chamilo, las cuales han hecho posible la instalación de Chamilo
+  de muchas maneras distintas:
+</p>
 <ul>
-  <li><a href="http://www.chamilo.org/">Descargar Chamilo LMS</a></li>
+  <li>Como un solo paquete a través de un proveedor oficial certificado por la Asociación Chamilo </li>
+  <li>Como una solución instalable en unos de muchos proveedores de alojamiento que soportan cPanel con Scriptaculous</li>
+  <li>Con vuestro proveedor de alojamiento preferido, usando instaladores a distancia como el Installatron</li>
+  <li>En vuestro propio servidor, descargando e instalando Chamilo manualmente</li>
+  <li>En vuestra computadora, en casa o en la oficina, solo para probarlo o desarrollarlo</li>
+</ul>
+<p>
+  Esta guía solo cubre los dos últimos métodos. Para los demás, siempre podeis consultar las posibilidades
+  con vuestro proveedor.
+</p>
+Para instalar, sigue estos sencillos 6 pasos:
+<ol>
+  <li><a href="https://chamilo.org/es/chamilo-lms/">Descargar Chamilo LMS</a></li>
   <li>Descomprimirlo.</li>
-  <li>Copiar el directorio de Chamilo en su directorio web de Apache. Este puede ser
-    <span style="font-weight: bold;">C:\xampp\htdocs\</span> en un servidor Windows o <span style="font-weight: bold;">/var/www/html/</span> en un servidor Linux.</li>
-    <li>Verificar que su servidor web soporta los archivos .htaccess (ver sección de Rewrite más a bajo) (este paso es nuevo en comparación con versiones anteriores)</li>
+  <li>
+    Copiar el directorio de Chamilo en su directorio web de Apache. Este puede ser
+    <span style="font-weight: bold;">C:\xampp\htdocs\</span> en un servidor Windows
+    o <span style="font-weight: bold;">/var/www/html/chamilo</span> (o /var/www/chamilo/)
+    en un servidor Linux.
+  </li>
+  <li>
+    Verificar que su servidor web soporta los archivos .htaccess (ver sección de Rewrite más a bajo)
+    (este paso es nuevo en comparación con versiones anteriores)
+  </li>
   <li>Abrir su navegador web (Internet Explorer, Firefox, Chrome, ...) y escribir
     <span style="font-weight: bold;">http://localhost/chamilo/</span> si se instala de manera local o
-    <span style="font-weight: bold;">http://www.domain.com/chamilo/</span> si se instala remotamente.</li>
-  <li>Seguir el proceso de instalación web. Usted puede aceptar todos los valores
-predeterminados. Considere cambiar la contraseña de administrador y recuérdela.&nbsp;</li>
-</ul>
-</div>
-
-    <span class="text-muted">* Recomendammos definir un VirtualHost específico para esta instalación, si tiene las competencias para hacerlo.</span>
-    <br /><br />
+    <span style="font-weight: bold;">http://www.tu-dominio-chamilo.com</span> si se instala remotamente.</li>
+  <li>Seguir el proceso de instalación web. Usted puede aceptar todos los valores predeterminados.
+    Considere cambiar la contraseña de administrador y recuérdela.&nbsp;</li>
+</ol>
 <span class="text-muted">
-    Nota: en caso de instalar Chamilo localmente usando "localhost" o la dirección IP de la máquina durante la instalación, algunos problemas podrían
-    presentarse cuando se acceda desde otra computadora. Para evitarlo, recomendamos la lectura
-    <a href="https://beeznest.com/blog/2013/01/15/answering-to-different-addresses-with-chamilo/">de este artículo para aprender como cambiar su archivo de configuración</a>.
+  * Recomendammos definir un VirtualHost específico para esta instalación, si tiene las competencias para hacerlo.
 </span>
-    <br /><br />
-<p>
-Los siguientes directorios necesitan tener permisos de lectura, escritura y ejecución en el servidor web. Esto por lo general no requiere ninguna acción específica en los servidores de Windows, pero se requiere un "chmod" bajo Linux y Mac. Consulte las siguientes instrucciones.
-</p>
+<br />
 
-<div>
+<h3>Recomendaciones</h3>
+<ul>
+  <li>Recomendamos definir un Virtual Host especifico para esta instalación.</li>
+  <li>
+    Si tiene que instalar varias instancias de Chamilo, evite la instalación de Chamilo dentro de una carpeta,
+    prefiera el uso de diferentes dominios o el uso de ejemplos de subdominios:
+    <ol>
+      <li>http://www.mi-dominio.com/ (<i class="fa fa-check" aria-hidden="true"></i> recomendado)</li>
+      <li>http://chamilo.mi-dominio.com (<i class="fa fa-check" aria-hidden="true"></i> recomendado)</li>
+      <li>http://chamilo2.mi-dominio.com (<i class="fa fa-check" aria-hidden="true"></i> recomendado)</li>
+      <li>http://www.mi-dominio.com/chamilo (<i class="fa fa-times" aria-hidden="true"></i> no recomendado)</li>
+      <li>http://www.mi-dominio.com/chamilo2 (<i class="fa fa-times" aria-hidden="true"></i> no recomendado)</li>
+      <li>http://chamilo.mi-dominio.com/my-chamilo/ (<i class="fa fa-times" aria-hidden="true"></i> no recomendado)</li>
+    </ol>
+  </li>
+</ul>
+    
+<span class="text-muted">
+  Nota: en caso de instalar Chamilo localmente usando "localhost" o la dirección IP de la máquina durante
+  la instalación, algunos problemas podrían presentarse cuando se acceda desde otra computadora. Para evitarlo,
+  recomendamos la lectura 
+  <a href="https://beeznest.com/blog/2013/01/15/answering-to-different-addresses-with-chamilo/">
+    de este artículo para aprender como cambiar su archivo de configuración
+  </a>.
+</span>
+
+<h3>Permisos</h3>
+<p>
+  Los siguientes directorios necesitan tener permisos de lectura, escritura y ejecución en el servidor web.
+  Esto por lo general no requiere ninguna acción específica en los servidores de Windows, pero se requiere
+  un "chmod" bajo Linux y Mac. Consulte las siguientes instrucciones.
+</p>
 Remplace [chamilo] por el directorio en el cual está ubicado su Chamilo:
 <ul>
-    <li>[chamilo]/app/</li>
-    <li>[chamilo]/vendor/ (solo en lectura y ejecución)</li>
-    <li>[chamilo]/web/</li>
-    <li>[chamilo]/main/default_course_document/images/</li>
+  <li>[chamilo]/app/</li>
+  <li>[chamilo]/vendor/ (solo en lectura y ejecución)</li>
+  <li>[chamilo]/web/</li>
+  <li>[chamilo]/main/default_course_document/images/</li>
 </ul>
-Opcionalmente, puede hacer lo mismo al directorio siguiente si desea
-activar  la definición de sub-idiomas:
+Opcionalmente, puede hacer lo mismo al directorio siguiente si desea activar  la definición de sub-idiomas:
 <ul>
   <li>[chamilo]/main/lang/</li>
 </ul>
-    <span class="text-muted">Si encuentra una carpeta tests/ a la raíz de su paquete Chamilo, por favor borrelo.
-    Se trata de una carpeta de trabajo de los desarrolladores, y no ha sido verificado para evitar riesgos de seguridad,
-    por lo cual no debería *nunca* ser accesible a usuarios finales en un servidor de producción.</span>
-</div>
+<span class="text-muted">
+  Si encuentra una carpeta tests/ a la raíz de su paquete Chamilo, por favor borrelo.
+  Se trata de una carpeta de trabajo de los desarrolladores, y no ha sido verificado para evitar riesgos de seguridad,
+  por lo cual no debería *nunca* ser accesible a usuarios finales en un servidor de producción.
+</span>
 
 <p>
-En Linux, Mac OS X y sistemas operativos BSD  puede usar el comando "chmod 0775" para cambiar estos permisos (aunque nosotros recomendamos que busque la ayuda de un
-administrador de sistemas con experiencia para evitar fallas de seguridad).
-En Windows, es probable que  necesite revisar las propiedades de los directorios (mediante el uso
-del clic derecho en ellos).
+  En Linux, Mac OS X y sistemas operativos BSD  puede usar el comando "chmod 0775" para cambiar estos permisos
+  (aunque nosotros recomendamos que busque la ayuda de un administrador de sistemas con experiencia para evitar
+  fallas de seguridad). En Windows, es probable que  necesite revisar las propiedades de los directorios
+  (mediante el uso del clic derecho en ellos).
 </p>
 
 <p>
-<span style="font-weight: bold;">Windows</span> : con paquetes combinados de todos en uno como XAMPP, usted puede instalar Chamilo facilmente. En este caso (y si no lo utiliza en la producción), el nombre de usuario y una contraseña para MySQL probablemente permanecerá vacía.
+ <span style="font-weight: bold;">Windows</span>: con paquetes combinados de todos en uno como XAMPP, usted puede
+ instalar Chamilo facilmente. En este caso (y si no lo utiliza en la producción), el nombre de usuario y una
+ contraseña para MySQL probablemente permanecerá vacía.
 </p>
 
 <h3><strong> Configuración y seguridad después de la instalación</strong></h3>
 <div>
-<ul>
-  <li><strong>Proteger su directorio de configuración: </strong> asegurarse que nadie pueda sobreescribirlo. Usted puede encontrar el directorio de configuración en (carpeta de chamilo)/main/inc/conf. Hacerlo de solo lectura (windows/xwindows: clic derecho en el archivo para editar las propiedades. linux/bsd/macosx: usar el comando chmod 0555). El archivo de configuración es creado por el servidor web (Apache + PHP, normalmente), por lo tanto usted necesita ser administrador para cambiar sus permisos.</li>
-  <li><strong>Configurar su instalación de Chamilo: </strong>
-en la sección de administración de Chamilo, usted puede usar las Opciones de Configuración de Chamilo para ajustar el comportamiento de su instalación.</li>
-  <li>Consulte nuestra nueva <a href="security.html">guia de seguridad</a> para más información.</li>
-</ul>
+  <ul>
+    <li>
+      <strong>Proteger su directorio de configuración: </strong> asegurarse que nadie pueda sobreescribirlo.
+      Usted puede encontrar el directorio de configuración en (carpeta de chamilo)/main/inc/conf. Hacerlo de solo
+      lectura (windows/xwindows: clic derecho en el archivo para editar las propiedades. linux/bsd/macosx: usar el
+      comando chmod 0555). El archivo de configuración es creado por el servidor web (Apache + PHP, normalmente),
+      por lo tanto usted necesita ser administrador para cambiar sus permisos.
+    </li>
+    <li>
+      <strong>Configurar su instalación de Chamilo: </strong>
+      en la sección de administración de Chamilo, usted puede usar las Opciones de Configuración de Chamilo para
+      ajustar el comportamiento de su instalación.
+    </li>
+    <li>Consulte nuestra nueva <a href="security.html">guia de seguridad</a> para más información.</li>
+  </ul>
 </div>
 
 <h3>Configuración PHP</h3>
-
 <div>
-Para obtener lo mejor de Chamilo, necesita ajustar la configuración de PHP. Considere: <br />
-
-<ul>
-  <li>Editar el archivo php.ini (en Windows puede estar ubicado en <span style="font-weight: bold;">C:\xampp\php\php.ini</span>, en Ubuntu Linux : <span style="font-weight: bold;">/etc/php5/apache2/php.ini</span></li>
-
-  <li>Buscar la palabra "_max" y incrementar los valores para optimizar el servidor</li>
-
-  <li>Nosotros recomendamos ajustar los siguiente valores (lo que sigue ";" son comentarios): </li>
-</ul>
+  Para obtener lo mejor de Chamilo, necesita ajustar la configuración de PHP. Considere: <br />
+  <ul>
+    <li>
+      Configuración del correo de Chamilo: la mayor parte de Chamilo usa la configuración de correo del archivo
+      php.ini. Sin embargo, si utiliza un servidor de correo electrónico distinto, puede necesitar ajustar la
+      configuración del correo electrónico en (carpeta chamilo ) /app/config/mail.conf.php.
+    </li>
+    <li>
+      Editar el archivo php.ini (en Windows puede estar ubicado en
+      <span style="font-weight: bold;">C:\xampp\php\php.ini</span>, en Ubuntu Linux :
+      <span style="font-weight: bold;">/etc/php5/apache2/php.ini</span>
+    </li>
+    <li>Buscar la palabra "_max" y incrementar los valores para optimizar el servidor</li>
+    <li>Nosotros recomendamos ajustar los siguiente valores (lo que sigue ";" son comentarios): </li>
+  </ul>
 </div>
-<div class="code">
-			  max_execution_time = 300 ;Tiempo máximo de ejecucion para cada script, en segundos<br />
-			  max_input_time = 600 ;Tiempo máximo que cada script que puede emplear para analizar los datos solicitados<br />
-			  memory_limit = 256M ;Maxima cantidad de memoria que un script puede consumir (128MB)<br />
-			  post_max_size = 100M<br />
-    upload_max_filesize = 100M;<br />
-    short_open_tag       = Off<br />
-    safe_mode            = Off<br />
-    magic_quotes_gpc     = Off<br />
-    magic_quotes_runtime = Off<br />
-</div>
+<pre>
+max_execution_time = 300; Tiempo máximo de ejecucion para cada script, en segundos
+max_input_time = 600; Tiempo máximo que cada script que puede emplear para analizar los datos solicitados
+memory_limit = 256M; Maxima cantidad de memoria que un script puede consumir (128MB
+post_max_size = 100M
+upload_max_filesize = 100M;
+short_open_tag       = Off
+safe_mode            = Off
+magic_quotes_gpc     = Off
+magic_quotes_runtime = Off
+</pre>
 
 <br />
 <p><strong>Importante:</strong> Necesitará configurar el parámetro <em>date.timezone</em>
-    al valor de zona horaria de su servidor.
-    Por ejemplo, si su servidor está en la zona horaria de 'America/New_York', configurar el
-    parámetro date.timezone a este valor en su php.ini:</p>
-    <div class="code">
-        date.timezone = 'America/New_York'
-    </div>
-    <br />
-<p><strong>Nota:</strong> <span class="text-muted">PHP 5.3.9 introduce un nuevo parámetro
-    llamado "max_input_vars", que limita la cantidad de elementos que puede enviar
-    en un solo formulario.
-    Si gestiona numerosos usuarios o lecciones muy largas, asegúrese de configurar este parámetro
-    a un valor mayor a su valor predeterminado de 1000.</span></p>
+  al valor de zona horaria de su servidor.
+  Por ejemplo, si su servidor está en la zona horaria de 'America/New_York', configurar el
+  parámetro date.timezone a este valor en su php.ini:
+</p>
+<pre>
+date.timezone = 'America/New_York'
+</pre>
 
+<p>
+  <strong>Nota:</strong> <span class="text-muted">PHP 5.3.9 introduce un nuevo parámetro
+  llamado "max_input_vars", que limita la cantidad de elementos que puede enviar
+  en un solo formulario.
+  Si gestiona numerosos usuarios o lecciones muy largas, asegúrese de configurar este parámetro
+  a un valor mayor a su valor predeterminado de 1000.</span>
+</p>
 
-<p><strong>Usuarios BSD:</strong> estas bibliotecas de php tienen que ser incluidas durante la instalación de php:</p>
+<p>
+  <strong>Usuarios BSD y CentOS:</strong> estas bibliotecas de php tienen que ser incluidas durante la
+  instalación de PHP (php5 podría tener que ser reemplazado por php en algunos casos):
+</p>
 
 <ul>
-    <li>php5-session La extensión compartida de sesión para php</li>
-    <li>php5-mysqlnd La extensión compartida de mysql para php</li>
-    <li>php5-zlib La extensión compartida de zlib para php</li>
-    <li>php5-pcre La extensión compartida de pcre para php</li>
-    <li>php5-xml</li>
-    <li>php5-json</li>
-    <li>php5-mcrypt</li>
-    <li>php5-iconv o php5-mbstring (cualquiera de los dos)</li>
-    <li>php5-gd la extensión de generación de gráficos de PHP</li>
-    <li>php5-intl la extensión de reglas de representación internacionales</li>
+  <li>php5-session La extensión compartida de sesión para php</li>
+  <li>php5-mysqlnd La extensión compartida de mysql para php</li>
+  <li>php5-zlib La extensión compartida de zlib para php</li>
+  <li>php5-pcre La extensión compartida de pcre para php</li>
+  <li>php5-xml</li>
+  <li>php5-json</li>
+  <li>php5-mcrypt</li>
+  <li>php5-iconv o php5-mbstring (cualquiera de los dos)</li>
+  <li>php5-gd la extensión de generación de gráficos de PHP</li>
+  <li>php5-intl la extensión de reglas de representación internacionales</li>
 </ul>
 
-    <p>También puede necesitar  estos módulos y paquetes:</p>
+<p>También puede necesitar  estos módulos y paquetes:</p>
 <ul>
 <li>php5-ctype</li>
-    <li>php5-ldap</li>
-    <li>php5-xapian</li>
-    <li>php5-curl</li>
-    <li>php5-xsl</li>
+  <li>php5-ldap</li>
+  <li>php5-xapian</li>
+  <li>php5-curl</li>
+  <li>php5-xsl</li>
 </ul>
 
 <hr />
-<h2><a name="3._Upgrade_from_a_previous_version_of"></a>3. Actualizar desde una versión previa de Chamilo LMS (1.*) o Dok€os (&lt;2.0)</h2>
-
+<h2>
+  <a id="3._Upgrade_from_a_previous_version_of"></a>
+  3. Actualizar desde una versión previa de Chamilo LMS (1.*) o Dok€os (&lt;2.0)
+</h2>
 <p>
-Antes de actualizar, le recomendamos <b>seriamente</b> que haga una copia de seguridad de los directorios
-y bases de datos de Chamilo/Dokeos que previamente haya en su servidor. Si no está seguro de cómo hacer esto solicite
-asistencia a su proveedor de servicios de almacenamiento.
+  Antes de actualizar, le recomendamos <b>seriamente</b> que haga una copia de seguridad de los directorios
+  y bases de datos de Chamilo/Dokeos que previamente haya en su servidor. Si no está seguro de cómo hacer esto
+  solicite asistencia a su proveedor de servicios de almacenamiento.
 </p>
 <p>
-Chamilo LMS 1.10 unifica todos los archivos dentro de cada idioma de la carpeta main/lang/.
-Si había cambiado algun archivo de idioma directamente (en vez de usar el método recomendado: sub-idiomas), debería
-tomar una copia de backup de estos cambios antes de actualizar.</p>
+  Chamilo LMS 1.10 unifica todos los archivos dentro de cada idioma de la carpeta main/lang/.
+  Si había cambiado algun archivo de idioma directamente (en vez de usar el método recomendado: sub-idiomas),
+  debería tomar una copia de backup de estos cambios antes de actualizar.
+</p>
 
-    <div class="muted"> NOTA: Para sistemas Chamilo con bases de datos muy pesadas, algunos de nuestros proveedores han desarrollado procedimientos usando más memoria pero acortando el tiempo necesario de la migración por hasta 20 veces. No dude en contactar con ellos (referencias más a bajo) si requiere de este tipo de servicios</div>
+<div class="text-muted">
+  NOTA: Para sistemas Chamilo con bases de datos muy pesadas, algunos de nuestros proveedores
+  han desarrollado procedimientos usando más memoria pero acortando el tiempo necesario de la migración por hasta
+  20 veces. No dude en contactar con ellos (referencias más a bajo) si requiere de este tipo de servicios
 </div>
-<div class="muted">
-NOTA: Esta versión de Chamilo sólo se puede utilizar para actualizar desde versiones inferiores de Chamilo 1.9.*. Por ejemplo, no puede utilizar los scripts de actualización normales de Chamilo 1.9 para actualizar desde Dok€oS 2.0. Si usted necesita esto, por favor póngase en contacto con uno de los proveedores oficiales de la Asociación Chamilo)
+<br />
+<div class="text-muted">
+  NOTA: Esta versión de Chamilo sólo se puede utilizar para actualizar desde versiones inferiores
+  de Chamilo 1.9.*. Por ejemplo, no puede utilizar los scripts de actualización normales de Chamilo 1.9 para
+  actualizar desde Dok€oS 2.0. Si usted necesita esto, por favor póngase en contacto con uno de los proveedores
+  oficiales de la Asociación Chamilo)
 </div>
 
 <h3>3.1 Actualizar desde Chamilo 1.11.x (actualización menor)</h3>
 <div>
-Dado que se trata sólo de un cambio de versión menor previa de Chamilo 1.11.*, lo único que tiene que hacer es:
-<ul>
-<li>Revisar que no ha dejado alguna hoja de estilo personalizada o imagen (si es que tiene, asegúrese de guardar una copia de respaldo)</li>
-<li>Descargar el paquete de instalación de Chamilo 1.9 desde la página de descarga de Chamilo</li>
-<li>Descomprimir los nuevos archivos de Chamilo 1.9 sobre los archivos de la versión anterior (o descomprimirlos en una nueva carpeta y después copiarlos sobre los archivos de la versión anterior)</li>
-<li>Editar el archivo app/config/configuration.php: hacia el final del archivo, localizar el número de la versión (p.e. ‘1.9.4’) y cambiarlo por la nueva versión (p.e.‘1.9.8’)</li>
-<li>Ya está! Ningún otro procedimiento de actualización es requerido.</li>
-</ul>
+  Dado que se trata sólo de un cambio de versión menor previa de Chamilo 1.11.*, lo único que tiene que hacer es:
+  <ul>
+    <li>
+      Revisar que no ha dejado alguna hoja de estilo personalizada o imagen
+      (si es que tiene, asegúrese de guardar una copia de respaldo)
+    </li>
+    <li>
+      Descargar el paquete de instalación de Chamilo 1.11 desde la
+      <a href="https://chamilo.org/es/chamilo-lms/">página de descarga de Chamilo</a>
+    </li>
+    <li>
+      Descomprimir los nuevos archivos de Chamilo 1.11 sobre los archivos de la versión anterior
+      (o descomprimirlos en una nueva carpeta y después copiarlos sobre los archivos de la versión anterior)
+    </li>
+    <li>
+      Limpie el directorio app/cache/twig: elimine todos los contenidos *en* este directorio (NO elimine el directorio
+      en sí, ¡solo sus contenidos!). Se volverá a generar todo. También puede eliminar los contenidos de este
+      directorio a través de la opción "Limpieza de caché y archivos temporales " en el cuadro "Sistema" de la página
+      de Administración.
+    </li>
+    <li>Ya está! Ningún otro procedimiento de actualización es requerido.</li>
+  </ul>
 </div>
 
-<h3>3.2 Actualizar desde Chamilo 1.9.x p 1.10.x</h3>
+<h3>3.2 Actualizar desde Chamilo 1.10.x</h3>
 <ul>
-  <li>Asegúrese que ninguna tabla de una versión anterior (a la 1.9) exista en su base de datos. Estas tablas pueden causar errores durante el proceso de actualización hacia versiones superiores. En particular, las tablas de versiones 1.8.* y anteriores podían repetirse una vez por curso, resultando en una gran cantidad de tablas que compartían el mismo prefijo. Solo las tablas sin prefijo o con un prefijo "c_" son legítimas en Chamilo 1.9 y siguientes. Asegúrese de que ninguna de estas antiguas tablas persista. Tóme una copia de seguridad de la base de datos (por si a caso) y luego borre estas tablas con prefijo (drop table ...).</li>
-  <li>Compruebe que no ha dejado ninguna hoja de estilo o imagen personalizada (si la tuviera, asegúrese de realizar una copia de respaldo*)</li>
-  <li>Descargue el paquete de instalación de Chamilo 1.9 desde la página de descarga de Chamilo</li>
-  <li>Descomprima los nuevos ficheros de Chamilo 1.9 sobre los ficheros de la antigua versión ( o descomprima en una carpeta y luego copie los archivos en el directorio de la versión antigua)</li>
-  <li>Asegúrese *por completo* que el archivo .htaccess de la versión 1.11 ha sido copiado en la raíz también</li>
-  <li>Asegúrese que "AllowOverride All" está presente en su configuración de Apache, ya que interpretar el archivo .htaccess es muy importante para que Chamilo funcione (ojo que la directiva Order-Allow ha sido remplazada por "Require all granted" en Apache 2.4)</li>
-  <li>Escriba en su navegador web la URL de su portal + main/install/</li>
-  <li>Elija su idioma y haga click sobre Actualizar desde 1.9.x</li>
+  <li>
+    Compruebe que no ha dejado ninguna hoja de estilo o imagen personalizada
+    <span class="text-muted">(si la tuviera, asegúrese de realizar una copia de respaldo*)</span>
+  </li>
+  <li>
+    Descargue el paquete de instalación de Chamilo 1.11 desde la
+    <a href="https://chamilo.org/es/chamilo-lms/">página de descarga de Chamilo</a>
+  </li>
+  <li>
+    Descomprima los nuevos ficheros de Chamilo 1.11 sobre los ficheros de la antigua versión
+    ( o descomprima en una carpeta y luego copie los archivos en el directorio de la versión antigua)
+    Nota: debes borrar los directorios "home" y "searchdb" del paquete antes de sobrescribir
+    los archivos anteriores.
+  </li>
+  <li>
+    Limpie el directorio app/cache/twig: elimine todos los contenidos *en* este directorio (NO elimine el directorio
+    en sí, ¡solo sus contenidos!). Se volverá a generar todo. También puede eliminar los contenidos de este
+    directorio a través de la opción "Limpieza de caché y archivos temporales " en el cuadro "Sistema" de la página
+    de Administración.
+  </li>
+  <li>Escriba en su navegador web la URL de su portal + main/install/ y sigue el procedimiento de actualización</li>
 </ul>
-<p>
-    * Los estilos e imágenes están ubicados en el directorio main/css o main/img.
-    Usted puede recuperarlos desde la copia de seguridad en el caso de que usted hya tenido la precaución de realizarla.
-    Cualquier estilo o imagen modificada que use el nombre predeterminado style/image será
-    sobrescrita en el siguiente paso. Para evitar perder cualquier personalización, siempre
-    asegúrese de copiar styles/images bajo un nuevo nombre y use y modifique la copia,
-    no el original. El original siempre sera sobrescrito por nuevas versiones.
-    En Dok€os 1.8.5, hemos cambiado el nombre de varios temas CSS.
-    La compatibilidad hacia atrás está asegurada por el hecho de que una actualización sólo agrega
-    los nuevos temas, sin embargo usted debe  usar estos nuevos temas en lugar de quedarse con los
-    antiguos que quedarán obsoletos dentro de poco (sin mantenimiento).
-</p>
-
+Tenga en cuenta que si (desafortunadamente) actualizó desde cualquiera de las versiones 1.9 a 1.10 en contra de
+nuestra recomendaciones, proporcionamos un parche (script) para obtener la mayor parte de orden. Este parche está
+disponible aquí: <br /> 
+<a href="https://raw.githubusercontent.com/chamilo/chamilo-lms/1.10.x/tests/scripts/fix_migrations_1.9.x_1.10.0.php">
+  https://raw.githubusercontent.com/chamilo/chamilo-lms/1.10.x/tests/scripts/fix_migrations_1.9.x_1.10.0.php
+</a> o, si está utilizando una versión de desarrollo de Chamilo, directamente en la carpeta tests/scripts/ .
+Debe colocar el fichero en la carpeta /tests/scripts/ , luego edítelo para eliminar la línea del "die();",
+finalmente ejecutelo  su navegador (después de conectarse a su sitio Chamilo como administrador).
+Deberías borrar el script una vez finalizado.<br />
+Este script se proporciona sin garantía. Por favor * siempre * realice una copia de seguridad antes de usarlo. 
 <br />
 
-<h3>3.3 Actualizar desde Chamilo o Dok€os 1.8.x</h3>
-Para actualizar desde una versión previa a la 1.9.0, deberá a partir de ahora primero actualizar a la versión 1.9.10.x, para luego actualizar de ahí a la 1.11.x.
-Podrá encontrar una versión descargable de 1.9.10.x aquí: <a href="https://github.com/chamilo/chamilo-lms/releases">https://github.com/chamilo/chamilo-lms/releases</a>
-
-<h3>3.4 En ambos últimos casos</h3>
-
-Las carpetas siguientes necesitan tener permisos de lectura, escritura y ejecución para el servidor
-web:
+<h3>3.3 Actualizar desde Chamilo 1.9.x</h3>
+<p>
+  Chamilo LMS 1.11.x viene con una nueva estructura de base de datos en comparación con 1.9, como fue el caso
+  entre 1.9 y 1.8. Aunque el script de actualización toma la migración a cargo, puede generar una carga alta
+  de recursos en su servidor durante la actualización, y cambiará su base de datos considerablemente, conservando
+  los datos lo mejor posible (hemos probado el procedimiento muchas veces, pero recuerde esto es GNU/GPLv3 y no
+  nos hacemos responsables de lo que sucedería con sus datos sin supervisión profesional). Es por eso que *realmente*
+  le recomendamos que haga una copia de seguridad completa de su sistema antes de actualizar.
+</p>
+<p>
+  También tenga en cuenta que Chamilo LMS 1.10 une todos los archivos de idioma del directorio main/lang/ en un
+  solo archivo por idioma. Si ha cambiado los archivos de idioma directamente (en lugar de usar la manera
+  recomendada: sub-idiomas), debe tomar una copia de seguridad de estas traducciones modificadas antes de
+  actualizar. Los sub-idiomas también pueden requerir algún trabajo manual, pero el procedimiento de actualización
+  no afectará directamente a los sub-idiomas.
+</p> 
 <ul>
-    <li>[chamilo]/main/lang/ (in order to delete unnecessary language files)</li>
-    <li>[chamilo]/courses/ (in order to move the courses files to the app/courses folder)</li>
-    <li>[chamilo]/archive/ (in order to remove unnecessary files or move them to app/cache/)</li>
-    <li>[chamilo]/home/ (in order to move files to app/home)</li>
-    <li>[chamilo]/app</li>
-    <li>[chamilo]/web</li>
-    <li>[chamilo]/vendor</li>
-    <li>[chamilo]/main/default_course_document/images/</li>
+  <li>
+    Asegúrese que ninguna tabla de una versión anterior (a la 1.9) exista en su base de datos. Estas tablas pueden
+    causar errores durante el proceso de actualización hacia versiones superiores. En particular, las tablas de
+    versiones 1.8.* y anteriores podían repetirse una vez por curso, resultando en una gran cantidad de tablas que
+    compartían el mismo prefijo. Solo las tablas sin prefijo o con un prefijo "c_" son legítimas en Chamilo 1.9 y
+    siguientes. Asegúrese de que ninguna de estas antiguas tablas persista. Tóme una copia de seguridad de la base
+    de datos (por si a caso) y luego borre estas tablas con prefijo (drop table ...).
+  </li>
+  <li>
+    Compruebe que no ha dejado ninguna hoja de estilo o imagen personalizada (si la tuviera, asegúrese de realizar
+    una copia de respaldo*)
+  </li>
+  <li>
+    Descargue el paquete de instalación de Chamilo 1.11 desde la
+    <a href="https://chamilo.org/es/chamilo-lms/">página de descarga de Chamilo</a>
+  </li>
+  <li>
+    Descomprima los nuevos ficheros de Chamilo 1.11 sobre los ficheros de la antigua versión ( o descomprima en una
+    carpeta y luego copie los archivos en el directorio de la versión antigua)
+  </li>
+  <li>Asegúrese *por completo* que el archivo .htaccess de la versión 1.11 ha sido copiado en la raíz también</li>
+  <li>
+    Asegúrese que "AllowOverride All" está presente en su configuración de Apache, ya que interpretar el archivo
+    .htaccess es muy importante para que Chamilo funcione (ojo que la directiva Order-Allow ha sido remplazada
+    por "Require all granted" en Apache 2.4)
+  </li>
+  <li>Escriba en su navegador web la URL de su portal + main/install/</li>
+  <li>Elija su idioma y haga click sobre Actualizar desde 1.9.x</li>
+  <li>
+    Limpie el directorio app/cache/twig: elimine todos los contenidos *en* este directorio (NO elimine el directorio
+    en sí, ¡solo sus contenidos!). Se volverá a generar todo. También puede eliminar los contenidos de este
+    directorio a través de la opción "Limpieza de caché y archivos temporales " en el cuadro "Sistema" de la página
+    de Administración.
+  </li>
+</ul>
+<span class="text-muted">
+  * Los estilos e imágenes están ubicados en el directorio main/css o main/img. Usted puede recuperarlos desde la
+  copia de seguridad en el caso de que usted hya tenido la precaución de realizarla. Cualquier estilo o imagen
+  modificada que use el nombre predeterminado style/image será sobrescrita en el siguiente paso. Para evitar
+  perder cualquier personalización, siempre asegúrese de copiar styles/images bajo un nuevo nombre y use y
+  modifique la copia, no el original. El original siempre sera sobrescrito por nuevas versiones.
+  En Dok€os 1.8.5, hemos cambiado el nombre de varios temas CSS. La compatibilidad hacia atrás está asegurada
+  por el hecho de que una actualización sólo agrega los nuevos temas, sin embargo usted debe  usar estos nuevos
+  temas en lugar de quedarse con los antiguos que quedarán obsoletos dentro de poco (sin mantenimiento).
+</span>
+<br />
+
+<h3>3.4 Actualizar desde Chamilo 1.8.x</h3>
+<p>
+  Para actualizar desde una versión previa a la 1.9.0, deberá a partir de ahora primero actualizar a la
+  versión 1.9.10.x, para luego actualizar de ahí a la 1.11.x. Podrá encontrar una versión descargable de
+  1.9.10.x aquí:
+  <a href="https://github.com/chamilo/chamilo-lms/releases">https://github.com/chamilo/chamilo-lms/releases</a>
+</p>
+<h3>3.5 Permisos de directorios al actualizar desde 1.9.x</h3>
+Las carpetas siguientes necesitan tener permisos de lectura, escritura y ejecución para el servidor web:
+<ul>
+  <li>[chamilo]/main/lang/ (in order to delete unnecessary language files)</li>
+  <li>[chamilo]/courses/ (in order to move the courses files to the app/courses folder)</li>
+  <li>[chamilo]/archive/ (in order to remove unnecessary files or move them to app/cache/)</li>
+  <li>[chamilo]/home/ (in order to move files to app/home)</li>
+  <li>[chamilo]/app</li>
+  <li>[chamilo]/web</li>
+  <li>[chamilo]/vendor</li>
+  <li>[chamilo]/main/default_course_document/images/</li>
 </ul>
 En Linux, Mac OS X y BSD, puede arreglar esto rápido usando el comando chmod 0777 pero, si no
 está seguro, recomendamos que busque consejo para su propio sistema operativo en nuestro
@@ -387,500 +556,467 @@ En Windows, puede necesitar propiedades de las carpetas.
 <p></p>
 
 <p>
-<b>ADVERTENCIA:</b><br />
-No elimine el directorio de instalación previo de Chamilo/Dok€os antes de instalar
-el nuevo. Usted puede eliminar la ruta antigua, cuando la actualización haya finalizado satisfactoriamente.
+  <b>ADVERTENCIA:</b><br />
+  No elimine el directorio de instalación previo de Chamilo antes de instalar
+  el nuevo. Usted puede eliminar la ruta antigua, cuando la actualización haya finalizado satisfactoriamente.
 </p>
-
 <hr style="width: 100%; height: 2px;" />
 
-<h2><a name="4._Troubleshooting"></a>4. Solución de problemas</h2>
-
-<p>Si usted tiene problemas, vaya al <a href="http://www.chamilo.org">Sitio Web de Chamilo</a> y haga una pregunta en el
-<a href="http://www.chamilo.org/forum">foro de soporte</a>. Por favor, primero lea los mensajes previos para ver si existe ya
-una respuesta a su pregunta. Nosotros también mantenemos una lista de
-<a href="http://www.chamilo.org/FAQ">Preguntas Frecuentes</a>.
-</p>
-
-
-<h2></h2>
-
-
-<hr style="width: 100%; height: 2px;" />
-<h2><a name="5._Administration_section"></a>5. Sección de Administración</h2>
-
-<p>Para acceder a la sección de administración de Chamilo, abra el navegador,
-diríjase a su dirección de Chamilo y acceda a el con el usuario admin.
-Luego usted verá un enlace a la "Sección de administración de la plataforma" en la parte superior
-de la página web. En ese lugar usted puede administrar usuarios, cursos, secciones, apariencia del portal
-contenido de la página principal, categorías de cursos, entre otros.</p>
-
+<h2><a id="4._Troubleshooting"></a>4. Solución de problemas</h2>
 <p>
+  Si usted tiene problemas, vaya al <a href="http://www.chamilo.org">Sitio Web de Chamilo</a> y haga una
+  pregunta en el <a href="http://www.chamilo.org/forum">foro de soporte</a>. Por favor, primero lea los mensajes
+  previos para ver si existe ya una respuesta a su pregunta. Nosotros también mantenemos una lista de
+  <a href="http://www.chamilo.org/FAQ">Preguntas Frecuentes</a>.
 </p>
 <hr style="width: 100%; height: 2px;" />
-<h2><a name="6._LDAP"></a>6. LDAP</h2>
 
+<h2><a id="5._Administration_section"></a>5. Sección de Administración</h2>
 <p>
-<i>Esta parte es opcional, solamente organizaciones con un servidor LDAP necesitan leer esto.</i><br />
-Un módulo LDAP está ya implementado en Chamilo, pero debe ser configurado para que tenga un correcto funcionamiento.
+  Para acceder a la sección de administración de Chamilo, abra el navegador,
+  diríjase a su dirección de Chamilo y acceda a el con el usuario admin.
+  Luego usted verá un enlace a la "Sección de administración de la plataforma" en la parte superior
+  de la página web. En ese lugar usted puede administrar usuarios, cursos, secciones, apariencia del portal
+  contenido de la página principal, categorías de cursos, entre otros.
 </p>
+<hr style="width: 100%; height: 2px;" />
 
+<h2><a id="6._LDAP"></a>6. LDAP</h2>
+<p>
+  <i>Esta parte es opcional, solamente organizaciones con un servidor LDAP necesitan leer esto.</i><br />
+  Un módulo LDAP está ya implementado en Chamilo, pero debe ser configurado para que tenga un correcto funcionamiento.
+</p>
 
 <h3><b>Compilar</b></h3>
-
 <p>
-Servidores Linux: Es posible que se requiera recompilar PHP con soporte para LDAP.
-Distribuciones nuevas también permiten descargar rpms para los paquetes adicionales.
+  Servidores Linux: Es posible que se requiera recompilar PHP con soporte para LDAP.
+  Distribuciones nuevas también permiten descargar rpms para los paquetes adicionales.
 </p>
-
 
 <h3><b>Activar LDAP en Chamilo</b></h3>
-
-<p><span>Nota:</span>El mecanismo de LDAP ha cambiado en 1,9. Como resultado, parte de la información siguiente puede no ser correcta. Por favor, compruebe los ajustes de configuración dentro de Chamilo para conocer los detalles.</p>
-<p>
-En (la carpeta de Chamilo)/app/config/configuration.php, aproximadamente en la line 90, se puede ver<br />
-//for new login module<br />
-//uncomment these to activate ldap<br />
-//$extAuthSource['ldap']['login'] = "./main/auth/ldap/login.php";<br />
-//$extAuthSource['ldap']['newUser'] = "./main/auth/ldap/newUser.php";<br />
-<br />
+<p class="text-muted">Nota: compruebe la configuración de LDAP dentro de Chamilo para conocer los detalles.</p>
+En (la carpeta de Chamilo)/app/config/configuration.php, aproximadamente en la line 93, se puede ver:<br />
+<pre>
+// -> Uncomment the two lines below to activate LDAP AND edit main/inc/conf/auth.conf.php for configuration
+// $extAuthSource["extldap"]["login"] = $_configuration['root_sys'].$_configuration['code_append']."auth/external_login/login.ldap.php";
+// $extAuthSource["extldap"]["newUser"] = $_configuration['root_sys'].$_configuration['code_append']."auth/external_login/newUser.ldap.php";
+</pre>
 eliminar // de las dos últimas líneas para activar LDAP.<br />
-</p>
-
 
 <h3><b>Configuraciones</b></h3>
 <p>
-Solicitar al administrador del servidor LDAP los siguientes datos:
+  Solicitar al administrador del servidor LDAP los siguientes datos:
 </p>
 <ul>
   <li>nombre del servidor ldap</li>
   <li>puerto del servidor ldap (usualmente 389)</li>
   <li>dc del ldap</li>
 </ul>
+<p>
 Desde 1.8.5, usted tiene que cambiar las configuraciones de LDAP dentro del panel
 "Administración del Portal", bajo "Opciones de configuración de Chamilo", sección
 "LDAP".
 <br />
-
 Como ejemplo, usted debe encontrar tipos de valores como los siguientes:<br />
-
 Dirección principal del servidor LDAP: "miservidorldap.com";  // su servidor ldap<br />
-
 Puerto principal del servidor LDAP: 389;                 // el número de puerto de su servidor ldap<br />
-
 dominio LDAP: "dc=xx, dc=yy, dc=zz"; //dominio<br />
-
-<br />
-
+</p>
 
 <h3><b>Estado Profesor/Estudiante</b></h3>
-
 <p>
-De manera predeterminada, Chamilo revisará si el campo "employeenumber" tiene un valor. Si lo tiene, entonces Chamilo
-considerará que este usuario es profesor.<br />
-
-Si usted desea cambiar este comportamiento, usted puede editar main/auth/ldap/authldap.php, la función ldap_put_user_info_locally(),
-y cambiar la condición <em>if (empty($info_array[$tutor_field]))</em> a la que a usted mejor le convenga.<br />
-
-Adicionalmente usted puede suprimir esta revisión, eliminando la condición y dejando solamente la linea <em>$status = STUDENT;</em>
+  De manera predeterminada, Chamilo revisará si el campo "employeenumber" tiene un valor. Si lo tiene,
+  entonces Chamilo considerará que este usuario es profesor.<br />
+  Si usted desea cambiar este comportamiento, usted puede editar main/auth/ldap/authldap.php, la función
+  ldap_put_user_info_locally(), y cambiar la condición <em>if (empty($info_array[$tutor_field]))</em> a
+  la que a usted mejor le convenga.<br />
+  Adicionalmente usted puede suprimir esta revisión, eliminando la condición y dejando solamente la linea
+  <em>$status = STUDENT;</em>
 </p>
-
 
 <h3><b>Servidores LDAP protegidos</b></h3>
-
-
 <p>
-Algunos servidores LDAP no permiten usos anónimos de los servicios del directorio.<br />
-En este caso, usted debe rellenar los campos apropiados en el
-panel de administración (ej. "manager" y "mypassword") y Chamilo tratará
-de autentificarse usando esto, o volver al modo anónimo antes de darse por vencido.</p>
-
+  Algunos servidores LDAP no permiten usos anónimos de los servicios del directorio.<br />
+  En este caso, usted debe rellenar los campos apropiados en el
+  panel de administración (ej. "manager" y "mypassword") y Chamilo tratará
+  de autentificarse usando esto, o volver al modo anónimo antes de darse por vencido.
+</p>
 
 <h3>Importar LDAP en sesiones</h3>
-
-<p>Existe un nuevo grupo de scripts que permiten  insertar usuarios
-desde LDAP directamente a una sesión de Chamilo. Sin embargo, esto se basa en un
-conjunto de opciones estáticas en los atributos de contacto de LDAP.<br />
-
-Los campos usados intensivamente por el módulo de Chamilo son:<br />
-
-</p>
-
-<ul>
-
-	<li>uid, el cual se corresponde con el username en Chamilo</li>
-	<li>userPassword, el cual se corresponde con la contraseña del usuario. Aunque esta parte, por ahora, solamente funcionará con contraseñas no encriptadas,  no será necesaria si se usa el servidor LDAP para la autentificación.</li>
-
-	<li>ou debe terminar con el año de registro de la persona o cualquier
-criterio que usted use para filtrar a los usuarios, de manera que ellos puedan obtenerse
-con ese criterio</li>
-
-	<li>sn es usado como el campo lastname en Chamilo</li>
-
-	<li>givenName es usado como el campo firstname en Chamilo</li>
-
-	<li>mail es usado como el campo email en Chamilo</li>
-
-</ul>
-
-
-<hr style="width: 100%; height: 2px;" />
-<h2><a name="7._Mathematical_formulas"></a>7. Fórmulas Matemáticas con LaTeX</h2>
-
-<i>Esta parte es opcional, sólo interesa a las organizaciones que deseen usar fórmulas matemáticas dentro del editor en línea.</i><br />
-
-Usted puede habilitar la escritura de ecuaciones matemáticas dentro del editor en línea de Chamilo (FCKEditor) aplicando los siguientes pasos:
-<ul>
-
-	<li>1. Configurar su instalación de Apache para agregar un directorio cgi-bin que contenga un enlace simbólico a mimetex.cgi en <i>chamilo/main/inc/lib/mimetex/</i>(*ver debajo)</li>
-
-	<li>2. Recargar su configuración de Apache</li>
-
-	<li>3. Editar <i>chamilo/main/inc/lib/fckeditor/myconfig.js</i> y
-
-	    <ul>
-	        <li>3.1. Agregar <b>FCKConfig.Plugins.Add("mimetex", "en", sOtherPluginPath ) ;</b> al final del archivo</li>
-			<li>3.2. Agregar <b>'mimetex'</b> al final de las lineas
-	FCKConfig.ToolbarSets donde usted desee que el icono de LaTeX aparezca
-	(existe un FCKConfig.ToolbarSets por herramienta). Por ejemplo:
-	        <div class="code">FCKConfig.ToolbarSets["Test"] = [<br />
-	['Bold','Italic','Underline','StrikeThrough','Subscript','Superscript','Link','Unlink','ImageManager','MP3','OrderedList','UnorderedList','Table','mimetex']<br />
-
-	] ;</div>
-
-	        Usted puede agregarlo a todas las herramientas, o sólo a alguna de ellas (por ej., documentos y ejercicios)<br />
-	        <br />
-			</li>
-	    </ul>
-    </li>
-
-	<li>4. En raras ocasiones puede ser necesario realizar ajustes manuales editando el fichero /chamilo/main/inc/lib/fckeditor/fckeditor.php</li>
-	<li>5. Limpiar la cache de su navegador para probarlo (muy importante). Esto se puede hacer mediante el uso de la página de configuraciones de su navegador</li>
-    <li>6. Realice estos cambios:
-
-	<i>Agregar el directorio cgi-bin correspondiente a su configuración de Apache puede ser realizada de esta manera, en Apache 2:</i>
-
-	<div class="code">
-			  ScriptAlias /cgi-bin/ /var/www/cgi-bin/<br />
-
-	  &lt;Directory "/var/www/cgi-bin"&gt;<br />
-
-	        &nbsp;&nbsp;AllowOverride None<br />
-
-	        &nbsp;&nbsp;Options ExecCGI -MultiViews +SymLinksIfOwnerMatch<br />
-
-	        &nbsp;&nbsp;Order allow,deny<br />
-
-	        &nbsp;&nbsp;Allow from all<br />
-
-	  &lt;/Directory&gt;<br />
-
-		</div>
-
-
-	<i>Agregar un enlace simbólico bajo Windows, puede ser realizado mediante la creación de un
-	acceso directo al archivo mimetex.exe desde el directorio cgi-bin, o bajo
-	Linux usando el siguiente comando:</i>
-
-	<div class="code">ln -s /var/www/chamilo/main/inc/lib/mimetex/mimetex.cgi /var/www/cgi-bin/mimetex.cgi</div>
-	<p>Si no quiere modificar su Apache, alternativamente a  este punto 6: copie mimetex.exe (para Windows) o mimetex.cgi (para Linux) en su cgi-bin/ </p>
-	<p>&nbsp;</p>
-	</li>
-
-	<li>7. Asegurarse que el archivo mimetex.cgi (o mimetex.exe) ha sido subido al servidor usando el formato BINARY. Es posible que el servidor de un error 500 cuando se intenta entrar a cgi-bin/mimetex.cgi a pesar de que los permisos están correctos.
-	   Probar volviendo a subir el archivo usando FTP (ASCII format) o si no usando el "administrador de archivos" o CPanel. Si el error persiste contactar con el administrador del servidor para habilitar el acceso público del archivo cgi-bin/mimetex.cgi.
-	</li>
-</ul>
-<p>Este procedimiento creará un nuevo icono en su editor en línea de Chamilo, el cual hará posible la inserción de fórmulas matemáticas en sus documentos.</p>
-
-
-<hr style="width: 100%; height: 2px;" />
-<h2><a name="8._ASCIIMathML_mathematical_formulas"></a>8. Fórmulas matemáticas con ASCIIMathML</h2>
-
-<p>Las fórmulas matemáticas pueden ser renderizadas en páginas web usando el script ASCIIMathML.js (en su versión modificada para Chamilo). Para más información sobre este script y sobre la sintaxis de fórmulas de ASCIIMath, ver <a href="http://www1.chapman.edu/~jipsen/mathml/asciimath.html">http://www1.chapman.edu/~jipsen/mathml/asciimath.html</a> y <a href="http://dlippman.imathas.com/asciimathtex/AMT.html">http://dlippman.imathas.com/asciimathtex/AMT.html</a>.</p>
-
-<p>Para escribir fórmulas ASCIIMath en documentos, es necesario activar el plugin correspondiente del editor en línea. Para hacerlo, ver la sección de administración de la plataforma, "Administración &gt; Parámetros de configuración  &gt; &gt; Editor WYSIWYG".
-Activar el parámetro <strong>"Editor matemático ASCIIMathML"</strong>.</p>
-
-<p>El script ASCIIMathML.js puede mostrar fórmulas matemáticas en los documentos de dos formas:</p>
-<ul>
-        <li>Traduciendo las fórmulas en notación ASCIIMath en código MathML. El estándar MathML está soportado actualmente sobre tres navegadores:
-                <ul>
-                        <li>Mozilla Firefox: debería considerar la instalación de las fuentes de carácter STIX (<a href="http://www.stixfonts.org">http://www.stixfonts.org</a>) en sus máquinas cliente para tener fórmulas bonitas</li>
-                        <li>Internet Explorer 6 o superior, con el add-on MathPlayer 2.0 o superior (<a href="http://www.dessci.com/en/products/mathplayer">http://www.dessci.com/en/products/mathplayer</a>)</li>
-                        <li>Opera 9.5 o superior</li>
-                </ul>
-      </li>
-        <li>Traduciendo la notación de fórmulas ASCIIMath en notación TeX y pasándolo a un servicio externo. Se debe usar en el caso de navegadores que no soporten MathML.  El servicio externo produce y devuelve un imagen que contiene la fórmula. Esta técnica se llama "image-based fallback".
-        </li>
-</ul>
-<p>Para proveer <strong>image-based fallback</strong> en un sistema en producción, debería seleccionar e instalar en su servidor algun software de renderización TeX, como:</p>
-<ul>
-        <li>mimeTeX - <a href="http://www.forkosh.dreamhost.com/source_mimetex.html">http://www.forkosh.dreamhost.com/source_mimetex.html</a>.
-        Ver <a href="#7._Mathematical_formulas">"7. Fórmulas matemáticas con LaTeX"</a> para instalar el ejecutable mimetex en su servidor</li>
-        <li>mathTeX - <a href="http://www.forkosh.com/mathtex.html">http://www.forkosh.com/mathtex.html</a>. Ver el sitio para instrucciones de instalación</li>
-</ul>
-
-<p>Y como alternativa, puede intentar servicios públicos, como:</p>
-<ul>
-        <li>MathTran - <a href="http://www.mathtran.org">http://www.mathtran.org</a></li>
-        <li>Google Chart Tools - <a href="http://code.google.com/apis/charttools">http://code.google.com/apis/charttools</a></li>
-</ul>
-<p>Abrir el fichero <strong>.../chamilo/main/inc/lib/asciimath/ASCIIMathML.js</strong> con un editor de texto.
-Encuentre un lugar al inicio de la línea que inicializa la variable <strong>AMTcgiloc</strong>.
-Podría necesitar modificar el ejemplo para tener algo como:</p>
-<ul>
-        <li><div class="code">var AMTcgiloc = "http://mychamiloserver.org/cgi-bin/mimetex.cgi";</div></li>
-        <li><div class="code">var AMTcgiloc = "http://mychamiloserver.org/cgi-bin/mathtex.cgi";</div></li>
-        <li><div class="code">var AMTcgiloc = "http://www.mathtran.org/cgi-bin/mathtran?tex=";</div></li>
-        <li><div class="code">var AMTcgiloc = "http://chart.googleapis.com/chart?cht=tx&amp;chs=1x0&amp;chl=";</div></li>
-        <li>... o algo similar</li>
-</ul>
-<p>Para formas de probar como la variable <strong>AMTcgiloc</strong> tiene que ser configurada, existen unos ejemplos (en comentario) dentro del script.</p>
-
-<hr style="width: 100%; height: 2px;" />
-<h2><a name="9._WIRIS_mathematical_formulas"></a>9. Fórmulas matemáticas con WIRIS</h2>
-<p>Instalando este plugin obtendrá WIRIS editor y WIRIS CAS. <br/>La activación no se realiza completamente si previamente no ha descargado el <a href="http://www.wiris.com/plugins/ckeditor/download" target="_blank">PHP plugin for CKeditor de WIRIS</a> y descomprimido su contenido en el directorio de Chamilo main/inc/lib/ckeditor/editor/plugins/ckeditor_wiris/ <br/>Esto es necesario debido a que Wiris es un software propietario y los servicios de Wiris son <a href="http://www.wiris.com/store/who-pays" target="_blank">comerciales</a>. Para realizar ajustes en el plugin edite el archivo configuration.ini o sustituya su contenido por el de configuration.ini.default que acompaña a Chamilo.
-</p>
-
-<hr style="width: 100%; height: 2px;" />
-<h2><a name="10._xapian"></a>10. Indexación de texto completo con Xapian</h2>
-
 <p>
-Nota: Este paso requiere de un servidor dedicado o servidor virtual privado (VPS) porque los paquetes involucrados no están disponibles en la mayoría de soluciones de hosting compartido.
+  Existe un nuevo grupo de scripts que permiten  insertar usuarios
+  desde LDAP directamente a una sesión de Chamilo. Sin embargo, esto se basa en un
+  conjunto de opciones estáticas en los atributos de contacto de LDAP.<br />
+  Los campos usados intensivamente por el módulo de Chamilo son:<br />
 </p>
-<div>
-En Debian o Ubuntu 10.04 o superior, usted simplemente puede instalar el paquete php5-xapian y reiniciar su servidor web:
+
+<ul>
+  <li>uid, el cual se corresponde con el username en Chamilo</li>
+  <li>
+    userPassword, el cual se corresponde con la contraseña del usuario. Aunque esta parte, por ahora,
+    solamente funcionará con contraseñas no encriptadas,  no será necesaria si se usa el servidor LDAP
+    para la autentificación.
+  </li>
+  <li>ou debe terminar con el año de registro de la persona o cualquier
+    criterio que usted use para filtrar a los usuarios, de manera que ellos puedan obtenerse
+    con ese criterio</li>
+  <li>sn es usado como el campo lastname en Chamilo</li>
+  <li>givenName es usado como el campo firstname en Chamilo</li>
+  <li>mail es usado como el campo email en Chamilo</li>
+</ul>
+<hr style="width: 100%; height: 2px;" />
+
+<h2><a id="9._WIRIS_mathematical_formulas"></a>7. Fórmulas matemáticas con WIRIS</h2>
+<p>
+  Instalando este plugin obtendrá WIRIS editor y WIRIS CAS. <br/>
+  La activación no se realiza completamente si previamente no ha descargado el
+  <a href="http://www.wiris.com/plugins/ckeditor/download" target="_blank">PHP plugin for CKeditor de WIRIS</a>
+  y descomprimido su contenido en el directorio de Chamilo main/inc/lib/ckeditor/editor/plugins/ckeditor_wiris/ <br/>
+  Esto es necesario debido a que Wiris es un software propietario y los servicios de Wiris son
+  <a href="http://www.wiris.com/store/who-pays" target="_blank">comerciales</a>.
+  Para realizar ajustes en el plugin edite el archivo configuration.ini o sustituya su contenido por el de
+  configuration.ini.default que acompaña a Chamilo.
+</p>
+<hr style="width: 100%; height: 2px;" />
+
+<h2><a id="10._xapian"></a>8. Indexación de texto completo con Xapian</h2>
+<p>
+  Nota: Este paso requiere de un servidor dedicado o servidor virtual privado (VPS) porque los paquetes
+  involucrados no están disponibles en la mayoría de soluciones de hosting compartido.
+</p>
+En Debian o Ubuntu 10.04 o superior, simplemente puede instalar el paquete php5-xapian y reiniciar su servidor web:
 <pre>
 sudo apt-get install php5-xapian
 sudo /etc/init.d/apache2 restart
 </pre>
-</div>
-<p>
-A continuación, vaya a la página de administración -&gt; Ajustes de configuración -&gt; Buscar y habilitar la herramienta de búsqueda. Siga las recomendaciones de la página para obtener la suite completa de indexación instalada. Una vez que haya terminado, todos los documentos importados en su portal Chamilo en un formato reconocido serán indexados y buscados. En formación de administradores de Chamilo ( el cual puede preguntar a cualquier <a href="http://www.chamilo.org/en/providers">Proveedor Oficial de Chamilo</a>) incluyen una revisión completa de la función de búsqueda de texto completo.
-</p>
 
-<hr style="width: 100%; height: 2px;" />
-<h2><a name="11._rapid"></a>11. Chamilo Rapid - sistema conversion PPT</h2>
 <p>
-Nota: Este paso requiere un servidor dedicado o un servidor dedicado virtual ya que los paquetes involucrados no están disponibles en la mayoría de soluciones de hosting compartido. (Consulte con su proveedor):
+  A continuación, vaya a la página de administración -&gt; Ajustes de configuración -&gt; Buscar y
+  habilitar la herramienta de búsqueda. Siga las recomendaciones de la página para obtener la suite
+  completa de indexación instalada. Una vez que haya terminado, todos los documentos importados en su
+  portal Chamilo en un formato reconocido serán indexados y buscados. En formación de administradores
+  de Chamilo ( el cual puede preguntar a cualquier
+  <a href="http://www.chamilo.org/en/providers">Proveedor Oficial de Chamilo</a>) incluyen una revisión
+  completa de la función de búsqueda de texto completo.
+</p>
+<hr style="width: 100%; height: 2px;" />
+
+<h2><a id="11._rapid"></a>9. Chamilo Rapid - sistema conversion PPT</h2>
+<p>
+  Nota: Este paso requiere un servidor dedicado o un servidor dedicado virtual ya que los paquetes involucrados
+  no están disponibles en la mayoría de soluciones de hosting compartido. (Consulte con su proveedor):
+</p>
+En Debian o Ubuntu 11.10 y superior, instale LibreOffice.org v3 (o v4) e iniciarlo como un servidor en segundo plano:
+<pre>
+sudo apt-get install libreoffice screen
+sudo adduser rapid
+sudo adduser rapid www-data
+screen
+sudo -s
+su - rapid
+soffice --accept="socket,host=127.0.0.1,port=2002,tcpNoDelay=1;urp;" --headless --nodefault --nofirststartwizard --nolockcheck --nologo --norestore
+CTRL+a, CTRL+d
+</pre>
+Tenga en cuenta que esto ejecutará LibreOffice en modo "headless" (gracias a la opción --headless), en un terminal
+"headless" (gracias a la pantalla). Tu puedes posteriormente regresar a tu terminal "headless" ejecutando:
+<pre>
+sudo screen -r
+</pre>
+<p>
+  A continuación, vaya a la página de administración -&gt; Chamilo Rapid y establecer el host a "localhost" y
+  el puerto a "2002". Guarde los cambios. Vaya a su curso, en la pantalla de herramientas de aprendizaje y verá
+  que apareció un nuevo icono. Importar tu PPT. Esto debería funcionar. 
+</p>
+<p>
+  <em>Nota</em>: A veces, esto no se resuelve tan fácilmente. Usted probablemente tenga que solicitar la asistencia
+  de algún administrador de sistemas con un poco de experiencia en  Java y PHP, o siempre podrá preguntar a uno de
+  los proveedores oficiales de Chamilo para asistirle (pregunte por un contrato comercial garantizado).
+  <em>Nota</em>: Si usa la versión 4 de LibreOffice, es importante notar que la versión 4.2 (disponible en
+  Ubuntu 14.04) ha mostrado resultados considerablemente más exitosos al momento de convertir documentos que la
+  versión 4.1 (disponible en Ubuntu 13.10), la cual tiene tendencia a colgarse durante las conversiones.
+</p>
+<hr style="width: 100%; height: 2px;" />
+
+<h2><a id="12._cron"></a>10. Configuración de tareas programadas</h2>
+<p>
+  Desde Chamilo 1.8.8, algunas tareas necesitan ejecutarse con regularidad con el fin de obtener lo mejor de los
+  recursos del servidor. Una de las tareas de este tipo (y el único en todo en el momento de Chamilo 1.8.8) es el
+  envío de notificaciones de mensajería interna por e-mail, es decir, cuando usted recibe un correo electrónico de
+  otra persona o de un grupo dentro de la mensajería interna del sistema de Chamilo, si se envían todos los e-mails
+  inmediatamente,  puede que no llegue a recibir el correo a su ritmo, una vez al día o una vez a la semana.
+  Para casos como este, como administrador de Chamilo, debe configurar un proceso cron en el servidor para comprobar
+  la cola de mensajes de correo electrónico y enviarlo puntualmente.
+</p>
+Configurar una tarea de cron es fácil y hay varias maneras de hacerlo. Le recomendamos echar un vistazo a la
+documentación de Drupal para configurar el cron y definir su propio proceso de cron como:
+<pre>35 * * * * wget -O - -q -t 1 http://campus.example.com/main/cron/run.php</pre>
+
+<p>
+  Asegúrese de revisar el run.php tal vez desee cambiar algunas algunas opciones de configuración.
+</p>
+<hr style="width: 100%; height: 2px;" />
+
+<h2><a id="13._name_order"></a>11. Cambiando el orden del nombre/apellido en el idioma</h2>
+<p>
+  Como Chamilo se hace más popular y atraviesa muchas fronteras ahora, es frecuente que los administradores
+  quieran pedir cambiar el orden del nombre y apellido en los campos de las tablas, y también en qué campo se
+  pondrá en primer lugar.
 </p>
 <div>
-En Debian o Ubuntu 11.10 y superior, instale LibreOffice.org v3 e iniciarlo como un servidor en segundo plano:
+  Esto fácilmente se puede modificar editando el archivo app/config/configuration.php, encontrando la siguiente
+  sección, descomentando las líneas PHP y adaptándolas a su idioma:
 <pre>
-sudo apt-get install libreoffice
-sudo soffice --accept="socket,host=127.0.0.1,port=2002,tcpNoDelay=1;urp;" --headless --nodefault --nofirststartwizard --nolockcheck --nologo --norestore &amp;
+// Custom name_order_conventions
+//$_configuration['name_order_conventions'] = array(
+// 'french' => array('format' => 'title last_name first_name', 'sort_by' => 'last_name')
+//);
+</pre><br />
+  Siéntase libre de cambiar esto a
+<pre>
+// Custom name_order_conventions
+$_configuration['name_order_conventions'] = array(
+  'french' => array('format' => 'first_name last_name', 'sort_by' => 'last_name')
+);
 </pre>
+  por ejemplo. El efecto debería ser inmediato.
 </div>
-<p>
-A continuación, vaya a la página de administración -&gt; Chamilo Rapid y establecer el host a "localhost" y el puerto a "2002". Guarde los cambios. Vaya a su curso, en la pantalla de herramientas de aprendizaje y verá que apareció un nuevo icono. Importar tu PPT. Esto debería funcionar. Otra possibilidad es lanzar soffice desde una instancia de "screen", sin el &amp; al final.
-</p>
-<div>
-<em>Nota</em>: A veces, esto no se resuelve tan fácilmente. Usted probablemente tenga que solicitar la asistencia de algún administrador de sistemas con un poco de experiencia en  Java y PHP, o siempre podrá preguntar a uno de los proveedores oficiales de Chamilo para asistirle (pregunte por un contrato comercial garantizado).
-<em>Nota</em>: Si usa la versión 4 de LibreOffice, es importante notar que la versión 4.2 (disponible en Ubuntu 14.04) ha mostrado resultados considerablemente más exitosos al momento de convertir documentos que la versión 4.1 (disponible en Ubuntu 13.10), la cual tiene tendencia a colgarse durante las conversiones.
-</div>
-
 <hr style="width: 100%; height: 2px;" />
-<h2><a name="12._cron"></a>12. Configuración de tareas programadas</h2>
-<p>
-Desde Chamilo 1.8.8, algunas tareas necesitan ejecutarse con regularidad con el fin de obtener lo mejor de los recursos del servidor. Una de las tareas de este tipo (y el único en todo en el momento de Chamilo 1.8.8) es el envío de notificaciones de mensajería interna por e-mail, es decir, cuando usted recibe un correo electrónico de otra persona o de un grupo dentro de la mensajería interna del sistema de Chamilo, si se envían todos los e-mails inmediatamente,  puede que no llegue a recibir el correo a su ritmo, una vez al día o una vez a la semana. Para casos como este, como administrador de Chamilo, debe configurar un proceso cron en el servidor para comprobar la cola de mensajes de correo electrónico y enviarlo puntualmente.
-</p>
-<div>
-Configurar una tarea de cron es fácil y hay varias maneras de hacerlo. Le recomendamos echar un vistazo a la documentación de Drupal para configurar el cron y definir su propio proceso de cron como:
-<pre>
-35 * * * * wget -O - -q -t 1 http://campus.example.com/main/cron/run.php
-</pre>
-</div>
-<p>
-Asegúrese de revisar el run.php tal vez desee cambiar algunas algunas opciones de configuración.
-</p>
 
+<h2><a id="14._Improving_files_download"></a>12. Mejora de la eficacia de descarga de archivos</h2>
+La descarga de archivos puede ser muy lenta al pasar a través de un script PHP para controlar los permisos.
+Una solución para esto es usar la cabecera X-Sendfile, que depende de un módulo en el servidor web.
+<a href="http://stackoverflow.com/a/3731639/1406662">
+  Consultar http://stackoverflow.com/a/3731639/1406662 para obtener más información sobre la implementación de Sendfile
+</a>.
+Chamilo LMS 1.9.8 (y versiones siguientes) es compatible con las cabeceras X-Sendfile, pero requiere una línea
+específica de configuración para ser agregado a configuration.php:
+<pre>$_configuration['enable_x_sendfile_headers'] = true;</pre>
+Si tiene problemas con los archivos que tardan mucho tiempo en descargarse, asegúrese de reconfigurar su
+servidor web y agregar esta línea. Debería ver una diferencia notable en el tiempo de descarga.
 <hr style="width: 100%; height: 2px;" />
-<h2><a name="13._name_order"></a>13. Cambiando el orden del nombre/apellido en el idioma</h2>
+
+<h2><a id="15._Videoconference"></a>13. Videoconferencia</h2>
 <p>
-Como Chamilo se hace más popular y atraviesa muchas fronteras ahora, es frecuente que los administradores quieran pedir cambiar el orden del nombre y apellido en los campos de las tablas, y también en qué campo se pondrá en primer lugar.
+  Chamilo admite la conexión a dos servidores de videoconferencia diferentes:
+  BigBlueButton (versiones 0.81, 0.9 y 1.0) y OpenMeetings.<br />
+  Aunque BigBlueButton parece más fácil de instalar, más documentado y más estéticamente acabado, algunos usuarios
+  han manifestado que OpenMeetings consume menos ancho de banda, es menos restrictivo en términos de entornos en
+  ejecución y ofrece más herramientas y conectores.<br />
+  La decisión depende de usted, pero en cualquier caso tendrá que instalar un servidor de videoconferencia
+  por separado del proceso normal de instalación de Chamilo LMS.<br />
+  Encontrarás <a href="http://docs.bigbluebutton.org/install/install.html">una guía de instalación aquí</a>.
+  Una vez instalados, ejecute un "bbb-conf --secret" sobre línea de comandos para obtener los parámetros que se
+  solicitan desde la configuración del plugin de la videoconferencia.<br />
+  Esto debería hacer que aparezca un icono adicional de la herramienta "Videoconferencia" en cada curso.<br />
 </p>
-<div>
-Esto fácilmente se puede modificar editando el archivo main/inc/lib/internationalization_database/name_order_conventions.php, buscando nuestro idioma y cambiando los campos. Es tan simple que se explica por sí mismo y se ve así:
-<pre>
-'simpl_chinese' =&gt; array( 'format' =&gt; 'title last_name first_name', 'sort_by' =&gt; 'last_name' ), // Eastern order
-</pre>
-Siéntase libre de cambiar esto a
-<pre>
-'simpl_chinese' =&gt; array( 'format' =&gt; 'title first_name lastname', 'sort_by' =&gt; 'last_name' ), // Eastern order
-</pre>
-por ejemplo. El efecto debería ser inmediato.
-</div>
-
 <hr style="width: 100%; height: 2px;" />
-<h2><a name="14._alter_conf"></a>14. Configuraciones opcionales para Apache y Nginx</h2>
-<p><p>
-    Dadas las nuevas actualizaciones de servidores web y la fragilidad en cuanto a seguridad de archivos facilmente
-    localizables por atacantes como los htaccess, se aconseja restringir las configuraciones a un solo archivo.
-    A continuación se presentan dos ejemplos de configuración de modo que no se dependa de los archivos .htaccess.
+
+<h2><a id="16._Rewrite"></a>14. Rewrite</h2>
+<p>
+  Chamilo LMS 1.10 es la primera versión que requiere que el servidor web permita las redirecciones de las solicitudes
+  (y, por lo tanto, también lo hace 1.11).<br />
+  Para Apache, esto se hace habilitando el módulo Rewrite y permitiendo reemplazos (a través de .htaccess) o agregando
+  una sección de configuración específica al VirtualHost definido para Apache.<br />
+  Para Nginx, esto se hace a través de reglas de redirección específicas en el virtual host correspondiente
+  (cláusula de servidor).
 </p>
-<div>
-    Nginx: La configuración para nuestro sitio de ejemplo my.chamilo10.net (en el cual los archivos se han almacenado
-    en /var/www/my.chamilo10.net/www) sería la siguiente, tomando como supuesto el uso de php5-fpm a través de sockets:
+<p>
+  Para asegurarse de que esto no sea demasiado complejo para nadie, recomendamos una configuración a continuación
+  para ayudarlo en ambos casos. Tenga en cuenta que el uso de .htaccess es la manera más fácil pero puede
+  afectar considerablemente la carga de su servidor, dado que los archivos .htaccess se interpretan en *cada*
+  solicitud, mientras que un bloque de configuración en su sección VirtualHost se compila en el momento de la
+  recarga de la configuración.
+</p>
+<h3>Apache + .htaccess</h3>
+<p>
+  Para habilitar .htaccess en Apache, solo tiene que marcar 1 cosa: en un bloque &lt;Directory&gt; de la carpeta
+  raíz de Chamilo, asegúrese de que las siguientes líneas estén presentes:
+</p>
 <pre>
-  # Add your own "server {" header here with listen, server_name, access_log, error_log, index, root and error_page params
-
-  charset utf-8;
-
-  location @rewrite{
-    rewrite ^certificates/$ certificates/index.php last;
-    rewrite ^/courses/([^/]+)/$ /main/course_home/course_home.php?cDir=$1 last;
-    rewrite ^/courses/([^/]+)/index.php$ /main/course_home/course_home.php?cDir=$1 last;
-    rewrite ^/courses/([^/]+)/scorm/(.*)$ /main/document/download_scorm.php?doc_url=/$2&cDir=$1 last;
-    # Alternatively, you can choose to give direct access to all SCORM files, which is much faster but less secure
-    # rewrite "^/courses/([^/]+)/scorm/(.*)$" /app/courses/$1/scorm/$2 break;
-
-    rewrite "^/courses/([^/]+)/document/certificates/(.*)$" /app/courses/$1/document/certificates/$2 last;
-    rewrite ^/courses/([^/]+)/document/(.*)$ /main/document/download.php?doc_url=/$2&cDir=$1 last;
-    rewrite ^/courses/([^/]+)/upload/([^/]+)/(.*)$ /main/document/download_uploaded_files.php?code=$1&type=$2&file=$3 last;
-    rewrite ^/courses/([^/]+)/work/(.*)$ /main/work/download.php?file=work/$2&cDir=$1 last;
-    rewrite ^/courses/([^/]+)/(.*)$ /app/courses/$1/$2 last;
-    rewrite ^/session/([^/]+)/about/?$ /main/session/about.php?session_id=$1 last;
-    rewrite ^/badge/(\d+) /main/badge/issued.php?issue=$1 last;
-    rewrite ^/skill/(\d+)/user/(\d+)$ /main/badge/issued_all.php?skill=$1&user=$2 last;
-    rewrite ^/badge/(\d+)/user/(\d+)$ /main/badge/issued_all.php?skill=$1&user=$2 last;
-    rewrite ^/main/exercice/(.*)$ /main/exercise/$1 last;
-    rewrite ^/main/newscorm/(.*)$ /main/lp/$1 last;
-    rewrite ^/service/(\d+)$ /plugin/buycourses/src/service_information.php?service_id=$1 last;
-    rewrite "^/main/upload/users/(.*)/(.*)/my_files/(.*)$" /app/upload/users/$1/$2/my_files/$3 last;
-
-    try_files $uri /index.php$is_args$args;
-    break;
-  }
-
-  location / {
-    rewrite ^/courses/([^/]+)/$ /main/course_home/course_home.php?cDir=$1 last;
-    rewrite ^/courses/([^/]+)/index.php$ /main/course_home/course_home.php?cDir=$1 last;
-    rewrite ^/skill/(\d+)/user/(\d+)$ /main/badge/issued_all.php?skill=$1&user=$2 last;
-    rewrite ^/badge/(\d+)/user/(\d+)$ /main/badge/issued_all.php?skill=$1&user=$2 last;
-    try_files $uri @rewrite;
-  }
-
-  location /main {
-    rewrite ^/main/admin/$ /main/admin/index.php last;
-  }
-
-  location ~ \.php$ {
-    client_max_body_size 20M;
-    try_files $uri /index.php$is_args$args;
-
-    rewrite ^/certificates/$ /certificates/index.php?id=%1  last;
-    rewrite ^/courses/([^/]+)/$ /main/course_home/course_home.php?cDir=$1 last;
-    rewrite ^/courses/([^/]+)/index.php$ /main/course_home/course_home.php?cDir=$1 last;
-    rewrite ^/session/([^/]+)/about/?$ /main/session/about.php?session_id=$1 last;
-    rewrite ^/badge/([^/]+) /main/badge/issued.php?issue=$1 last;
-    rewrite ^/main/exercice/(.+)$ /main/exercise/$1 last;
-    rewrite ^/main/newscorm/(.+)$ /main/lp/$1 last;
-
-    fastcgi_pass unix:/var/run/php5-fpm.sock;
-    fastcgi_split_path_info ^(.+\.php)(/.*)$;
-    include fastcgi_params;
-    fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
-    fastcgi_param HTTPS off;
-  }
-
-  # Serve static files directly
-  location ~* \.(png|jpe?g|gif|ico|js|css|mp3|swf|flv|mp4|ogg)$ {
-    expires 1y;
-    access_log off;
-    rewrite ^/courses/([^/]+)/course-pic85x85.png$ /app/courses/$1/course-pic85x85.png last;
-    rewrite ^/courses/([^/]+)/course-pic.png$ /app/courses/$1/course-pic.png last;
-    rewrite ^/courses/([^/]+)/scorm/(.*)$ /main/document/download_scorm.php?doc_url=/$2&cDir=$1 last;
-    rewrite ^/courses/([^/]+)/document/(.*)$ /main/document/download.php?doc_url=/$2&cDir=$1 last;
-    rewrite ^/courses/([^/]+)/work/(.*)$ /main/work/download.php?file=work/$2&cDir=$1 last;
-    rewrite ^/courses/([^/]+)/upload/(.*)$ /app/courses/$1/upload/$2 last;
-    # For all these media resources not treated by previous rewrites, give direct access (no permission check)
-    rewrite ^/courses/(.*)$ /app/courses/$1 break;
-    try_files $uri @rewrite;
-  }
-  location ~ ~\.(ht|git){
-    deny all;
-  }
-  location ^~ /tests/ {
-    deny all;
-  }
+&lt;Directory /&gt;
+  AllowOverride All
+  Order allow,deny
+  allow from all
+&lt;/Directory&gt;
 </pre>
-
-Apache2: La configuración para nuestro sitio de ejemplo my.chamilo.net sería la siguiente:
-
+  o, si está trabajando con Apache 2.4, esa sintaxis cambió un poco y se parece más a esto:
 <pre>
-&lt;VirtualHost *:80&gt;
-  ServerAdmin root@localhost
-  DocumentRoot /var/www/my.chamilo.net/www
-  ServerName my.chamilo.net
-  ErrorLog  /var/log/apache2/my.chamilo.net-error.log
-  CustomLog /var/log/apache2/my.chamilo.net-access.log combined
+&lt;Directory /&gt;
+  AllowOverride All
+  Require all granted
+&lt;/Directory&gt;
+</pre>
+<h3>Apache RewriteRules</h3>
+<pre>
+&lt;LocationMatch "/.git*"&gt;
+  order deny,allow
+  deny from all
+&lt;/LocationMatch&gt;
 
-  ErrorDocument 401 /public/error-401.html
-  DirectoryIndex index.php index.html
-  Options Indexes FollowSymLinks
+&lt;Directory ~/.&gt;
+  AllowOverride None
+  Options -Indexes
+&lt;/Directory&gt;
 
-  &lt;LocationMatch "/.git*"&gt;
-	order deny,allow
-	deny from all
-  &lt;/LocationMatch&gt;
+&lt;Directory "/var/www/chamilo"&gt;
+  RewriteEngine On
+  RewriteCond %{QUERY_STRING} ^id=(.*)$
+  RewriteRule ^certificates/$ certificates/index.php?id=%1 [L]
+  RewriteRule ^courses/([^/]+)/?$ main/course_home/course_home.php?cDir=$1 [QSA,L]
+  RewriteRule ^courses/([^/]+)/index.php$ main/course_home/course_home.php?cDir=$1 [QSA,L]
+  RewriteRule ^courses/([^/]+)/scorm/(.*)$ main/document/download_scorm.php?doc_url=/$2&cDir=$1 [QSA,L]
+  RewriteRule ^courses/([^/]+)/document/certificates/(.*)$ app/courses/$1/document/certificates/$2 [QSA,L]
+  RewriteRule ^courses/([^/]+)/document/(.*)$ main/document/download.php?doc_url=/$2&cDir=$1 [QSA,L]
+  RewriteRule ^courses/([^/]+)/upload/([^/]+)/(.*)$ main/document/download_uploaded_files.php?code=$1&type=$2&file=$3 [QSA,L]
+  RewriteRule ^courses/([^/]+)/work/(.*)$ main/work/download.php?file=work/$2&cDir=$1 [QSA,L]
+  RewriteRule ^courses/([^/]+)/course-pic85x85.png$ main/inc/ajax/course.ajax.php?a=get_course_image&code=$1&image=course_image_source [QSA,L]
+  RewriteRule ^courses/([^/]+)/course-pic.png$ main/inc/ajax/course.ajax.php?a=get_course_image&code=$1&image=course_image_large_source [QSA,L]
+  RewriteRule ^courses/([^/]+)/(.*)$ app/courses/$1/$2 [QSA,L]
+  RewriteRule ^session/(\d{1,})/about/?$ main/session/about.php?session_id=$1 [L]
+  RewriteRule ^badge/(\d{1,}) main/badge/issued.php?issue=$1 [L]
+  RewriteRule ^skill/(\d{1,})/user/(\d{1,}) main/badge/issued.php?skill=$1&user=$2 [L]
+  RewriteRule ^badge/(\d{1,})/user/(\d{1,}) main/badge/issued.php?skill=$1&user=$2 [L]
+  RewriteRule ^main/exercice/(.*)$ main/exercise/$1 [QSA,L]
+  RewriteRule ^main/newscorm/(.*)$ main/lp/$1 [QSA,L]
+  RewriteRule ^main/upload/users/(.*)/(.*)/my_files/(.*)$ app/upload/users/$1/$2/my_files/$3 [QSA,L]
+  RewriteRule ^main/admin/$ main/admin/index.php [QSA,L]
+  RewriteRule ^service/(\d+)$ plugin/buycourses/src/service_information.php?service_id=$1 [L]
+  RewriteRule ^([^/.]+)/?$ user.php?$1 [L]
+  RewriteRule ^(tests|.git) - [F,L,NC]
+&lt;/Directory&gt;
 
-  &lt;Directory ~/.&gt;
-    AllowOverride None
-	Options -Indexes
-  &lt;/Directory&gt;
+AddType application/font-woff .woff .woff2
+&lt;IfModule mod_expires.c&gt;
+  ExpiresActive On
+  ExpiresByType application/font-woff "access plus 1 month"
+&lt;/IfModule&gt;
+</pre>
+<h3>Nginx</h3>
+Nginx no es compatible con las reglas de .htaccess, por lo que no tiene otra opción que aplicar las siguientes reglas
+(tenga en cuenta que la configuración de back-end de PHP puede variar). Estas son solo las reglas de redireccionamiento
+que se colocarán dentro de un bloque de servidor {}, ya que otras configuraciones pueden diferir de una instalación a otra.
+<pre>
+# Add your own "server {" header here with listen, server_name, access_log, error_log, index, root and error_page params
 
-  &lt;Directory "/var/www/chamilo"&gt;
-	RewriteEngine On
-	RewriteCond %{QUERY_STRING} ^id=(.*)$
-	RewriteRule ^([^/.]+)/?$ user.php?$1 [L]
-	RewriteRule ^certificates/$ certificates/index.php?id=%1 [L]
-	RewriteRule ^courses/([^/]+)/$ main/course_home/course_home.php?cDir=$1 [QSA,L]
-	RewriteRule ^courses/([^/]+)/index.php$ main/course_home/course_home.php?cDir=$1 [QSA,L]
-	RewriteRule ^courses/([^/]+)/document/certificates/(.*)$ app/courses/$1/document/certificates/$2 [QSA,L]
-	RewriteRule ^courses/([^/]+)/document/(.*)$ main/document/download.php?doc_url=/$2&cDir=$1 [QSA,L]
-	RewriteRule ^courses/([^/]+)/scorm/(.*)$ main/document/download_scorm.php?doc_url=/$2&cDir=$1 [QSA,L]
-	RewriteRule ^courses/([^/]+)/work/(.*)$ main/work/download.php?file=work/$2&cDir=$1 [QSA,L]
-	RewriteRule ^courses/([^/]+)/upload/(.*)$ app/courses/$1/upload/$2 [QSA,L]
-	RewriteRule ^courses/([^/]+)/course-pic85x85.png$ app/courses/$1/course-pic85x85.png [QSA,L]
-	RewriteRule ^courses/([^/]+)/course-pic.png$ app/courses/$1/course-pic.png [QSA,L]
-	RewriteRule ^main/upload/users/(.*)/(.*)/my_files/(.*)$ app/upload/users/$1/$2/my_files/$3 [QSA,L]
-	RewriteRule ^session/(\d{1,})/about/?$ main/session/about.php?session_id=$1 [L]
-    RewriteRule ^badge/(\d{1,})/user/(\d{1,}) main/badge/issued.php?skill=$1&user=$2 [L]
-	RewriteRule ^main/admin/$ main/admin/index.php [QSA,L]
-    RewriteRule ^main/exercice/(.+)$ main/exercise/$1 [QSA,L]
-    RewriteRule ^main/newscorm/(.*)$ main/lp/$1 [QSA,L]
-	RewriteRule ^courses/(.*)$ app/courses/$1 [QSA,L]
-  &lt;/Directory&gt;
+charset utf-8;
 
-  php_value display_errors Off
-  php_value log_errors On
-  php_value display_startup_errors Off
-  php_value post_max_size 300M
-  php_value upload_max_filesize 300M
-  # E_ALL:  php_admin_value error_reporting 6143
-  # E_ALL & ^E_NOTICE:
-  php_admin_value error_reporting 6135
-  #php_admin_value session.save_path /var/www/my.chamilo.net/sessions/
-  php_admin_value short_open_tag Off
-  php_value session.cookie_httponly 1
+location @rewrite{
+  rewrite ^certificates/$ certificates/index.php last;
+  rewrite ^/courses/([^/]+)/$ /main/course_home/course_home.php?cDir=$1 last;
+  rewrite ^/courses/([^/]+)/index.php$ /main/course_home/course_home.php?cDir=$1 last;
+  rewrite ^/courses/([^/]+)/scorm/(.*)$ /main/document/download_scorm.php?doc_url=/$2&cDir=$1 last;
+  # Alternatively, you can choose to give direct access to all SCORM files, which is much faster but less secure
+  # rewrite "^/courses/([^/]+)/scorm/(.*)$" /app/courses/$1/scorm/$2 break;
 
-&lt;/VirtualHost&gt;
-</pre></div>
+  rewrite "^/courses/([^/]+)/document/certificates/(.*)$" /app/courses/$1/document/certificates/$2 last;
+  rewrite ^/courses/([^/]+)/document/(.*)$ /main/document/download.php?doc_url=/$2&cDir=$1 last;
+  rewrite ^/courses/([^/]+)/upload/([^/]+)/(.*)$ /main/document/download_uploaded_files.php?code=$1&type=$2&file=$3 last;
+  rewrite ^/courses/([^/]+)/work/(.*)$ /main/work/download.php?file=work/$2&cDir=$1 last;
+  rewrite ^/courses/([^/]+)/(.*)$ /app/courses/$1/$2 last;
+  rewrite ^/session/([^/]+)/about/?$ /main/session/about.php?session_id=$1 last;
+  rewrite ^/badge/(\d+) /main/badge/issued.php?issue=$1 last;
+  rewrite ^/skill/(\d+)/user/(\d+)$ /main/badge/issued_all.php?skill=$1&user=$2 last;
+  rewrite ^/badge/(\d+)/user/(\d+)$ /main/badge/issued_all.php?skill=$1&user=$2 last;
+  rewrite ^/main/exercice/(.*)$ /main/exercise/$1 last;
+  rewrite ^/main/newscorm/(.*)$ /main/lp/$1 last;
+  rewrite ^/service/(\d+)$ /plugin/buycourses/src/service_information.php?service_id=$1 last;
+  rewrite "^/main/upload/users/(.*)/(.*)/my_files/(.*)$" /app/upload/users/$1/$2/my_files/$3 last;
 
+  try_files $uri /index.php$is_args$args;
+  break;
+}
+
+location / {
+ try_files $uri @rewrite;
+}
+
+location /main {
+  rewrite ^/main/admin/?$ /main/admin/index.php last;
+}
+
+location ~ \.php$ {
+  client_max_body_size 20M;
+  try_files $uri @rewrite;
+
+  fastcgi_pass unix:/var/run/php5-fpm.sock;
+  fastcgi_split_path_info ^(.+\.php)(/.*)$;
+  include fastcgi_params;
+  fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+  fastcgi_param HTTPS off;
+}
+
+# Serve static files directly
+location ~* \.(png|jpe?g|gif|ico|js|css|mp3|swf|flv|mp4|ogg|woff|woff2)$ {
+  expires 30d;
+  access_log off;
+  rewrite ^/courses/([^/]+)/course-pic85x85.png$ /app/courses/$1/course-pic85x85.png last;
+  rewrite ^/courses/([^/]+)/course-pic.png$ /app/courses/$1/course-pic.png last;
+  try_files $uri @rewrite;
+}
+location ~ ~\.(ht|git){
+  deny all;
+}
+location ^~ /tests/ {
+  deny all;
+}
+</pre>
+<h3>Apple en servidores OS X</h3>
+<p>
+  Scott Steven informa que Apache en OS X requiere acciones específicas
+</p>
+<ul>
+  <li>Primero, asegúrese de tener el archivo .htaccess presente en la raíz de su carpeta Chamilo</li>
+  <li>Acceda al archivo HTTPd.conf de su Apache y configure su dominio y el hecho de que se carga mod_rewrite</li>
+  <li>En su aplicación de servidor Apple, Configuración avanzada, marque la casilla para permitir .htaccess</li>
+</ul>
+<p>  
+  Alternativamente, puede encontrar el archivo de configuración para su dominio en la carpeta de configuración
+  de Apple en /Library/Server/Web/Settings para actualizarlo manualmente.<br />
+  Sin embargo, no puede permitir archivos .htaccess en el archivo httpd.conf principal, ya que OS X
+  lo reemplazará con el archivo de configuración específico del dominio.
+</p>
+<hr style="width: 100%; height: 2px;" />
+
+<h2><a id="17._Git_Upgrade"></a>15. Actualización de Git</h2>
+<p>
+  Si tiene suficiente experiencia con Git y ha instalado su portal inicial de Chamilo desde la versión de Git,
+  es posible que desee actualizar de 1.9.x a 1.11.x usando Git directamente.<br />
+  Aquí hay algunos consejos que pueden ayudarlo:
+</p>
+<ul>
+  <li>Entra en tu repositorio de Chamilo Git</li>
+  <li>Asegúrate de no tener elementos adicionales que no se hayan comprometido (git status / git stash))</li>
+  <li>ISi tiene problemas, siempre puede guardar su código en otro lugar y pedirle a Git que lo coloque exactamente
+ en la etapa 1.9.x más reciente ("git pull" / "git reset --hard origin/1.9.x")</li>
+  <li>
+    Una vez que esté seguro de tener un repositorio local "limpio" de Chamilo, cree una rama 1.11.x
+    con "git checkout -b 1.11.x"
+  </li>
+  <li>En la nueva rama, descargue todo el código de la rama 1.11.x upstream: "git pull origin 1.11.x"</li>
+  <li>Si nunca usó composer o lo usó solo unas pocas veces en el pasado, es posible que necesite actualizarlo
+ (rm -rf ~/.composer/vendor; composer clear-cache) antes de intentar el siguiente comando</li>
+  <li>Actualizar composer: "composer update" (es posible que necesite dar un token Github aquí)</li>
+  <li>Cambiar permisos en la aplicación de carpetas app, web, main/lang y main/default_course_document/images</li>
+  <li>Vaya a la página de instalación del portal (main/install/) y siga el procedimiento de actualización</li>
+</ul>
 <hr style="width: 100%; height: 2px;" />
 <p>
-  <br />
-  <br />
   Dirección de Contacto: Chamilo<br />
   Correo: info@chamilo.org<br />
 </p>
-<hr />
+<hr style="width: 100%; height: 2px;" />
 
-<hr />
-    <a href="http://validator.w3.org/check?uri=referer"><img src="//www.w3.org/Icons/valid-xhtml10-blue" alt="Valid XHTML 1.0 Transitional" style="margin: 1em; float: right;" height="31" width="88" /></a>
-	<a href="http://jigsaw.w3.org/css-validator/">
-		<img src="//jigsaw.w3.org/css-validator/images/vcss-blue" style="margin: 1em; float: right;" alt="Valid CSS" />
-	</a>
+<a href="http://validator.w3.org/check?uri=referer">
+    <img src="//www.w3.org/Icons/valid-xhtml10-blue"
+        style="margin:1em;border:0;width:88px;height:31px; float: right;"
+        alt="Valid XHTML 1.0 Transitional" />
+</a>
+<a href="http://jigsaw.w3.org/css-validator/check/referer">
+    <img style="margin:1em;border:0;width:88px;height:31px; float: right;"
+        src="http://jigsaw.w3.org/css-validator/images/vcss-blue"
+        alt="¡CSS Válido!" />
+</a>
+
+</div>
 </body>
 </html>


### PR DESCRIPTION
Actualización de la guía en castellano basándose en la documentación en ingles.

- Corregido errores del validador de html (https://validator.w3.org/)
 `Bad value screen,projection for attribute media on element link: Deprecated media type projection
 The name attribute is obsolete. Consider putting an id attribute on the nearest container instead.`
- Actualizadas las referencias a versiones antiguas de Chamilo LMS
- Actualizados los enlaces a la página de descarga de chamilo
