### PR TITLE
If the BigBlueButton URL has a protocol, use it when making API calls

### DIFF
--- a/plugin/bbb/lib/bbb.lib.php
+++ b/plugin/bbb/lib/bbb.lib.php
@@ -125,13 +125,15 @@ class bbb
                 $urlWithProtocol = $bbb_host;
             } else {
                 // We assume it's an http, if user wants to use https, the host *must* include the protocol.
-                $urlWithProtocol = 'http://'.$bbb_host;
+                $this->protocol = 'http://';
+                $urlWithProtocol = $this->protocol.$bbb_host;
             }
 
             // Setting BBB api
             define('CONFIG_SECURITY_SALT', $this->salt);
             define('CONFIG_SERVER_URL_WITH_PROTOCOL', $urlWithProtocol);
             define('CONFIG_SERVER_BASE_URL', $this->url);
+            define('CONFIG_SERVER_PROTOCOL', $this->protocol);
 
             $this->api = new BigBlueButtonBN();
             $this->pluginEnabled = true;

--- a/plugin/bbb/lib/bbb_api.php
+++ b/plugin/bbb/lib/bbb_api.php
@@ -41,6 +41,7 @@ class BigBlueButtonBN
 {
 	private $_securitySalt;
 	private $_bbbServerBaseUrl;
+	private $_bbbServerProtocol;
 
 	public function __construct()
     {
@@ -51,6 +52,7 @@ class BigBlueButtonBN
 		// simply flow in here via the constants:
 		$this->_securitySalt 		= CONFIG_SECURITY_SALT;
 		$this->_bbbServerBaseUrl 	= CONFIG_SERVER_BASE_URL;
+		$this->_bbbServerProtocol 	= CONFIG_SERVER_PROTOCOL;
 	}
 
 	private function _processXmlResponse($url)
@@ -62,7 +64,7 @@ class BigBlueButtonBN
 			$ch = curl_init() or die ( curl_error($ch) );
 			$timeout = 10;
 			curl_setopt( $ch, CURLOPT_SSL_VERIFYPEER, false);
-			curl_setopt( $ch, CURLOPT_URL, $url );
+			curl_setopt( $ch, CURLOPT_URL, $this->_bbbServerProtocol.$url );
 			curl_setopt( $ch, CURLOPT_RETURNTRANSFER, 1 );
 			curl_setopt( $ch, CURLOPT_CONNECTTIMEOUT, $timeout);
             // Following redirect required to use Scalelite, BBB's Load Balancer


### PR DESCRIPTION
When configuring a BigBlueButton server with HTTPS, it wasn't using HTTPS in the API calls. Even if the server returned a redirect on HTTP calls they would not work, since curl is not configured to follow redirects. So all API calls would fail.

This was initially done and tested over the tag v1.11.10, then ported to branch 1.11.x.

I've seen that you recently added the `CURLOPT_FOLLOWLOCATION` flag (https://github.com/chamilo/chamilo-lms/commit/79b4840172b3f99bc41b603eac30167f5cd45c7c), so I would probably not run into this issue in a new version. However, I still think that using the protocol the user specified and not having to follow redirects is a better solution.


