### PR TITLE
HR managers did not receive a copy of the messages #3333

### DIFF
--- a/main/announcements/announcements.php
+++ b/main/announcements/announcements.php
@@ -732,7 +732,8 @@ switch ($action) {
                                 api_get_course_info(),
                                 api_get_session_id(),
                                 $insert_id,
-                                $sendToUsersInSession
+                                $sendToUsersInSession,
+                                isset($data['send_to_hrm_users'])
                             );
                         }
 

--- a/main/inc/lib/message.lib.php
+++ b/main/inc/lib/message.lib.php
@@ -782,12 +782,9 @@ class MessageManager
                         get_lang('CopyOfMessageSentToXUser'),
                         $userInfo['complete_name']
                     ).' <br />'.$message;
-                    if(!isset( $drhInfo['user_id']) and isset( $drhInfo['id'])){
-                         $drhInfo['user_id'] = $drhInfo['id'];
-                    }
 
                     self::send_message_simple(
-                        $drhInfo['user_id'],
+                        $drhInfo['id'],
                         $subject,
                         $message,
                         $sender_id,

--- a/main/inc/lib/message.lib.php
+++ b/main/inc/lib/message.lib.php
@@ -782,6 +782,9 @@ class MessageManager
                         get_lang('CopyOfMessageSentToXUser'),
                         $userInfo['complete_name']
                     ).' <br />'.$message;
+                    if(!isset( $drhInfo['user_id']) and isset( $drhInfo['id'])){
+                         $drhInfo['user_id'] = $drhInfo['id'];
+                    }
 
                     self::send_message_simple(
                         $drhInfo['user_id'],


### PR DESCRIPTION


Prevents error when "user_id" is not found but "id" if it exists.

Change user_id to id