### PR TITLE
Check the logic in method setAnswer on Ims2Question

### DIFF
--- a/main/exercise/export/qti2/qti2_classes.php
+++ b/main/exercise/export/qti2/qti2_classes.php
@@ -19,13 +19,7 @@ class Ims2Question extends Question
     {
         switch ($this->type) {
             case MCUA:
-                $answer = new ImsAnswerMultipleChoice($this->id);
-
-                return $answer;
             case MCMA:
-                $answer = new ImsAnswerMultipleChoice($this->id);
-
-                return $answer;
             case TF:
                 $answer = new ImsAnswerMultipleChoice($this->id);
 
@@ -47,12 +41,9 @@ class Ims2Question extends Question
                 $answer = new ImsAnswerHotspot($this->id);
 
                 return $answer;
-            default:
-                $answer = null;
-                break;
         }
 
-        return $answer;
+        return null;
     }
 
     public function createAnswersForm($form)

--- a/main/exercise/export/qti2/qti2_classes.php
+++ b/main/exercise/export/qti2/qti2_classes.php
@@ -17,6 +17,7 @@ class Ims2Question extends Question
      */
     public function setAnswer()
     {
+        $answer = null;
         switch ($this->type) {
             case MCUA:
             case MCMA:
@@ -41,9 +42,11 @@ class Ims2Question extends Question
                 $answer = new ImsAnswerHotspot($this->id);
 
                 return $answer;
+            default:
+                break;
         }
 
-        return null;
+        return $answer;
     }
 
     public function createAnswersForm($form)


### PR DESCRIPTION
The types `MCUA`, `MCMA` and `TF` generate the same answer(`ImsAnswerMultipleChoice`).

The `default` option was eliminated, since it was inefficient besides generating the same result, see the simple test:

```php
function test1($type) {
	switch ($type) {
		case 1:
		case 2:
			$answer = "1 or 2";
			return $answer;
		default:
			$answer = null;
			break;
	}
	return $answer;
}

var_dump(test1(1)) . "\n";
// string(6) "1 or 2"
var_dump(test1(5)) . "\n";
// NULL

function test2($type) {
	switch ($type) {
		case 1:
		case 2:
			$answer = "1 or 2";
			return $answer;
	}
	return null;
}

var_dump(test2(1)) . "\n";
// string(6) "1 or 2"
var_dump(test2(5)) . "\n";
// NULL
```

if in structure switch in each case returns the $answer, I think it could look like:

```php
public function setAnswer()
{
	switch ($this->type) {
		case MCUA:
		case MCMA:
		case TF:
			return new ImsAnswerMultipleChoice($this->id);
		case FIB:
			return new ImsAnswerFillInBlanks($this->id);
		case MATCHING:
		case MATCHING_DRAGGABLE:
			return new ImsAnswerMatching($this->id);
		case FREE_ANSWER:
			return new ImsAnswerFree($this->id);
		case HOT_SPOT:
			return new ImsAnswerHotspot($this->id);
	}
	return null;
}
```