### PR TITLE
Course home: Add icon to switch visibility for all tools in course #3301

### DIFF
--- a/main/course_home/activity.php
+++ b/main/course_home/activity.php
@@ -52,6 +52,12 @@ if ($session_id === 0 && api_is_course_admin() && api_is_allowed_to_edit(null, t
 		<div class="alert alert-success" id="id_confirmation_message" style="display:none"></div>
 	</div>';
     $content .= $pluginExtra;
+    //show/hide all tools
+    $content .= '<div class="btn-group pull-right">'.
+        '<a class="hidden invisible-all show-hide-all-tools" href="javascript:void(0);"><img  src="'.api_get_path(WEB_IMG_PATH).'invisible.png" alt="'.get_lang('Deactivate', '').'" title="'.get_lang('Deactivate', '').'"></a>'.
+        '<a class="hidden visible-all  show-hide-all-tools" href="javascript:void(0);"><img  src="'.api_get_path(WEB_IMG_PATH).'visible.png" alt="'.get_lang('Activate', '').'" title="'.get_lang('Activate', '').'"></a>'.
+        '</div>';
+
 } elseif (api_is_coach()) {
     $content .= $pluginExtra;
     if (api_get_setting('show_session_data') === 'true' && $session_id > 0) {

--- a/main/course_home/activity.php
+++ b/main/course_home/activity.php
@@ -52,11 +52,6 @@ if ($session_id === 0 && api_is_course_admin() && api_is_allowed_to_edit(null, t
 		<div class="alert alert-success" id="id_confirmation_message" style="display:none"></div>
 	</div>';
     $content .= $pluginExtra;
-    //show/hide all tools
-    $content .= '<div class="btn-group pull-right">'.
-        '<a class="hidden invisible-all show-hide-all-tools" href="javascript:void(0);"><img  src="'.api_get_path(WEB_IMG_PATH).'invisible.png" alt="'.get_lang('Deactivate', '').'" title="'.get_lang('Deactivate', '').'"></a>'.
-        '<a class="hidden visible-all  show-hide-all-tools" href="javascript:void(0);"><img  src="'.api_get_path(WEB_IMG_PATH).'visible.png" alt="'.get_lang('Activate', '').'" title="'.get_lang('Activate', '').'"></a>'.
-        '</div>';
 
 } elseif (api_is_coach()) {
     $content .= $pluginExtra;

--- a/main/course_home/course_home.php
+++ b/main/course_home/course_home.php
@@ -36,8 +36,89 @@ $js = '<script>'.api_get_language_translate_html().'</script>';
 $htmlHeadXtra[] = $js;
 
 $htmlHeadXtra[] = '<script>
-/* option show/hide thematic-block */
+    /* show eye for all show/hide*/
+    function buttomForAllShowHide()
+    {
+        tools_invisibles = [];
+        tools_visibles = [];
+        $.each($(".make_visible_and_invisible").parent(), function (index, item) {
+            var element = $(item).find("a");
+            image = $(element[0]).find("img")[0];
+            image_id = $(image).attr("id").replace("linktool_","");
+            if (!$(element[1]).hasClass("text-muted")) {
+                tools_invisibles.push(image_id)
+            }else{
+                tools_visibles.push(image_id)
+            }
+        });
+        if (tools_visibles.length == 0) {
+            $(".visible-all").addClass("hidden");
+            $(".invisible-all").removeClass("hidden");
+        } else {
+            $(".visible-all").removeClass("hidden");
+            $(".invisible-all").addClass("hidden");
+        }
+    };
+    /* option show/hide thematic-block */
 $(function() {
+	buttomForAllShowHide();
+	/* option show/hide all*/
+    $(".show-hide-all-tools").on("click",function(){
+        $(".show-hide-all-tools").addClass("disabled");
+        tools_invisibles = [];
+        tools_visibles = [];
+        $.each($(".make_visible_and_invisible").parent(), function (index, item) {
+            var element = $(item).find("a");
+            image = $(element[0]).find("img")[0];
+            image_id = $(image).attr("id").replace("linktool_","");
+            if (!$(element[1]).hasClass("text-muted")) {
+                tools_invisibles.push(image_id)
+            }else{
+                tools_visibles.push(image_id)
+            }
+        });
+        messaje_invisible = "'.get_lang('ToolIsNowHidden', '').'";
+        ids = tools_invisibles;
+        if (tools_invisibles.length == 0) {
+            ids = tools_visibles;
+             messaje_invisible = "'.get_lang('ToolIsNowVisible', '').'";
+
+        }
+
+        $.ajax({
+            contentType: "application/x-www-form-urlencoded",
+            beforeSend: function (myObject) {
+                $(".normal-message").show();
+                $("#id_confirmation_message").hide();
+            },
+            type: "GET",
+            url: "'.api_get_path(WEB_AJAX_PATH).'course_home.ajax.php?'.api_get_cidreq().'&a=set_visibility_for_all",
+            data: "tools_ids=" + JSON.stringify(ids) + "&sent_http_request=1",
+            success: function (data) {
+            data = JSON.parse(data);
+            $.each(data,function(index,item){
+                 new_current_view       = "'.api_get_path(WEB_IMG_PATH).'" + item.view;
+                //eyes
+                $("#linktool_"+item.id).attr("src", new_current_view);
+                //tool
+                $("#toolimage_" + item.id).attr("src", item.image);
+                //clase
+                $("#tooldesc_" + item.id).attr("class", item.tclass);
+                $("#istooldesc_" + item.id).attr("class", item.tclass);
+            });
+            $(".show-hide-all-tools").removeClass("disabled");
+            $(".normal-message").hide();
+            $("#id_confirmation_message").html(messaje_invisible);
+            $("#id_confirmation_message").show();
+            buttomForAllShowHide();
+            },
+            error:  function( jqXHR, textStatus, errorThrown ) {
+            $(".show-hide-all-tools").removeClass("disabled");
+            $(".normal-message").hide();
+            buttomForAllShowHide();
+            }
+        });
+    });
     $("#thematic-show").click(function(){
         $(".btn-hide-thematic").hide();
         $(".btn-show-thematic").show(); //show using class

--- a/main/course_home/course_home.php
+++ b/main/course_home/course_home.php
@@ -43,13 +43,14 @@ $htmlHeadXtra[] = '<script>
         tools_visibles = [];
         $.each($(".make_visible_and_invisible").parent(), function (index, item) {
             var element = $(item).find("a");
-            image = $(element[0]).find("img")[0];
+            image = $(element[0]).find("em")[0];
             image_id = $(image).attr("id").replace("linktool_","");
-            if (!$(element[1]).hasClass("text-muted")) {
+            if (!$(image).hasClass("fa-eye-slash")) {
                 tools_invisibles.push(image_id)
-            }else{
+            } else {
                 tools_visibles.push(image_id)
             }
+
         });
         if (tools_visibles.length == 0) {
             $(".visible-all").addClass("hidden");
@@ -69,11 +70,11 @@ $(function() {
         tools_visibles = [];
         $.each($(".make_visible_and_invisible").parent(), function (index, item) {
             var element = $(item).find("a");
-            image = $(element[0]).find("img")[0];
+           image = $(element[0]).find("em")[0];
             image_id = $(image).attr("id").replace("linktool_","");
-            if (!$(element[1]).hasClass("text-muted")) {
+            if (!$(image).hasClass("fa-eye-slash")) {
                 tools_invisibles.push(image_id)
-            }else{
+            } else {
                 tools_visibles.push(image_id)
             }
         });
@@ -99,7 +100,8 @@ $(function() {
             $.each(data,function(index,item){
                  new_current_view       = "'.api_get_path(WEB_IMG_PATH).'" + item.view;
                 //eyes
-                $("#linktool_"+item.id).attr("src", new_current_view);
+                //$("#linktool_"+item.id).attr("src", new_current_view);
+                $("#linktool_"+item.id).attr("class", item.fclass);
                 //tool
                 $("#toolimage_" + item.id).attr("src", item.image);
                 //clase
@@ -132,12 +134,12 @@ $(function() {
     });
 
 	$(".make_visible_and_invisible").attr("href", "javascript:void(0);");
-	$(".make_visible_and_invisible > img").click(function () {
+	$(".make_visible_and_invisible > em").click(function () {
 		make_visible = "visible.gif";
 		make_invisible = "invisible.gif";
-		path_name = $(this).attr("src");
-		list_path_name = path_name.split("/");
-		image_link = list_path_name[list_path_name.length - 1];
+		//path_name = $(this).attr("src");
+		//list_path_name = path_name.split("/");
+		//image_link = list_path_name[list_path_name.length - 1];
 		tool_id = $(this).attr("id");
 		tool_info = tool_id.split("_");
 		my_tool_id = tool_info[1];
@@ -157,7 +159,8 @@ $(function() {
 				new_current_tool_image = info.image;
 				new_current_view       = "'.api_get_path(WEB_IMG_PATH).'" + info.view;
 				//eyes
-				$("#" + tool_id).attr("src", new_current_view);
+				//$("#" + tool_id).attr("src", new_current_view);
+				 $("#linktool_"+my_tool_id).attr("class", info.fclass);
 				//tool
 				$("#toolimage_" + my_tool_id).attr("src", new_current_tool_image);
 				//clase

--- a/main/course_home/course_home.php
+++ b/main/course_home/course_home.php
@@ -64,13 +64,13 @@ $htmlHeadXtra[] = '<script>
 $(function() {
 	buttomForAllShowHide();
 	/* option show/hide all*/
-    $(".show-hide-all-tools").on("click",function(){
+    $(".show-hide-all-tools").on("click" , function() {
         $(".show-hide-all-tools").addClass("disabled");
         tools_invisibles = [];
         tools_visibles = [];
         $.each($(".make_visible_and_invisible").parent(), function (index, item) {
             var element = $(item).find("a");
-           image = $(element[0]).find("em")[0];
+            image = $(element[0]).find("em")[0];
             image_id = $(image).attr("id").replace("linktool_","");
             if (!$(image).hasClass("fa-eye-slash")) {
                 tools_invisibles.push(image_id)
@@ -82,7 +82,7 @@ $(function() {
         ids = tools_invisibles;
         if (tools_invisibles.length == 0) {
             ids = tools_visibles;
-             messaje_invisible = "'.get_lang('ToolIsNowVisible', '').'";
+            messaje_invisible = "'.get_lang('ToolIsNowVisible', '').'";
 
         }
 
@@ -96,28 +96,28 @@ $(function() {
             url: "'.api_get_path(WEB_AJAX_PATH).'course_home.ajax.php?'.api_get_cidreq().'&a=set_visibility_for_all",
             data: "tools_ids=" + JSON.stringify(ids) + "&sent_http_request=1",
             success: function (data) {
-            data = JSON.parse(data);
-            $.each(data,function(index,item){
-                 new_current_view       = "'.api_get_path(WEB_IMG_PATH).'" + item.view;
-                //eyes
-                //$("#linktool_"+item.id).attr("src", new_current_view);
-                $("#linktool_"+item.id).attr("class", item.fclass);
-                //tool
-                $("#toolimage_" + item.id).attr("src", item.image);
-                //clase
-                $("#tooldesc_" + item.id).attr("class", item.tclass);
-                $("#istooldesc_" + item.id).attr("class", item.tclass);
-            });
-            $(".show-hide-all-tools").removeClass("disabled");
-            $(".normal-message").hide();
-            $("#id_confirmation_message").html(messaje_invisible);
-            $("#id_confirmation_message").show();
-            buttomForAllShowHide();
+                data = JSON.parse(data);
+                $.each(data,function(index,item){
+                     new_current_view       = "'.api_get_path(WEB_IMG_PATH).'" + item.view;
+                    //eyes
+                    //$("#linktool_"+item.id).attr("src", new_current_view);
+                    $("#linktool_"+item.id).attr("class", item.fclass);
+                    //tool
+                    $("#toolimage_" + item.id).attr("src", item.image);
+                    //clase
+                    $("#tooldesc_" + item.id).attr("class", item.tclass);
+                    $("#istooldesc_" + item.id).attr("class", item.tclass);
+                });
+                $(".show-hide-all-tools").removeClass("disabled");
+                $(".normal-message").hide();
+                $("#id_confirmation_message").html(messaje_invisible);
+                $("#id_confirmation_message").show();
+                buttomForAllShowHide();
             },
-            error:  function( jqXHR, textStatus, errorThrown ) {
-            $(".show-hide-all-tools").removeClass("disabled");
-            $(".normal-message").hide();
-            buttomForAllShowHide();
+            error: function( jqXHR, textStatus, errorThrown ) {
+                $(".show-hide-all-tools").removeClass("disabled");
+                $(".normal-message").hide();
+                buttomForAllShowHide();
             }
         });
     });

--- a/main/inc/ajax/course_home.ajax.php
+++ b/main/inc/ajax/course_home.ajax.php
@@ -135,6 +135,139 @@ switch ($action) {
             echo json_encode($response);
         }
         break;
+    case 'set_visibility_for_all':
+        require_once __DIR__ . '/../global.inc.php';
+        $course_id = api_get_course_int_id();
+        $sessionId = api_get_session_id();
+        $allowEditionInSession = api_get_configuration_value('allow_edit_tool_visibility_in_session');
+        $response = [];
+        $tools_ids = json_decode($_GET['tools_ids']);
+        $em = Database::getManager();
+        $repository = $em->getRepository('ChamiloCourseBundle:CTool');
+        // Allow tool visibility in sessions.
+        if (api_is_allowed_to_edit(null, true)) {
+            if (is_array($tools_ids) && count($tools_ids) != 0) {
+                $total_tools = count($tools_ids);
+                for ($i = 0; $i < $total_tools; $i++) {
+                    $tool_id = (int)$tools_ids[$i];
+
+                    $criteria = [
+                        'cId' => $course_id,
+                        'sessionId' => 0,
+                        'iid' => $tool_id,
+                    ];
+                    /** @var CTool $tool */
+                    $tool = $repository->findOneBy($criteria);
+                    $visibility = $tool->getVisibility();
+
+                    if ($allowEditionInSession && !empty($sessionId)) {
+                        $criteria = [
+                            'cId' => $course_id,
+                            'sessionId' => $sessionId,
+                            'name' => $tool->getName(),
+                        ];
+
+                        /** @var CTool $tool */
+                        $toolInSession = $repository->findOneBy($criteria);
+                        if ($toolInSession) {
+                            // Use the session
+                            $tool = $toolInSession;
+                            $visibility = $toolInSession->getVisibility();
+                        } else {
+                            // Creates new row in c_tool
+                            $toolInSession = clone $tool;
+                            $toolInSession->setIid(0);
+                            $toolInSession->setId(0);
+                            $toolInSession->setVisibility(0);
+                            $toolInSession->setSessionId($session_id);
+                            $em->persist($toolInSession);
+                            $em->flush();
+                            // Update id with iid
+                            $toolInSession->setId($toolInSession->getIid());
+                            $em->persist($toolInSession);
+                            $em->flush();
+                            // $tool will be updated later
+                            $tool = $toolInSession;
+                        }
+                    }
+
+                    $toolImage = $tool->getImage();
+                    $customIcon = $tool->getCustomIcon();
+
+                    if (api_get_setting('homepage_view') != 'activity_big') {
+                        $toolImage = Display::return_icon(
+                            $toolImage,
+                            null,
+                            null,
+                            null,
+                            null,
+                            true
+                        );
+                        $inactiveImage = str_replace('.gif', '_na.gif', $toolImage);
+                    } else {
+                        // Display::return_icon() also checks in the app/Resources/public/css/themes/{theme}/icons folder
+                        $toolImage = (substr($toolImage, 0, strpos($toolImage, '.'))) . '.png';
+                        $toolImage = Display::return_icon(
+                            $toolImage,
+                            get_lang(ucfirst($tool->getName())),
+                            null,
+                            ICON_SIZE_BIG,
+                            null,
+                            true
+                        );
+                        $inactiveImage = str_replace('.png', '_na.png', $toolImage);
+                    }
+
+                    if (isset($customIcon) && !empty($customIcon)) {
+                        $toolImage = CourseHome::getCustomWebIconPath() . $customIcon;
+                        $inactiveImage = CourseHome::getCustomWebIconPath() . CourseHome::getDisableIcon($customIcon);
+                    }
+
+                    $requested_image = $visibility == 0 ? $toolImage : $inactiveImage;
+                    $requested_class = $visibility == 0 ? '' : 'text-muted';
+                    $requested_message = $visibility == 0 ? 'is_active' : 'is_inactive';
+                    $requested_view = $visibility == 0 ? 'visible.png' : 'invisible.png';
+                    $requestedVisible = $visibility == 0 ? 1 : 0;
+                    $requested_view = $visibility == 0 ? 'visible.png' : 'invisible.png';
+                    $requestedVisible = $visibility == 0 ? 1 : 0;
+
+                    // HIDE AND REACTIVATE TOOL
+                    if ($tool_id == strval(intval($tool_id))) {
+                        $tool->setVisibility($requestedVisible);
+                        $em->persist($tool);
+                        $em->flush();
+
+                        // Also hide the tool in all sessions
+                        if ($allowEditionInSession && empty($sessionId)) {
+                            $criteria = [
+                                'cId' => $course_id,
+                                'name' => $tool->getName(),
+                            ];
+
+                            /** @var CTool $toolItem */
+                            $tools = $repository->findBy($criteria);
+                            foreach ($tools as $toolItem) {
+                                $toolSessionId = $toolItem->getSessionId();
+                                if (!empty($toolSessionId)) {
+                                    $toolItem->setVisibility($requestedVisible);
+                                    $em->persist($toolItem);
+                                }
+                            }
+                            $em->flush();
+                        }
+                    }
+                    $response[] = [
+                        'image' => $requested_image,
+                        'tclass' => $requested_class,
+                        'message' => $requested_message,
+                        'view' => $requested_view,
+                        'id'=>$tool_id,
+                    ];
+                }
+            }
+        }
+        echo json_encode($response);
+        break;
     case 'show_course_information':
         require_once __DIR__.'/../global.inc.php';
 

--- a/main/inc/ajax/course_home.ajax.php
+++ b/main/inc/ajax/course_home.ajax.php
@@ -99,6 +99,7 @@ switch ($action) {
             $requestedVisible = $visibility == 0 ? 1 : 0;
             $requested_view = $visibility == 0 ? 'visible.png' : 'invisible.png';
             $requestedVisible = $visibility == 0 ? 1 : 0;
+            $requested_fa_class = $visibility == 0 ? 'fa fa-eye '.$requested_class : 'fa fa-eye-slash '.$requested_class;
 
             // HIDE AND REACTIVATE TOOL
             if ($_GET['id'] == strval(intval($_GET['id']))) {
@@ -131,6 +132,7 @@ switch ($action) {
                 'tclass' => $requested_class,
                 'message' => $requested_message,
                 'view' => $requested_view,
+                'fclass' => $requested_fa_class,
             ];
             echo json_encode($response);
         }
@@ -229,6 +231,7 @@ switch ($action) {
                     $requested_view = $visibility == 0 ? 'visible.png' : 'invisible.png';
                     $requestedVisible = $visibility == 0 ? 1 : 0;
                     $requested_view = $visibility == 0 ? 'visible.png' : 'invisible.png';
+                    $requested_fa_class = $visibility == 0 ? 'fa fa-eye '.$requested_class : 'fa fa-eye-slash '.$requested_class;
                     $requestedVisible = $visibility == 0 ? 1 : 0;
 
                     // HIDE AND REACTIVATE TOOL
@@ -261,6 +264,7 @@ switch ($action) {
                         'tclass' => $requested_class,
                         'message' => $requested_message,
                         'view' => $requested_view,
+                        'fclass' => $requested_fa_class,
                         'id'=>$tool_id,
                     ];
                 }

--- a/main/inc/introductionSection.inc.php
+++ b/main/inc/introductionSection.inc.php
@@ -290,6 +290,13 @@ if (api_is_allowed_to_edit() && empty($session_id)) {
         api_get_path(WEB_CODE_PATH).'course_info/tools.php?'.api_get_cidreq(),
         ['class' => 'btn btn-default', 'title' => get_lang('CustomizeIcons')]
     );
+
+}
+/* Tool to show /hide all tools on course */
+$toolAllShowHide = '';
+if (api_is_allowed_to_edit() && empty($session_id)) {
+    $toolAllShowHide =  '<button class="btn btn-default hidden visible-all  show-hide-all-tools" title="'.get_lang('Activate', '').'"><em class="fa fa-eye "></em></button>';
+    $toolAllShowHide .=  '<button class="btn btn-default hidden invisible-all show-hide-all-tools" title="'.get_lang('Deactivate', '').'"><em class="fa fa-eye-slash"></em></button>';
 }
 
 $toolbar = '';
@@ -303,10 +310,10 @@ if ($intro_dispCommand) {
             $textIntro = '<a class="btn btn-default" title="'.addslashes(get_lang('AddIntro')).'" href="'.api_get_self().'?'.api_get_cidreq().$blogParam.'&intro_cmdAdd=1">';
             $textIntro .= '<em class="fa fa-file-text"></em> ';
             $textIntro .= "</a>";
-            $toolbar .= $textIntro.$editIconButton;
+            $toolbar .= $textIntro . $editIconButton.$toolAllShowHide;
         } else {
             $toolbar .= '<a class="btn btn-default" href="'.api_get_self().'?intro_cmdAdd=1">'.get_lang('AddIntro').'</a>';
-            $toolbar .= $editIconButton;
+            $toolbar .= $editIconButton . $toolAllShowHide;
         }
         $toolbar .= '</div></div>';
     } else {
@@ -317,7 +324,7 @@ if ($intro_dispCommand) {
             $toolbar .=
                 '<a class="btn btn-default" href="'.api_get_self().'?'.api_get_cidreq().$blogParam.'&intro_cmdEdit=1" title="'.get_lang('Modify').'">
                 <em class="fa fa-pencil"></em></a>';
-            $toolbar .= $editIconButton;
+            $toolbar .= $editIconButton . $toolAllShowHide;
             $toolbar .= "<a class=\"btn btn-default\" href=\"".api_get_self()."?".api_get_cidreq().$blogParam."&intro_cmdDel=1\" onclick=\"javascript:
                 if(!confirm('".addslashes(api_htmlentities(get_lang('ConfirmYourChoice'), ENT_QUOTES, $charset)).
                 "')) return false;\"><em class=\"fa fa-trash-o\"></em></a>";
@@ -326,7 +333,7 @@ if ($intro_dispCommand) {
                 '<a class="btn btn-default" href="'.api_get_self().'?intro_cmdEdit=1" title="'.get_lang('Modify').'">
                 <em class="fa fa-pencil"></em>
                 </a>"';
-            $toolbar .= $editIconButton;
+            $toolbar .= $editIconButton . $toolAllShowHide;
             $toolbar .= "<a class=\"btn btn-default\" href=\"".api_get_self()."?".api_get_cidreq()."&intro_cmdDel=1\" onclick=\"javascript:
                 if(!confirm('".addslashes(api_htmlentities(get_lang('ConfirmYourChoice'), ENT_QUOTES, $charset)).
                 "')) return false;\"><em class=\"fa fa-trash-o\"></em></a>";

--- a/main/inc/lib/course_home.lib.php
+++ b/main/inc/lib/course_home.lib.php
@@ -898,6 +898,7 @@ class CourseHome
                                     ICON_SIZE_SMALL,
                                     false
                                 );
+                                $link['name']='<em id="'.'linktool_'.$tool['iid'].'"class="fa fa-eye" title="'.get_lang('Deactivate').'"></em>';
                                 $link['cmd'] = 'hide=yes';
                                 $lnk[] = $link;
                             }
@@ -909,6 +910,7 @@ class CourseHome
                                     ICON_SIZE_SMALL,
                                     false
                                 );
+                                $link['name']='<em id="'.'linktool_'.$tool['iid'].'"class="fa fa-eye-slash text-muted" title="'.get_lang('Activate').'"></em>';
                                 $link['cmd'] = 'restore=yes';
                                 $lnk[] = $link;
                             }
@@ -935,6 +937,7 @@ class CourseHome
                                         ICON_SIZE_SMALL,
                                         false
                                     );
+                                    $link['name']='<em id="'.'linktool_'.$tool['iid'].'"class="fa fa-eye" title="'.get_lang('Deactivate').'"></em>';
                                     $link['cmd'] = 'restore=yes';
                                     $lnk[] = $link;
                                     break;
@@ -946,6 +949,7 @@ class CourseHome
                                         ICON_SIZE_SMALL,
                                         false
                                     );
+                                    $link['name']='<em id="'.'linktool_'.$tool['iid'].'"class="fa fa-eye-slash text-muted" title="'.get_lang('Activate').'"></em>';
                                     $link['cmd'] = 'hide=yes';
                                     $lnk[] = $link;
                                     break;
@@ -958,6 +962,7 @@ class CourseHome
                                 ICON_SIZE_SMALL,
                                 false
                             );
+                            $link['name']='<em id="'.'linktool_'.$tool['iid'].'"class="fa fa-eye-slash text-muted" title="'.get_lang('Activate').'"></em>';
                             $link['cmd'] = 'hide=yes';
                             $lnk[] = $link;
                         }
@@ -982,7 +987,7 @@ class CourseHome
                         if (empty($tool['adminlink'])) {
                             $item['visibility'] .=
                                 '<a class="make_visible_and_invisible" href="'.api_get_self().'?'.api_get_cidreq().'&id='.$tool['iid'].'&'.$this_link['cmd'].'">'.
-                                $this_link['name'].'</a>';
+                                $this_link['name'].'</a>' ;
                         }
                     }
                 }


### PR DESCRIPTION
On a course homepage, you cannot change the visibility of all tools at once. Add an open "eye" icon next to the 2 icons of the introduction section, that enable setting all tools to "invisible". Change the icon to closed eye to revert visibility to "visible".

Only show the open eye ("make visible") when all tools are invisible.
Show the closed eye ("make invisible") in any other case