### PR TITLE
 Mejorar el seguimiento de acceso en BBB

### DIFF
--- a/plugin/bbb/README.md
+++ b/plugin/bbb/README.md
@@ -63,4 +63,8 @@ For version 2.8
 
 ```sql
 ALTER TABLE plugin_bbb_meeting ADD COLUMN internal_meeting_id VARCHAR(255) DEFAULT NULL;
+ALTER TABLE plugin_bbb_room ADD close INT NOT NULL DEFAULT 0
 ```
+
+## Improve access tracking in BBB
+You need to configure the cron using the *cron_close_meeting.php* file.

--- a/plugin/bbb/lib/bbb_plugin.class.php
+++ b/plugin/bbb/lib/bbb_plugin.class.php
@@ -21,6 +21,10 @@ class BBBPlugin extends Plugin
     const LAUNCH_TYPE_SET_BY_TEACHER = 1;
     const LAUNCH_TYPE_SET_BY_STUDENT = 2;
 
+    const ROOM_OPEN = 0;
+    const ROOM_CLOSE = 1;
+    const ROOM_CHECK = 2;
+
     public $isCoursePlugin = true;
 
     // When creating a new course this settings are added to the course
@@ -45,8 +49,8 @@ class BBBPlugin extends Plugin
     protected function __construct()
     {
         parent::__construct(
-            '2.8.1',
-            'Julio Montoya, Yannick Warnier, Angel Fernando Quiroz Campos',
+            '2.8.2',
+            'Julio Montoya, Yannick Warnier, Angel Fernando Quiroz Campos, Jose Angel Ruiz',
             [
                 'tool_enable' => 'boolean',
                 'host' => 'text',
@@ -323,6 +327,28 @@ class BBBPlugin extends Plugin
 
             // Deleting course settings
             $this->uninstall_course_fields_in_all_courses($this->course_settings);
+        }
+    }
+
+    /**
+     * Update
+     */
+    public function update()
+    {
+        $sql = "SHOW COLUMNS FROM plugin_bbb_room WHERE Field = 'close'";
+        $res = Database::query($sql);
+
+        if (Database::num_rows($res) === 0) {
+            $sql = "ALTER TABLE plugin_bbb_room ADD close int unsigned NULL";
+            $res = Database::query($sql);
+            if (!$res) {
+                echo Display::return_message($this->get_lang('ErrorUpdateFieldDB'), 'warning');
+            }
+
+            Database::update(
+                'plugin_bbb_room',
+                ['close' => BBBPlugin::ROOM_CLOSE]
+            );
         }
     }
 

--- a/plugin/bbb/update.php
+++ b/plugin/bbb/update.php
@@ -1,0 +1,14 @@
+<?php
+/* For licensing terms, see /license.txt */
+/**
+ * Update the plugin.
+ *
+ * @package chamilo.plugin.bigbluebutton
+ */
+require_once __DIR__.'/config.php';
+
+if (!api_is_platform_admin()) {
+    die('You must have admin permissions to install plugins');
+}
+
+BBBPlugin::create()->update();


### PR DESCRIPTION
Si un usuario entra varías veces a la misma sala el sistema no contabiliza bien el tiempo real.
Si el usuario cierra la ventana de la videoconferencia y no cierra correctamente la sesión tampoco contabiliza el tiempo correctamente.
A través del cron y un nuevo campo en la tabla de plugin_bbb_room se controla el acceso y salida del usuario de la videoconferencia.