### PR TITLE
Limit speed of user searches in social network #3191

### DIFF
--- a/main/inc/lib/formvalidator/Element/SelectAjax.php
+++ b/main/inc/lib/formvalidator/Element/SelectAjax.php
@@ -75,6 +75,10 @@ class SelectAjax extends HTML_QuickForm_select
         $max = $this->getAttribute('maximumSelectionLength');
         $max = !empty($max) ? "maximumSelectionLength: $max, " : '';
 
+        // wait XX milliseconds before triggering the request
+        $delay = $this->getAttribute('delay');
+        $delay = !empty($delay) ? "delay: $delay, " : '';
+
         $html = <<<JS
             <script>
                 $(function(){
@@ -87,6 +91,7 @@ class SelectAjax extends HTML_QuickForm_select
                         tags: $tags,
                         ajax: {
                             url: $url,
+                            {$delay}
                             dataType: 'json',
                             data: function(params) {
                                 return {

--- a/main/inc/lib/formvalidator/Element/SelectAjax.php
+++ b/main/inc/lib/formvalidator/Element/SelectAjax.php
@@ -76,8 +76,8 @@ class SelectAjax extends HTML_QuickForm_select
         $max = !empty($max) ? "maximumSelectionLength: $max, " : '';
 
         // wait XX milliseconds before triggering the request
-        $delay = $this->getAttribute('delay');
-        $delay = !empty($delay) ? "delay: $delay, " : '';
+        $delay = (int)$this->getAttribute('delay');
+        $delay = (0 !== $delay) ? "delay: $delay, " : '';
 
         $html = <<<JS
             <script>

--- a/main/messages/new_message.php
+++ b/main/messages/new_message.php
@@ -149,7 +149,7 @@ function manageForm($default, $select_from_user_list = null, $sent_to = '', $tpl
                     [],
                     [
                         'multiple' => 'multiple',
-                        'delay' => '1000',
+                        'delay' => 1000,
                         'url' => api_get_path(WEB_AJAX_PATH).'message.ajax.php?a=find_users',
                     ]
                 );

--- a/main/messages/new_message.php
+++ b/main/messages/new_message.php
@@ -149,6 +149,7 @@ function manageForm($default, $select_from_user_list = null, $sent_to = '', $tpl
                     [],
                     [
                         'multiple' => 'multiple',
+                        'delay' => '1000',
                         'url' => api_get_path(WEB_AJAX_PATH).'message.ajax.php?a=find_users',
                     ]
                 );
@@ -242,8 +243,8 @@ function manageForm($default, $select_from_user_list = null, $sent_to = '', $tpl
 
     $form->addLabel(
         '',
-        '<iframe 
-            frameborder="0" height="200" width="100%" scrolling="no" 
+        '<iframe
+            frameborder="0" height="200" width="100%" scrolling="no"
             src="'.api_get_path(WEB_CODE_PATH).'messages/record_audio.php"></iframe>'
     );
 


### PR DESCRIPTION
Limit speed of user searches in social network #3191

Add delay to select2 option, set it to 1000 ms.

More info about select2 ajax options [https://select2.org/data-sources/ajax](https://select2.org/data-sources/ajax)