### PR TITLE
Modificaciones en el plugin de customcertificates

### DIFF
--- a/main/gradebook/gradebook_display_certificate.php
+++ b/main/gradebook/gradebook_display_certificate.php
@@ -128,7 +128,8 @@ switch ($action) {
     case 'export_all_certificates':
         if ($allowCustomCertificate) {
             $params = 'course_code='.api_get_course_id().'&session_id='.api_get_session_id().'&'.api_get_cidreq();
-            $url = api_get_path(WEB_PLUGIN_PATH).'customcertificate/src/print_certificate.php?export_all_in_one=1&'.$params;
+            $url = api_get_path(WEB_PLUGIN_PATH).
+                'customcertificate/src/print_certificate.php?export_all_in_one=1&'.$params;
         } else {
             if (api_is_student_boss()) {
                 $userGroup = new UserGroup();

--- a/main/gradebook/gradebook_display_certificate.php
+++ b/main/gradebook/gradebook_display_certificate.php
@@ -74,7 +74,7 @@ if ($filter === 'true') {
 
 $content = '';
 $courseCode = api_get_course_id();
-$allowExportToZip = api_get_plugin_setting('customcertificate', 'enable_plugin_customcertificate') === 'true' &&
+$allowCustomCertificate = api_get_plugin_setting('customcertificate', 'enable_plugin_customcertificate') === 'true' &&
     api_get_course_setting('customcertificate_course_enable', $courseInfo) == 1;
 
 $tags = Certificate::notificationTags();
@@ -126,23 +126,28 @@ switch ($action) {
         $content = $form->returnForm();
         break;
     case 'export_all_certificates':
-        if (api_is_student_boss()) {
-            $userGroup = new UserGroup();
-            $userList = $userGroup->getGroupUsersByUser(api_get_user_id());
+        if ($allowCustomCertificate) {
+            $params = 'course_code='.api_get_course_id().'&session_id='.api_get_session_id().'&'.api_get_cidreq();
+            $url = api_get_path(WEB_PLUGIN_PATH).'customcertificate/src/print_certificate.php?export_all_in_one=1&'.$params;
         } else {
-            $userList = [];
-            if (!empty($filterOfficialCodeGet)) {
-                $userList = UserManager::getUsersByOfficialCode($filterOfficialCodeGet);
+            if (api_is_student_boss()) {
+                $userGroup = new UserGroup();
+                $userList = $userGroup->getGroupUsersByUser(api_get_user_id());
+            } else {
+                $userList = [];
+                if (!empty($filterOfficialCodeGet)) {
+                    $userList = UserManager::getUsersByOfficialCode($filterOfficialCodeGet);
+                }
             }
-        }
 
-        Category::exportAllCertificates($categoryId, $userList);
+            Category::exportAllCertificates($categoryId, $userList);
+        }
 
         header('Location: '.$url);
         exit;
         break;
     case 'export_all_certificates_zip':
-        if ($allowExportToZip) {
+        if ($allowCustomCertificate) {
             $params = 'course_code='.api_get_course_id().'&session_id='.api_get_session_id().'&'.api_get_cidreq();
             $url = api_get_path(WEB_PLUGIN_PATH).'customcertificate/src/print_certificate.php?export_all=1&'.$params;
 
@@ -273,7 +278,7 @@ if (count($certificate_list) > 0 && $hideCertificateExport !== 'true') {
         $url.'&action=export_all_certificates'
     );
 
-    if ($allowExportToZip) {
+    if ($allowCustomCertificate) {
         $actions .= Display::url(
             Display::return_icon('file_zip.png', get_lang('ExportAllCertificatesToZIP'), [], ICON_SIZE_MEDIUM),
             $url.'&action=export_all_certificates_zip'

--- a/plugin/customcertificate/src/print_certificate.php
+++ b/plugin/customcertificate/src/print_certificate.php
@@ -131,8 +131,9 @@ foreach ($userList as $userInfo) {
     } else {
         $urlBackground = $path.$infoCertificate['background'];
         $htmlText .= ' <div 
-        class = "caraA"
-        style = "background-image:url('.$urlBackground.') no-repeat; background-image-resize:6; margin:0px; padding:0px;">';
+        class="caraA"
+        style="background-image:url('.$urlBackground.') no-repeat; 
+        background-image-resize:6; margin:0px; padding:0px;">';
     }
 
     if (!empty($infoCertificate['logo_left'])) {
@@ -169,7 +170,9 @@ foreach ($userList as $userInfo) {
         border="0">';
     $htmlText .= '<tr>';
     $htmlText .= '<td style="width:'.intval($workSpace / 3).'mm" class="logo">'.$logoLeft.'</td>';
-    $htmlText .= '<td style="width:'.intval($workSpace / 3).'mm; text-align:center;" class="logo">'.$logoCenter.'</td>';
+    $htmlText .= '<td style="width:'.intval($workSpace / 3).'mm; text-align:center;" class="logo">';
+    $htmlText .= $logoCenter;
+    $htmlText .= '</td>';
     $htmlText .= '<td style="width:'.intval($workSpace / 3).'mm; text-align:right;" class="logo">'.$logoRight.'</td>';
     $htmlText .= '</tr>';
     $htmlText .= '</table>';
@@ -511,7 +514,18 @@ if ($exportAllInOne) {
         $certificateContent .= $contentAllCertificate;
         $certificateContent .= '</body></html>';
 
-        $pdf->content_to_pdf($certificateContent, '', 'certificate'.date("Y_m_d_His"), null, 'D', false, null, false, false, false);
+        $pdf->content_to_pdf(
+            $certificateContent,
+            '',
+            'certificate'.date("Y_m_d_His"),
+            null,
+            'D',
+            false,
+            null,
+            false,
+            false,
+            false
+        );
     }
 } else {
     foreach ($htmlList as $fileName => $content) {

--- a/plugin/customcertificate/src/print_certificate.php
+++ b/plugin/customcertificate/src/print_certificate.php
@@ -16,6 +16,7 @@ api_block_anonymous_users();
 $plugin = CustomCertificatePlugin::create();
 $enable = $plugin->get('enable_plugin_customcertificate') == 'true';
 $tblProperty = Database::get_course_table(TABLE_ITEM_PROPERTY);
+$categoryId = isset($_GET['cat_id']) ? (int) $_GET['cat_id'] : 0;
 
 if (!$enable) {
     api_not_allowed(true, $plugin->get_lang('ToolDisabled'));
@@ -60,16 +61,9 @@ if (empty($_GET['export_all'])) {
     }
     $userList[] = api_get_user_info($studentId);
 } else {
-    $certificateTable = Database::get_main_table(TABLE_MAIN_GRADEBOOK_CERTIFICATE);
-    $categoryTable = Database::get_main_table(TABLE_MAIN_GRADEBOOK_CATEGORY);
-    $sql = "SELECT cer.user_id AS user_id
-            FROM $certificateTable cer
-            INNER JOIN $categoryTable cat
-            ON (cer.cat_id = cat.id)
-            WHERE cat.course_code = '$courseCode' AND cat.session_id = $sessionId";
-    $rs = Database::query($sql);
-    while ($row = Database::fetch_assoc($rs)) {
-        $userList[] = api_get_user_info($row['user_id']);
+    $certificate_list = GradebookUtils::get_list_users_certificates($categoryId);
+    foreach ($certificate_list as $index => $value) {
+        $userList[] = api_get_user_info($value['user_id']);
     }
 }
 

--- a/plugin/customcertificate/src/print_certificate.php
+++ b/plugin/customcertificate/src/print_certificate.php
@@ -53,7 +53,9 @@ if (empty($sessionId)) {
 $accessUrlId = api_get_current_access_url_id();
 
 $userList = [];
-if (empty($_GET['export_all'])) {
+$exportZip = false;
+$exportAllInOne = false;
+if (empty($_GET['export_all']) && empty($_GET['export_all_in_one'])) {
     if (!isset($_GET['student_id'])) {
         $studentId = api_get_user_id();
     } else {
@@ -61,6 +63,12 @@ if (empty($_GET['export_all'])) {
     }
     $userList[] = api_get_user_info($studentId);
 } else {
+    if (!empty($_GET['export_all'])) {
+        $exportZip = true;
+    }
+    if (!empty($_GET['export_all_in_one'])) {
+        $exportAllInOne = true;
+    }
     $certificate_list = GradebookUtils::get_list_users_certificates($categoryId);
     foreach ($certificate_list as $index => $value) {
         $userList[] = api_get_user_info($value['user_id']);
@@ -74,7 +82,7 @@ if ($sessionId > 0) {
 
 $table = Database::get_main_table(CustomCertificatePlugin::TABLE_CUSTOMCERTIFICATE);
 $useDefault = false;
-$path = api_get_path(SYS_UPLOAD_PATH).'certificates/';
+$path = api_get_path(WEB_UPLOAD_PATH).'certificates/';
 
 // Get info certificate
 $infoCertificate = CustomCertificatePlugin::getInfoCertificate($courseId, $sessionId, $accessUrlId);
@@ -103,16 +111,19 @@ $htmlList = [];
 $currentLocalTime = api_get_local_time();
 
 foreach ($userList as $userInfo) {
-    $htmlText = '<html>';
-    $htmlText .= '
-    <link rel="stylesheet"
-        type="text/css"
-        href="'.api_get_path(WEB_PLUGIN_PATH).'customcertificate/resources/css/certificate.css">';
-    $htmlText .= '
-    <link rel="stylesheet"
-        type="text/css"
-        href="'.api_get_path(WEB_CSS_PATH).'document.css">';
-    $htmlText .= '<body>';
+    $htmlText = '';
+    if (!$exportAllInOne) {
+        $htmlText = '<html>';
+        $htmlText .= '
+        <link rel="stylesheet"
+            type="text/css"
+            href="'.api_get_path(WEB_PLUGIN_PATH).'customcertificate/resources/css/certificate.css">';
+        $htmlText .= '
+        <link rel="stylesheet"
+            type="text/css"
+            href="'.api_get_path(WEB_CSS_PATH).'document.css">';
+        $htmlText .= '<body>';
+    }
     $studentId = $userInfo['user_id'];
 
     if (empty($infoCertificate['background'])) {
@@ -455,7 +466,10 @@ foreach ($userList as $userInfo) {
         }
         $htmlText .= '</div>';
     }
-    $htmlText .= '</body></html>';
+
+    if (!$exportAllInOne) {
+        $htmlText .= '</body></html>';
+    }
     $fileName = 'certificate_'.$courseInfo['code'].'_'.$userInfo['complete_name'].'_'.$currentLocalTime;
     $htmlList[$fileName] = $htmlText;
 }
@@ -466,10 +480,8 @@ if (!is_dir($archivePath)) {
     mkdir($archivePath, api_get_permissions_for_new_directories());
 }
 
-foreach ($htmlList as $fileName => $content) {
-    $fileName = api_replace_dangerous_char($fileName);
+if ($exportAllInOne) {
     $params = [
-        'filename' => $fileName,
         'pdf_title' => 'Certificate',
         'pdf_description' => '',
         'format' => 'A4-L',
@@ -479,25 +491,61 @@ foreach ($htmlList as $fileName => $content) {
         'bottom' => 0,
     ];
     $pdf = new PDF($params['format'], $params['orientation'], $params);
-    if (count($htmlList) == 1) {
-        $pdf->content_to_pdf($content, '', $fileName, null, 'D', false, null, false, false, false);
-        exit;
-    } else {
-        $filePath = $archivePath.$fileName.'.pdf';
-        $pdf->content_to_pdf($content, '', $fileName, null, 'F', true, $filePath, false, false, false);
-        $fileList[] = $filePath;
-    }
-}
 
-if (!empty($fileList)) {
-    $zipFile = $archivePath.'certificates_'.api_get_unique_id().'.zip';
-    $zipFolder = new PclZip($zipFile);
-    foreach ($fileList as $file) {
-        $zipFolder->add($file, PCLZIP_OPT_REMOVE_ALL_PATH);
+    $contentAllCertificate = '';
+    foreach ($htmlList as $fileName => $content) {
+        $contentAllCertificate .= $content;
     }
-    $name = 'certificates_'.$courseInfo['code'].'_'.$currentLocalTime.'.zip';
-    DocumentManager::file_send_for_download($zipFile, true, $name);
-    exit;
+
+    if (!empty($contentAllCertificate)) {
+        $certificateContent = '<html>';
+        $certificateContent .= '
+        <link rel="stylesheet"
+            type="text/css"
+            href="'.api_get_path(WEB_PLUGIN_PATH).'customcertificate/resources/css/certificate.css">';
+        $certificateContent .= '
+        <link rel="stylesheet"
+            type="text/css"
+            href="'.api_get_path(WEB_CSS_PATH).'document.css">';
+        $certificateContent .= '<body>';
+        $certificateContent .= $contentAllCertificate;
+        $certificateContent .= '</body></html>';
+
+        $pdf->content_to_pdf($certificateContent, '', 'certificate'.date("Y_m_d_His"), null, 'D', false, null, false, false, false);
+    }
+} else {
+    foreach ($htmlList as $fileName => $content) {
+        $fileName = api_replace_dangerous_char($fileName);
+        $params = [
+            'filename' => $fileName,
+            'pdf_title' => 'Certificate',
+            'pdf_description' => '',
+            'format' => 'A4-L',
+            'orientation' => 'L',
+            'left' => 15,
+            'top' => 15,
+            'bottom' => 0,
+        ];
+        $pdf = new PDF($params['format'], $params['orientation'], $params);
+        if ($exportZip) {
+            $filePath = $archivePath.$fileName.'.pdf';
+            $pdf->content_to_pdf($content, '', $fileName, null, 'F', true, $filePath, false, false, false);
+            $fileList[] = $filePath;
+        } else {
+            $pdf->content_to_pdf($content, '', $fileName, null, 'D', false, null, false, false, false);
+        }
+    }
+
+    if (!empty($fileList)) {
+        $zipFile = $archivePath.'certificates_'.api_get_unique_id().'.zip';
+        $zipFolder = new PclZip($zipFile);
+        foreach ($fileList as $file) {
+            $zipFolder->add($file, PCLZIP_OPT_REMOVE_ALL_PATH);
+        }
+        $name = 'certificates_'.$courseInfo['code'].'_'.$currentLocalTime.'.zip';
+        DocumentManager::file_send_for_download($zipFile, true, $name);
+        exit;
+    }
 }
 
 function getIndexFiltered($index)


### PR DESCRIPTION
- Uso de la api de chamilo para obtener el listado de usuarios para imprimir el diploma y su exportación
- El botón de exportar todos los certificados a pdf ahora comprueba si está activo el plugin y usa la personalización adecuada
https://task.beeznest.com/issues/17382