### PR TITLE
Corrección al tener el plugin SEPE activo y habilitar otros plugins

### DIFF
--- a/plugin/sepe/src/sepe_plugin.class.php
+++ b/plugin/sepe/src/sepe_plugin.class.php
@@ -80,7 +80,7 @@ class SepePlugin extends Plugin
         $sm = $cn->getSchemaManager();
         $tables = $sm->tablesExist($tablesToBeCompared);
 
-        if ($tables) {
+        if (empty($tables)) {
             return false;
         }
 


### PR DESCRIPTION
Cuando el plugin SEPE está activo y habilitas/deshabilitas otros plugins se produce un error, al intentar reinstalar tablas que ya existen del plugin del sepe.
En la condición se utilizado la función empty para verificar si el array que devuelve la función de comparar si existe las tablas se encuentra vacío, y si es así que retorne false.

Esta condición en la función install  se podría aplicar a otros plugins para evitar problemas.