### PR TITLE
Fixed form.php to send to the LTI Provider using POST arguments inste…

### DIFF
--- a/plugin/ims_lti/form.php
+++ b/plugin/ims_lti/form.php
@@ -83,8 +83,14 @@ $result = $oauth->sign(array(
         <title>title</title>
     </head>
     <body>
-        <form action="<?php echo $result['signed_url'] ?>" name="ltiLaunchForm" method="post" encType="application/x-www-form-urlencoded">
-            <input type="submit" value="Press to continue to external tool"/>
+        <form action="<?php echo $tool->getLaunchUrl() ?>" name="ltiLaunchForm" method="post" encType="application/x-www-form-urlencoded">
+        <?php
+          foreach($result["parameters"] as $key => $values) //Dump parameters
+			{
+                echo("<input type='hidden' name='$key' value='$values' />");
+			}
+		?>
+			<input type="submit" value="Press to continue to external tool"/>
         </form>
 
         <script language="javascript">

--- a/plugin/ims_lti/form.php
+++ b/plugin/ims_lti/form.php
@@ -85,11 +85,11 @@ $result = $oauth->sign(array(
     <body>
         <form action="<?php echo $tool->getLaunchUrl() ?>" name="ltiLaunchForm" method="post" encType="application/x-www-form-urlencoded">
         <?php
-          foreach($result["parameters"] as $key => $values) //Dump parameters
-			{
+        foreach($result["parameters"] as $key => $values) //Dump parameters
+        {
                 echo("<input type='hidden' name='$key' value='$values' />");
-			}
-		?>
+        }
+    ?>
 			<input type="submit" value="Press to continue to external tool"/>
         </form>
 


### PR DESCRIPTION
Changed form.php to use POST instead of QueryString Parameters it should resolve issue #2378 and be more in line with the IMS / LTI 1.0 Spec 

>
 The Basic LTI launch protocol is a POST to the launch URL with the Basic LTI parameters described above, properly signed using OAuth.

> 
Source : https://www.imsglobal.org/specs/ltiv1p0/implementation-guide#toc-11