### PR TITLE
Añadir opción de configuración para ocultar contenidos

### DIFF
--- a/plugin/customcertificate/lang/english.php
+++ b/plugin/customcertificate/lang/english.php
@@ -22,6 +22,7 @@ $strings['ContentsToShow'] = "Contents to show";
 $strings['ContentsCourseDescription'] = 'Use section "Course description"> "Contents"';
 $strings['ContentsIndexLearnpath'] = "Use learnpath index";
 $strings['ContentsCustom'] = "Use custom content";
+$strings['ContentsHide'] = "No show contents";
 $strings['Dates'] = "Dates";
 $strings['CourseDeliveryDates'] = "Course delivery dates";
 $strings['Custom'] = "Custom";

--- a/plugin/customcertificate/lang/spanish.php
+++ b/plugin/customcertificate/lang/spanish.php
@@ -22,6 +22,7 @@ $strings['ContentsToShow'] = "Contenidos a mostrar";
 $strings['ContentsCourseDescription'] = 'Usar apartado "Descripcion del curso" > "Contenidos"';
 $strings['ContentsIndexLearnpath'] = "Usar indice de lecciones";
 $strings['ContentsCustom'] = "Usar contenido personalizado";
+$strings['ContentsHide'] = "No mostrar contenidos";
 $strings['Dates'] = "Fechas";
 $strings['CourseDeliveryDates'] = "Fechas de impartición del curso";
 $strings['Custom'] = "Personalizado";

--- a/plugin/customcertificate/src/index.php
+++ b/plugin/customcertificate/src/index.php
@@ -325,6 +325,16 @@ $element = &$form->createElement(
     'radio',
     'contents_type',
     '',
+    get_lang('ContentsHide'),
+    3,
+    ['id' => 'contents_type_3', 'onclick' => 'javascript: contentsTypeSwitchRadioButton();']
+);
+$group[] = $element;
+
+$element = &$form->createElement(
+    'radio',
+    'contents_type',
+    '',
     get_lang('ContentsCustom'),
     2,
     ['id' => 'contents_type_2', 'onclick' => 'javascript: contentsTypeSwitchRadioButton();']
@@ -373,7 +383,7 @@ $option1 = &$form->createElement(
     '',
     get_lang('UseDateSessionAccess'),
     0,
-    ['id' => 'contents_type_0', 'onclick' => 'javascript: dateCertificateSwitchRadioButton0();']
+    ['id' => 'date_change_0', 'onclick' => 'javascript: dateCertificateSwitchRadioButton0();']
 );
 $group[] = $option1;
 
@@ -383,7 +393,7 @@ $option2 = &$form->createElement(
     '',
     get_lang('None'),
     2,
-    ['id' => 'contents_type_2', 'onclick' => 'javascript: dateCertificateSwitchRadioButton2();']
+    ['id' => 'date_change_2', 'onclick' => 'javascript: dateCertificateSwitchRadioButton2();']
 );
 $group[] = $option2;
 
@@ -393,7 +403,7 @@ $option3 = &$form->createElement(
     '',
     get_lang('Custom'),
     1,
-    ['id' => 'contents_type_1', 'onclick' => 'javascript: dateCertificateSwitchRadioButton1();']
+    ['id' => 'date_change_1', 'onclick' => 'javascript: dateCertificateSwitchRadioButton1();']
 );
 $group[] = $option3;
 


### PR DESCRIPTION
En muchas ocasiones puede que solo nos interese mostrar el contenido frontal del certificado y que no muestre la cara posterior donde suele estar el indice de contenidos del certificado.
Se añade un checkbox en la configuración del certificado en el apartado de contenidos con dicha opción.