### PR TITLE
Hide buttons for admin level actions on reports tab view

### DIFF
--- a/main/mySpace/index.php
+++ b/main/mySpace/index.php
@@ -298,6 +298,7 @@ $view->assign(
 $view->assign('studentboss', STUDENT_BOSS);
 $view->assign('drh', DRH);
 $view->assign('stats', $stats);
+$view->assign('isPlatformAdmin', $is_platform_admin);
 
 $form = new FormValidator(
     'search_user',

--- a/main/template/default/my_space/index.tpl
+++ b/main/template/default/my_space/index.tpl
@@ -107,7 +107,7 @@
                         </div>
                     </div>
 
-                    {% if _u.status == 1 %}
+                    {% if _u.status == 1 and isPlatformAdmin %}
                         <a href="{{ _p.web_main }}admin/dashboard_add_users_to_user.php?user={{ _u.id }}" class="btn btn-default btn-sm">
                             <i class="fa fa-plus" aria-hidden="true"></i>
                         </a>
@@ -154,7 +154,7 @@
                             <a class="btn btn-default" href="{{ _p.web_main }}mySpace/session.php">{{ 'FollowedSessions' | get_lang }}</a>
                         </div>
                     </div>
-                    {% if _u.status == 1 %}
+                    {% if _u.status == 1 and isPlatformAdmin %}
                         <a href="{{ _p.web_main }}admin/dashboard_add_sessions_to_user.php?user={{ _u.id }}" class="btn btn-default btn-sm">
                             <i class="fa fa-plus" aria-hidden="true"></i>
                         </a>


### PR DESCRIPTION
The reporting tab is displaying the action buttons to add "Followed users" and "Followed sessions" to users with the teacher role and non admin permissions.

![reporting](https://user-images.githubusercontent.com/48205899/78792665-b620da00-79b1-11ea-84e9-097c1ba15107.png)

For non admin users both actions would result in an error.

![error](https://user-images.githubusercontent.com/48205899/78792736-cd5fc780-79b1-11ea-8d5d-dfa3d79af76e.png)

The proposal is to hide these two buttons assigning the $is_platform_admin variable on [/main/mySpace/index.php](https://github.com/chamilo/chamilo-lms/blob/1.11.x/main/mySpace/index.php) to the template

![fix_01](https://user-images.githubusercontent.com/48205899/78793921-59262380-79b3-11ea-8419-d6d77b9d1402.png)

and checking if the template ([main/template/default/my_space/index.tpl](https://github.com/chamilo/chamilo-lms/blob/1.11.x/main/template/default/my_space/index.tpl)) has to draw the buttons for both actions.

![fix_02](https://user-images.githubusercontent.com/48205899/78794194-b7530680-79b3-11ea-975e-04e4d4815bda.png)


With this fix the buttons aren´t drawed to users with teacher role and without admin permissions

![reporting_fixed](https://user-images.githubusercontent.com/48205899/78794356-ec5f5900-79b3-11ea-9aa5-f160849d68cc.png)

