### PR TITLE
Estudiantes no se suscriben tras introducir la clave del curso

### DIFF
--- a/main/auth/set_temp_password.php
+++ b/main/auth/set_temp_password.php
@@ -41,7 +41,7 @@ if ($form->validate()) {
     if (sha1($formValues['course_password']) === $courseInfo['registration_code']) {
         Session::write('course_password_'.$courseInfo['real_id'], true);
         header('Location: '.api_get_course_url($courseInfo['code'], $sessionId).
-            '&action=subscribe&sec_token='.Security::get_existing_token());
+        '&action=subscribe&sec_token='.Security::get_existing_token());
         exit;
     } else {
         Display::addFlash(

--- a/main/auth/set_temp_password.php
+++ b/main/auth/set_temp_password.php
@@ -11,36 +11,37 @@ use ChamiloSession as Session;
 $cidReset = true;
 require_once __DIR__.'/../inc/global.inc.php';
 $this_section = SECTION_COURSES;
-$course_id = isset($_GET['course_id']) ? intval($_GET['course_id']) : null;
-$session_id = isset($_GET['session_id']) ? intval($_GET['session_id']) : null;
-$user_id = api_get_user_id();
+$courseId = isset($_GET['course_id']) ? intval($_GET['course_id']) : null;
+$sessionId = isset($_GET['session_id']) ? intval($_GET['session_id']) : null;
+$userId = api_get_user_id();
 
 /**
  * Security check.
  */
-if (empty($course_id)) {
+if (empty($courseId)) {
     api_not_allowed();
 }
 
-$course_info = api_get_course_info_by_id($course_id);
+$courseInfo = api_get_course_info_by_id($courseId);
 
 // Build the form
 $form = new FormValidator(
     'set_temp_password',
     'POST',
-    api_get_self().'?course_id='.$course_id.'&session_id='.$session_id
+    api_get_self().'?course_id='.$courseId.'&session_id='.$sessionId
 );
 $form->addElement('header', get_lang('CourseRequiresPassword'));
-$form->addElement('hidden', 'course_id', $course_id);
-$form->addElement('hidden', 'session_id', $session_id);
+$form->addElement('hidden', 'course_id', $courseId);
+$form->addElement('hidden', 'session_id', $sessionId);
 $form->addElement('password', 'course_password', get_lang('Password'));
 $form->addButtonSave(get_lang('Accept'));
 
 if ($form->validate()) {
-    $form_values = $form->exportValues();
-    if (sha1($form_values['course_password']) === $course_info['registration_code']) {
-        Session::write('course_password_'.$course_info['real_id'], true);
-        header('Location: '.api_get_course_url($course_info['code'], $session_id).'&action=subscribe&sec_token='.Security::get_existing_token());
+    $formValues = $form->exportValues();
+    if (sha1($formValues['course_password']) === $courseInfo['registration_code']) {
+        Session::write('course_password_'.$courseInfo['real_id'], true);
+        header('Location: '.api_get_course_url($courseInfo['code'], $sessionId).
+            '&action=subscribe&sec_token='.Security::get_existing_token());
         exit;
     } else {
         Display::addFlash(

--- a/main/auth/set_temp_password.php
+++ b/main/auth/set_temp_password.php
@@ -40,7 +40,7 @@ if ($form->validate()) {
     $form_values = $form->exportValues();
     if (sha1($form_values['course_password']) === $course_info['registration_code']) {
         Session::write('course_password_'.$course_info['real_id'], true);
-        header('Location: '.api_get_course_url($course_info['code'], $session_id));
+        header('Location: '.api_get_course_url($course_info['code'], $session_id).'&action=subscribe&sec_token='.Security::get_existing_token());
         exit;
     } else {
         Display::addFlash(


### PR DESCRIPTION
Problema:
En los cursos que están configurados con clave de acceso en la suscripción, al introducir la clave del curso, el usuario accede al curso pero no se suscribe (no aparece reflejado en el listado de estudiantes suscritos). Y cada vez que se loguea en la plataforma debe introducir la clave de acceso al curso.

Comportamiento esperado:
Al introducir la clave del curso, el estudiante se suscribe en el curso, apareciendo el curso en su listado de cursos. Y apareciendo el estudiante en la herramienta de usuarios en el apartado de estudiantes

Propuesta de solución:
Para solucionar el problema, he añadido en la url el parámetro de action y el token.