### PR TITLE
Remitente en la bandeja de salida de mensajes

### DIFF
--- a/main/inc/lib/message.lib.php
+++ b/main/inc/lib/message.lib.php
@@ -189,7 +189,8 @@ class MessageManager
                     title as col1, 
                     send_date as col2, 
                     msg_status as col3,
-                    user_sender_id
+                    user_sender_id,
+                    user_receiver_id
                 FROM $table
                 WHERE
                     $whereConditions
@@ -208,6 +209,7 @@ class MessageManager
             $sendDate = $row['col2'];
             $status = $row['col3'];
             $senderId = $row['user_sender_id'];
+            $receiverId = $row['user_receiver_id'];
 
             $title = Security::remove_XSS($title, STUDENT, true);
             $title = cut($title, 80, true);
@@ -218,6 +220,9 @@ class MessageManager
             }
 
             $userInfo = api_get_user_info($senderId);
+            if ($type == self::MESSAGE_TYPE_OUTBOX) {
+                $userInfo = api_get_user_info($receiverId);
+            }
             $message[3] = '';
             if (!empty($senderId) && !empty($userInfo)) {
                 $message[1] = '<a '.$class.' href="'.$viewUrl.'&id='.$messageId.'">'.$title.'</a><br />';


### PR DESCRIPTION
En la pantalla de la bandeja de salida de los mensajes, se muestra la información del propio usuario que fue el que mandó el mensaje, cuando lo ideal es que se muestre la información a quien se lo has mandado.