### PR TITLE
Added check to see if extra mail fields where set before remove.

### DIFF
--- a/custompages/registration-dist.php
+++ b/custompages/registration-dist.php
@@ -12,10 +12,17 @@ require_once api_get_path(SYS_PATH).'main/inc/global.inc.php';
 require_once __DIR__.'/language.php';
 /**
  * Removes some unwanted elementend of the form object.
+ * 03-26-2020  Added check if element exist.
  */
-$content['form']->removeElement('extra_mail_notify_invitation');
-$content['form']->removeElement('extra_mail_notify_message');
-$content['form']->removeElement('extra_mail_notify_group_message');
+if (isset($content['form']->_elementIndex['extra_mail_notify_invitation'])) {
+    $content['form']->removeElement('extra_mail_notify_invitation');
+}
+if (isset($content['form']->_elementIndex['extra_mail_notify_message'])) {
+    $content['form']->removeElement('extra_mail_notify_message');
+}
+if (isset($content['form']->_elementIndex['extra_mail_notify_group_message'])) {
+    $content['form']->removeElement('extra_mail_notify_group_message');
+}
 $content['form']->removeElement('official_code');
 $content['form']->removeElement('phone');
 $content['form']->removeElement('submit');

--- a/custompages/registration-dist.php
+++ b/custompages/registration-dist.php
@@ -23,15 +23,6 @@ if (isset($content['form']->_elementIndex['extra_mail_notify_message'])) {
 if (isset($content['form']->_elementIndex['extra_mail_notify_group_message'])) {
     $content['form']->removeElement('extra_mail_notify_group_message');
 }
-if (isset($content['form']->_elementIndex['official_code'])) {
-    $content['form']->removeElement('official_code');
-}
-if (isset($content['form']->_elementIndex['phone'])) {
-    $content['form']->removeElement('phone');
-}
-if (isset($content['form']->_elementIndex['submit'])) {
-    $content['form']->removeElement('submit');
-}
 
 if (isset($content['form']->_elementIndex['status'])) {
     $content['form']->removeElement('status');

--- a/custompages/registration-dist.php
+++ b/custompages/registration-dist.php
@@ -23,9 +23,16 @@ if (isset($content['form']->_elementIndex['extra_mail_notify_message'])) {
 if (isset($content['form']->_elementIndex['extra_mail_notify_group_message'])) {
     $content['form']->removeElement('extra_mail_notify_group_message');
 }
-$content['form']->removeElement('official_code');
-$content['form']->removeElement('phone');
-$content['form']->removeElement('submit');
+if (isset($content['form']->_elementIndex['official_code'])) {
+    $content['form']->removeElement('official_code');
+}
+if (isset($content['form']->_elementIndex['phone'])) {
+    $content['form']->removeElement('phone');
+}
+if (isset($content['form']->_elementIndex['submit'])) {
+    $content['form']->removeElement('submit');
+}
+
 if (isset($content['form']->_elementIndex['status'])) {
     $content['form']->removeElement('status');
     $content['form']->removeElement('status');


### PR DESCRIPTION
If these extra fields where not set it would throw an error: 
PHP Fatal error:  Uncaught Exception: Element 'extra_mail_notify_invitation' does not exist in HTML_QuickForm::removeElement()

$content['form']->removeElement('extra_mail_notify_invitation');
$content['form']->removeElement('extra_mail_notify_message');
$content['form']->removeElement('extra_mail_notify_group_message');