### PR TITLE
fix incorrect date values when copying a session

### DIFF
--- a/main/inc/lib/sessionmanager.lib.php
+++ b/main/inc/lib/sessionmanager.lib.php
@@ -4507,21 +4507,34 @@ class SessionManager
         $inOneMonth = api_get_local_time($inOneMonth);
         if (api_strtotime($s['access_start_date']) < $now) {
             $s['access_start_date'] = api_get_local_time($now);
+        } else {
+            $s['access_start_date'] = api_get_local_time($s['access_start_date']);
         }
         if (api_strtotime($s['display_start_date']) < $now) {
             $s['display_start_date'] = api_get_local_time($now);
+        } else {
+            $s['display_start_date'] = api_get_local_time($s['display_start_date']);
         }
         if (api_strtotime($s['coach_access_start_date']) < $now) {
             $s['coach_access_start_date'] = api_get_local_time($now);
+        } else {
+            $s['coach_access_start_date'] = api_get_local_time($s['coach_access_start_date']);
         }
         if (api_strtotime($s['access_end_date']) < $now) {
             $s['access_end_date'] = $inOneMonth;
+        } else {
+            $s['access_end_date'] = api_get_local_time($s['access_end_date']);
         }
         if (api_strtotime($s['display_end_date']) < $now) {
             $s['display_end_date'] = $inOneMonth;
+        } else {
+            $s['display_end_date'] = api_get_local_time($s['display_end_date']);
         }
         if (api_strtotime($s['coach_access_end_date']) < $now) {
             $s['coach_access_end_date'] = $inOneMonth;
+        }
+        else {
+            $s['coach_access_end_date'] = api_get_local_time($s['coach_access_end_date']);
         }
 
         $extraFieldValue = new ExtraFieldValue('session');

--- a/main/inc/lib/sessionmanager.lib.php
+++ b/main/inc/lib/sessionmanager.lib.php
@@ -4532,8 +4532,7 @@ class SessionManager
         }
         if (api_strtotime($s['coach_access_end_date']) < $now) {
             $s['coach_access_end_date'] = $inOneMonth;
-        }
-        else {
+        } else {
             $s['coach_access_end_date'] = api_get_local_time($s['coach_access_end_date']);
         }
 


### PR DESCRIPTION
When the copy option at the training session list is used, date values are copied incorrectly.

![imagen](https://user-images.githubusercontent.com/48205899/82246179-7f40cb00-9944-11ea-8e5b-1d15210baf33.png)

Date values on database are UTC timezone; when displayed these values are transformed to local time zone, such as: https://github.com/chamilo/chamilo-lms/blob/1.11.x/main/session/session_edit.php#L27#L51

The bug occurs when copying a session, values of the original session are passed as parameters to the "create_session" method of "main/inc/lib/sessionmanager.lib.php";

https://github.com/chamilo/chamilo-lms/blob/1.11.x/main/inc/lib/sessionmanager.lib.php#L4544#L4561

There values, already UTC, are transformed to UTC when saving to the database: 

https://github.com/chamilo/chamilo-lms/blob/1.11.x/main/inc/lib/sessionmanager.lib.php#L261#L282

To fix this we have to transform at main/inc/lib/sessionmanager.lib.php the date values to the local timezone:

![imagen](https://user-images.githubusercontent.com/48205899/82248319-35f27a80-9948-11ea-92af-13e82d4c7957.png)


https://github.com/juan-cortizas-ponte/chamilo-lms/blob/7799d1201837f0ffe234dbb438e319833e48f4ea/main/inc/lib/sessionmanager.lib.php#L4508#L4538