### PR TITLE
Ocultar lecciones no visibles en informe de progreso alumno

### DIFF
--- a/main/inc/lib/tracking.lib.php
+++ b/main/inc/lib/tracking.lib.php
@@ -5796,6 +5796,10 @@ class Tracking
 
             if (!empty($lp_list) > 0) {
                 foreach ($lp_list as $lp_id => $learnpath) {
+                    if (!$learnpath['lp_visibility']) {
+                        continue;
+                    }
+                    
                     $progress = self::get_avg_student_progress(
                         $user_id,
                         $course,


### PR DESCRIPTION
Problema: Al entrar en el informe de progreso como alumno se visualizan todas las lecciones incluidas las no visibles.
Solución: Consultar $learnpath['lp_visibility'] para consultar cual mostrar