### PR TITLE
Chamilo 11.chamilo.org link progess not responsive. #2915

### DIFF
--- a/app/Resources/public/css/base.css
+++ b/app/Resources/public/css/base.css
@@ -9624,6 +9624,13 @@ ul.dropdown-menu.inner > li > a {
     #show_graph {
         text-align: center;
     }
+
+    #my_timeline {
+        width: 320px;
+        overflow: scroll;
+
+    }
+
 }
 
 @media (min-width: 480px) and (max-width: 767px) {
@@ -9675,7 +9682,7 @@ ul.dropdown-menu.inner > li > a {
     }
 
     .navbar-nav .open .dropdown-menu {
-        background-color: #FFF;
+        background-color: #ffffff;
     }
 
     .navbar-nav {
@@ -9684,6 +9691,12 @@ ul.dropdown-menu.inner > li > a {
 
     .grid-courses .items.my-courses {
         width: 310px;
+    }
+
+    #my_timeline {
+        width: 480px;
+        overflow: scroll;
+
     }
 }
 


### PR DESCRIPTION
Possible solution set  my_timeline element width to 320 px on device between 320 and 480 and 480 when device width are between 480 and 767. Additional set overflow to scroll.