### PR TITLE
Información de listado de foros mezclada

### DIFF
--- a/main/forum/index.php
+++ b/main/forum/index.php
@@ -342,7 +342,6 @@ if (is_array($forumCategories)) {
         $forumCategoryInfo['tools'] = $tools;
         $forumCategoryInfo['forums'] = [];
         // The forums in this category.
-        $forumInfo = [];
         $forumsInCategory = get_forums_in_category($forumCategory['cat_id']);
 
         if (!empty($forumsInCategory)) {
@@ -390,6 +389,7 @@ if (is_array($forumCategories)) {
                     }
 
                     if ($show_forum) {
+                        $forumInfo = [];
                         $form_count++;
                         $mywhatsnew_post_info = isset($whatsnew_post_info[$forum['forum_id']])
                             ? $whatsnew_post_info[$forum['forum_id']]


### PR DESCRIPTION
En la lista de foros aparece información de los distintos foros mezclada.
Solución: Resetear el array que almacena la información del foro para que en cada iteracción no use información del foro anterior.