### PR TITLE
add user column to report view

### DIFF
--- a/main/inc/lib/tracking.lib.php
+++ b/main/inc/lib/tracking.lib.php
@@ -7615,7 +7615,8 @@ class TrackingCourseLog
                     user.official_code  as col0,
                     user.lastname       as col1,
                     user.firstname      as col2,
-                    user.username       as col3';
+                    user.username       as col3,
+                    user.email          as col4';
         if ($getCount) {
             $select = ' SELECT COUNT(distinct(user.id)) as count ';
         }
@@ -7869,6 +7870,7 @@ class TrackingCourseLog
                 }
             }
 
+            $user_row['email'] = $user['col4'];
             $user_row['link'] = $user['link'];
 
             if ($export_csv) {

--- a/main/inc/lib/tracking.lib.php
+++ b/main/inc/lib/tracking.lib.php
@@ -7870,7 +7870,10 @@ class TrackingCourseLog
                 }
             }
 
-            $user_row['email'] = $user['col4'];
+            if (api_get_setting('show_email_addresses') === 'true') {
+                $user_row['email'] = $user['col4'];
+            }
+
             $user_row['link'] = $user['link'];
 
             if ($export_csv) {

--- a/main/tracking/courseLog.php
+++ b/main/tracking/courseLog.php
@@ -694,22 +694,22 @@ if ($nbStudents > 0) {
     $headers['first_login'] = get_lang('FirstLoginInCourse');
     $table->set_header(14, get_lang('LatestLoginInCourse'), false);
     $headers['latest_login'] = get_lang('LatestLoginInCourse');
-    $table->set_header(15, get_lang('Email'), false);
-    $headers['email'] = get_lang('Email');
+    $counter = 15;
+    if (api_get_setting('show_email_addresses') === 'true') {
+        $table->set_header($counter, get_lang('Email'), false);
+        $headers['email'] = get_lang('Email');
+        $counter++;
+    }
     if (isset($_GET['additional_profile_field'])) {
-        $counter = 16;
         foreach ($_GET['additional_profile_field'] as $fieldId) {
             $table->set_header($counter, $extra_info[$fieldId]['display_text'], false);
             $headers[$extra_info[$fieldId]['variable']] = $extra_info[$fieldId]['display_text'];
             $counter++;
             $parameters['additional_profile_field'] = $fieldId;
         }
-        $table->set_header($counter, get_lang('Details'), false);
-        $headers['details'] = get_lang('Details');
-    } else {
-        $table->set_header(16, get_lang('Details'), false);
-        $headers['Details'] = get_lang('Details');
     }
+    $table->set_header($counter, get_lang('Details'), false);
+    $headers['Details'] = get_lang('Details');
 
     if (!empty($fields)) {
         foreach ($fields as $key => $value) {

--- a/main/tracking/courseLog.php
+++ b/main/tracking/courseLog.php
@@ -694,8 +694,10 @@ if ($nbStudents > 0) {
     $headers['first_login'] = get_lang('FirstLoginInCourse');
     $table->set_header(14, get_lang('LatestLoginInCourse'), false);
     $headers['latest_login'] = get_lang('LatestLoginInCourse');
+    $table->set_header(15, get_lang('Email'), false);
+    $headers['email'] = get_lang('Email');
     if (isset($_GET['additional_profile_field'])) {
-        $counter = 15;
+        $counter = 16;
         foreach ($_GET['additional_profile_field'] as $fieldId) {
             $table->set_header($counter, $extra_info[$fieldId]['display_text'], false);
             $headers[$extra_info[$fieldId]['variable']] = $extra_info[$fieldId]['display_text'];
@@ -705,7 +707,7 @@ if ($nbStudents > 0) {
         $table->set_header($counter, get_lang('Details'), false);
         $headers['details'] = get_lang('Details');
     } else {
-        $table->set_header(15, get_lang('Details'), false);
+        $table->set_header(16, get_lang('Details'), false);
         $headers['Details'] = get_lang('Details');
     }
 


### PR DESCRIPTION
This update adds an user email columns to the reports view (main/tracking/courseLog.php)

**Now:**

![now](https://user-images.githubusercontent.com/48205899/84041457-27760c80-a9a4-11ea-8685-c45681ce41ff.PNG)

**Expected result:**

![expected](https://user-images.githubusercontent.com/48205899/84041439-22b15880-a9a4-11ea-8e05-f322fb55777d.PNG)

**Changes:**

1. [/main/tracking/courseLog.php](https://github.com/juan-cortizas-ponte/chamilo-lms/blob/3b9b8d00fee5b5157b3919e43c74927862cda7c9/main/tracking/courseLog.php#L696#L712)

Added "email" header to the table and change the column counter for the next column to 16

![courselog_01](https://user-images.githubusercontent.com/48205899/84042065-e6cac300-a9a4-11ea-949f-39f3bca3d403.PNG)

2. [/main/inc/lib/tracking.lib.php](https://github.com/juan-cortizas-ponte/chamilo-lms/blob/3b9b8d00fee5b5157b3919e43c74927862cda7c9/main/inc/lib/tracking.lib.php#L7618#L7619)

Modified user data query on get_user_data method to retrieve the email field

![tracking lib_01](https://user-images.githubusercontent.com/48205899/84042489-6bb5dc80-a9a5-11ea-9208-4ebabe8c4b8f.PNG)

3. [/main/inc/lib/tracking.lib.php](https://github.com/juan-cortizas-ponte/chamilo-lms/blob/3b9b8d00fee5b5157b3919e43c74927862cda7c9/main/inc/lib/tracking.lib.php#L7873)

Add the previous email field to the result array

![tracking lib_02](https://user-images.githubusercontent.com/48205899/84042907-f565aa00-a9a5-11ea-949c-5290f0ab11fe.PNG)




