### PR TITLE
Marcar de forma manual los cursos populares

### DIFF
--- a/index.php
+++ b/index.php
@@ -140,7 +140,11 @@ if ($useCookieValidation === 'true') {
 // When loading a chamilo page do not include the hot courses and news
 if (!isset($_REQUEST['include'])) {
     if (api_get_setting('show_hot_courses') == 'true') {
-        $hotCourses = $controller->return_hot_courses();
+        if (api_get_configuration_value('popular_courses')) {
+            $hotCourses = $controller->return_popular_courses();
+        } else {
+            $hotCourses = $controller->return_hot_courses();
+        }
     }
     $announcements_block = $controller->return_announcements();
 }

--- a/index.php
+++ b/index.php
@@ -141,7 +141,7 @@ if ($useCookieValidation === 'true') {
 if (!isset($_REQUEST['include'])) {
     if (api_get_setting('show_hot_courses') == 'true') {
         if (api_get_configuration_value('popular_courses')) {
-            $hotCourses = $controller->return_popular_courses();
+            $hotCourses = $controller->returnPopularCourses();
         } else {
             $hotCourses = $controller->return_hot_courses();
         }

--- a/main/inc/lib/course.lib.php
+++ b/main/inc/lib/course.lib.php
@@ -4901,7 +4901,7 @@ class CourseManager
      *
      * @return array
      */
-    public static function return_popular_courses()
+    public static function returnPopularCourses()
     {
         if (api_is_invitee()) {
             return [];

--- a/main/inc/lib/userportal.lib.php
+++ b/main/inc/lib/userportal.lib.php
@@ -1901,9 +1901,9 @@ class IndexManager
     /**
      * @return array
      */
-    public function return_popular_courses()
+    public function returnPopularCourses()
     {
-        return CourseManager::return_popular_courses();
+        return CourseManager::returnPopularCourses();
     }
 
     /**

--- a/main/inc/lib/userportal.lib.php
+++ b/main/inc/lib/userportal.lib.php
@@ -1899,6 +1899,14 @@ class IndexManager
     }
 
     /**
+     * @return array
+     */
+    public function return_popular_courses()
+    {
+        return CourseManager::return_popular_courses();
+    }
+
+    /**
      * UserPortal view for session, return the HTML of the course list.
      *
      * @param $user_id

--- a/main/install/configuration.dist.php
+++ b/main/install/configuration.dist.php
@@ -1388,6 +1388,13 @@ ALTER TABLE notification_event ADD COLUMN event_id INT NULL;
 // In Scorm comunication use the username instead of the user_id
 //$_configuration['scorm_api_username_as_student_id'] = false;
 
+// Popular courses on the home page
+// Create a extra field in course called "popular_courses" (type CHECKBOX) OR
+// INSERT extra_field (extra_field_type, field_type, variable, display_text, visible_to_self, changeable, create_at)
+// VALUES (2, 13, 'popular_courses', 'Popular Courses', 1, 1, 'YYYY-mm-dd HH:mm:ss')
+// Change datetime in SQL
+// $_configuration['popular_courses'] = true;
+
 
 // KEEP THIS AT THE END
 // -------- Custom DB changes


### PR DESCRIPTION
En la actualidad los cursos populares utiliza como valores para filtrar el número de visitas de los últimos 30 días y con limitación de 6 elementos a mostrar, no dando la opción de personalización por parte de los administradores de la plataforma.

Alternativa propuesta:
 1- Crear un campo extra para los cursos con el nombre de etiqueta del campo "popular_courses".
![20-02-2020 12-25-30](https://user-images.githubusercontent.com/5868981/74930290-899f0780-53dd-11ea-8cb4-3bb774adee6a.jpg)

2 - Editar el curso y marca el campo checkbox de curso popular.
![20-02-2020 12-26-06](https://user-images.githubusercontent.com/5868981/74930349-acc9b700-53dd-11ea-87e6-b5095a65881d.jpg)

3 - Descomentar en el fichero de configuración la variable "popular_courses" 
<pre>$_configuration['popular_courses'] = true;</pre>

4 - Refrescar página principal de la plataforma
![20-02-2020 12-31-40](https://user-images.githubusercontent.com/5868981/74930437-e0a4dc80-53dd-11ea-83dd-f24dd71f9e7f.jpg)

 