### PR TITLE
Add bbb plugin option to hide settings on course administration options

### DIFF
--- a/plugin/bbb/README.md
+++ b/plugin/bbb/README.md
@@ -16,7 +16,8 @@ ALTER TABLE plugin_bbb_meeting ADD voice_bridge int NOT NULL DEFAULT 1;
 ALTER TABLE plugin_bbb_meeting ADD group_id int unsigned NOT NULL DEFAULT 0;
 ```
 ## Migrating to Chamilo LMS 1.11.x
-For Chamilo 1.11.x, Videoconference plugin has two new settings options: 
+For Chamilo 1.11.x, Videoconference plugin has one new setting option: 
+*Disable Course Settings*. 
 
 ##### Database changes
 You need execute this SQL query in your database after making the Chamilo migration process from 1.10.x.

--- a/plugin/bbb/lang/english.php
+++ b/plugin/bbb/lang/english.php
@@ -77,3 +77,4 @@ $strings['SetByTeacher'] = 'Set by teacher';
 $strings['SetByDefault'] = 'Set to default interface';
 $strings['allow_regenerate_recording'] = 'Allow regenerate recording';
 $strings['bbb_force_record_generation'] = 'Force record generation at the end of the meeting';
+$strings['disable_course_settings'] = 'Disable course settings';


### PR DESCRIPTION
Hide BBB plugin course settings on main/course_info/infocours.php

The purpose of this pull request is to provide a new functionality so the platform administrators can hide the plugin options from the course configuration.

![imagen](https://user-images.githubusercontent.com/48205899/80396140-811eed80-88b4-11ea-9c22-2a60193c1d22.png)

Hiding the BBB course settings also replace the value of the settings for each course with the one selected by the platform administrator.

### **Changes on /plugin/bbb/lib/bbb_plugin.class.php:**

**Added  'disable_course_settings' as a plugin option**

Boolean to show/hide plugin configuration options in infocours.php:

![imagen](https://user-images.githubusercontent.com/48205899/80396245-a7dd2400-88b4-11ea-863d-fc01d7a13c0f.png)

https://github.com/juan-cortizas-ponte/chamilo-lms/blob/5d368bc2bc8b64d98038e8cc3c433edde9c9cc30/plugin/bbb/lib/bbb_plugin.class.php#L90


**Updated validateCourseSetting($variable) method**

Check the value of disable_course_settings to show or hide the plugin course settings on main/course_info/infocours.php

```
    /**
     * @param string $variable
     *
     * @return bool
     */
    public function validateCourseSetting($variable)
    {
        if ($this->get('disable_course_settings') === 'true') {
            return false;
        }

        $result = true;
        switch ($variable) {
            case 'bbb_enable_conference_in_groups':
                $result = $this->get('enable_conference_in_course_groups') === 'true';
                break;
            case 'bbb_force_record_generation':
                $result = $this->get('allow_regenerate_recording') === 'true';
                break;
            case 'big_blue_button_record_and_store':
        }

        return $result;
    }
```

https://github.com/juan-cortizas-ponte/chamilo-lms/blob/5d368bc2bc8b64d98038e8cc3c433edde9c9cc30/plugin/bbb/lib/bbb_plugin.class.php#L114#L116


**Added performActionsAfterConfigure() method**

If disable_course_settings is true, replace the value of the settings for each course with the selected ones by the platform administrator

```
    /**
     *
     * @return \Plugin
     */
    public function performActionsAfterConfigure()
    {
        $result = $this->get('disable_course_settings') === 'true';
        if ($result) {
            $valueConference = $this->get('bbb_enable_conference_in_groups') === 'true' ? 1 : 0;
            self::update_course_field_in_all_courses('bbb_enable_conference_in_groups', $valueConference);

            $valueForceRecordGeneration = $this->get('bbb_force_record_generation') === 'true' ? 1 : 0;
            self::update_course_field_in_all_courses('bbb_force_record_generation', $valueForceRecordGeneration);

            $valueForceRecordStore = $this->get('big_blue_button_record_and_store') === 'true' ? 1 : 0;
            self::update_course_field_in_all_courses('big_blue_button_record_and_store', $valueForceRecordStore);
        }

        return $this;
    }
```

https://github.com/juan-cortizas-ponte/chamilo-lms/blob/5d368bc2bc8b64d98038e8cc3c433edde9c9cc30/plugin/bbb/lib/bbb_plugin.class.php#L146#L165


**Added update_course_field_in_all_courses method($variable, $value) method**

Update plugin course setting value for all courses

```

    /**
     * Set the course setting in all courses
     *
     * @param bool $variable Course setting to update
     * @param bool $value New values of the course setting
     */
    public function update_course_field_in_all_courses($variable, $value)
    {
        // Update existing courses to add the new course setting value
        $table = Database::get_main_table(TABLE_MAIN_COURSE);
        $sql = "SELECT id FROM $table ORDER BY id";
        $res = Database::query($sql);
        while ($row = Database::fetch_assoc($res)) {
            $courseSettingTable = Database::get_course_table(TABLE_COURSE_SETTING);

            Database::update(
                $courseSettingTable,
                ['value' => $value],
                ['variable = ? AND c_id = ?' => [$variable, $row['id']]]
            );
        }
    }
```


https://github.com/juan-cortizas-ponte/chamilo-lms/blob/5d368bc2bc8b64d98038e8cc3c433edde9c9cc30/plugin/bbb/lib/bbb_plugin.class.php#L359#L380


**Added getCourseSettings() method**

If an user click on "save settings" on main/course_info/infocours.php and the disable_course_settings option is true, prevents the update of the plugin course settings with a null value

```
    /**
     *
     * @return array
     */
    public function getCourseSettings()
    {
        $settings = [];
        if ($this->get('disable_course_settings') !== 'true') {
            $settings = parent::getCourseSettings();
        }

        return $settings;
    }
```

https://github.com/juan-cortizas-ponte/chamilo-lms/blob/5d368bc2bc8b64d98038e8cc3c433edde9c9cc30/plugin/bbb/lib/bbb_plugin.class.php#L132#L144


### **Changes on plugin/bbb/lang/english.php:**

Added the string value for the 'disable_course_settings' setting


### **Changes on plugin/bbb/README.md:**

Info about the inclusion of 'disable_course_settings' setting for Chamilo 1.11.x

