### PR TITLE
Ordenar la lista de salas de la bbb

### DIFF
--- a/plugin/bbb/lib/bbb.lib.php
+++ b/plugin/bbb/lib/bbb.lib.php
@@ -734,6 +734,8 @@ class bbb
             );
         }
 
+        $conditions['order'] = "created_at ASC";
+
         $meetingList = Database::select(
             '*',
             $this->table,


### PR DESCRIPTION
En algunas instalaciones la lista de salas salen desordenadas. 
La consulta que se realiza en base de datos obtiene los datos por la posición en la tabla (en instalaciones limpias o en las que no se han borrado muchos registros muestra el orden correctamente) pero en algunas ocasiones no es así. 
Para solucionarlo he puesto en la consulta una condición de "order" basado en la columna "created_at"