### PR TITLE
added try/catch on chat done callback

### DIFF
--- a/main/template/default/chat/chat.tpl
+++ b/main/template/default/chat/chat.tpl
@@ -81,14 +81,18 @@ $(function () {
                     friend: ChChat.currentFriend
                 })
                 .done(function (response) {
-                    if (response.data.history) {
-                        ChChat._historySize = response.data.oldFileSize;
-                        ChChat.setHistory(response.data.history);
-                    }
+                    try {
+                        if (response.data.history) {
+                            ChChat._historySize = response.data.oldFileSize;
+                            ChChat.setHistory(response.data.history);
+                        }
 
-                    if (response.data.userList) {
-                        ChChat.usersOnline = response.data.usersOnline;
-                        ChChat.setConnectedUsers(response.data.userList);
+                        if (response.data.userList) {
+                            ChChat.usersOnline = response.data.usersOnline;
+                            ChChat.setConnectedUsers(response.data.userList);
+                        }
+                    } catch (error) {
+                        console.error(error);
                     }
                 });
         },


### PR DESCRIPTION
In case the expected json is not received at the done callback method (for example, a temporal database error) the conversations and users status update is blocked and the user has to 
re-enter the chat to get the update list of conversations an users status.

![console_error](https://user-images.githubusercontent.com/48205899/84504332-0cfda500-acbc-11ea-860f-14510b9260ec.png)

![request_error](https://user-images.githubusercontent.com/48205899/84503942-66190900-acbb-11ea-8a8d-6fb95b91df3f.PNG)

![code_01](https://user-images.githubusercontent.com/48205899/84501965-c1e19300-acb7-11ea-84c4-de5ddc79c17a.PNG)

![code_02](https://user-images.githubusercontent.com/48205899/84501976-c4dc8380-acb7-11ea-9e8d-bc3c4cb676ec.PNG)

To avoid it, a try/catch is added to the "done" callback method to the /main/template/default/learnpath/list.tpl template

![fix](https://user-images.githubusercontent.com/48205899/84502494-b6429c00-acb8-11ea-9f18-3fbbe1a425d2.PNG)


