### PR TITLE
add 'Time spent/Time required' field on accordion lessons list

### DIFF
--- a/main/template/default/learnpath/list.tpl
+++ b/main/template/default/learnpath/list.tpl
@@ -221,10 +221,16 @@
                                             <th>{{ "PublicationDate"|get_lang }}</th>
                                             <th>{{ "ExpirationDate"|get_lang }}</th>
                                             <th>{{ "Progress"|get_lang }}</th>
+                                            {% if allow_min_time %}
+                                                <th>{{ "TimeSpentTimeRequired"|get_lang }}</th>
+                                            {% endif %}
                                             <th>{{ "AuthoringOptions"|get_lang }}</th>
                                         {% else %}
                                             {% if not is_invitee %}
                                                 <th>{{ "Progress"|get_lang }}</th>
+                                            {% endif %}
+                                            {% if allow_min_time %}
+                                                <th>{{ "TimeSpentTimeRequired"|get_lang }}</th>
                                             {% endif %}
 
                                             <th>{{ "Actions"|get_lang }}</th>
@@ -254,10 +260,24 @@
                                                 <td>
                                                     {{ row.dsp_progress }}
                                                 </td>
+                                                {% if allow_min_time %}
+                                                    <td>
+                                                        {% if row.info_time_prerequisite %}
+                                                            {{ row.info_time_prerequisite }}
+                                                        {% endif %}
+                                                    </td>
+                                                {% endif %}
                                             {% else %}
                                                 {% if not is_invitee %}
                                                     <td>
                                                         {{ row.dsp_progress }}
+                                                    </td>
+                                                {% endif %}
+                                                {% if allow_min_time %}
+                                                    <td>
+                                                        {% if row.info_time_prerequisite %}
+                                                            {{ row.info_time_prerequisite }}
+                                                        {% endif %}
                                                     </td>
                                                 {% endif %}
                                             {% endif %}
@@ -294,7 +314,7 @@
                                 {% for row in lp_data.lp_list %}
                                     <div class="lp-item">
                                         <div class="row">
-                                            <div class="col-md-8">
+                                            <div class="col-md-6">
                                                 <i class="fa fa-chevron-circle-right" aria-hidden="true"></i>
                                                 <a href="{{ row.url_start }}">
                                                     {{ row.title }}
@@ -305,6 +325,13 @@
                                             <div class="col-md-3">
                                                 {{ row.dsp_progress }}
                                             </div>
+                                            {% if allow_min_time %}
+                                                <div class="col-md-2">
+                                                    {% if row.info_time_prerequisite %}
+                                                        {{ row.info_time_prerequisite }}
+                                                    {% endif %}
+                                                </div>
+                                            {% endif %}
                                             <div class="col-md-1">
                                                 {{ row.action_pdf }}
                                             </div>
@@ -420,10 +447,16 @@
                                                         <th>{{ "PublicationDate"|get_lang }}</th>
                                                         <th>{{ "ExpirationDate"|get_lang }}</th>
                                                         <th>{{ "Progress"|get_lang }}</th>
+                                                        {% if allow_min_time %}
+                                                            <th>{{ "TimeSpentTimeRequired"|get_lang }}</th>
+                                                        {% endif %}
                                                         <th>{{ "AuthoringOptions"|get_lang }}</th>
                                                     {% else %}
                                                         {% if not is_invitee %}
                                                             <th>{{ "Progress"|get_lang }}</th>
+                                                        {% endif %}
+                                                        {% if allow_min_time %}
+                                                            <th>{{ "TimeSpentTimeRequired"|get_lang }}</th>
                                                         {% endif %}
 
                                                         <th>{{ "Actions"|get_lang }}</th>
@@ -453,10 +486,24 @@
                                                             <td>
                                                                 {{ row.dsp_progress }}
                                                             </td>
+                                                            {% if allow_min_time %}
+                                                                <td>
+                                                                    {% if row.info_time_prerequisite %}
+                                                                        {{ row.info_time_prerequisite }}
+                                                                    {% endif %}
+                                                                </td>
+                                                            {% endif %}
                                                         {% else %}
                                                             {% if not is_invitee %}
                                                                 <td>
                                                                     {{ row.dsp_progress }}
+                                                                </td>
+                                                            {% endif %}
+                                                            {% if allow_min_time %}
+                                                                <td>
+                                                                    {% if row.info_time_prerequisite %}
+                                                                        {{ row.info_time_prerequisite }}
+                                                                    {% endif %}
                                                                 </td>
                                                             {% endif %}
                                                         {% endif %}
@@ -489,7 +536,7 @@
                                         {% for row in lp_data.lp_list %}
                                             <div class="lp-item">
                                                 <div class="row">
-                                                    <div class="col-md-8">
+                                                    <div class="col-md-6">
                                                         <i class="fa fa-chevron-circle-right" aria-hidden="true"></i>
                                                         <a href="{{ row.url_start }}">
                                                             {{ row.title }}
@@ -500,6 +547,13 @@
                                                     <div class="col-md-3">
                                                         {{ row.dsp_progress }}
                                                     </div>
+                                                    {% if allow_min_time %}
+                                                        <div class="col-md-2">
+                                                            {% if row.info_time_prerequisite %}
+                                                                {{ row.info_time_prerequisite }}
+                                                            {% endif %}
+                                                        </div>
+                                                    {% endif %}
                                                     <div class="col-md-1">
                                                         {{ row.action_pdf }}
                                                     </div>


### PR DESCRIPTION
Chamilo [has an option to activate an accordion view list](https://github.com/chamilo/chamilo-lms/blob/1.11.x/main/install/configuration.dist.php#L440) for the lesson list.

If the option is enabled we will lose the "Time spent / Time required" field

**$_configuration['lp_category_accordion'] = false**

teacher view:

![imagen](https://user-images.githubusercontent.com/48205899/87521460-b6053a00-c684-11ea-928b-87f42bc7fc1c.png)

alumn view:

![imagen](https://user-images.githubusercontent.com/48205899/87521508-c4535600-c684-11ea-9534-f56db58a3391.png)


**$_configuration['lp_category_accordion'] = true**

teacher view:

![imagen](https://user-images.githubusercontent.com/48205899/87521629-ea78f600-c684-11ea-9ca0-970f680ec6a0.png)

alumn view:

![imagen](https://user-images.githubusercontent.com/48205899/87521664-f2d13100-c684-11ea-9050-a24976a91115.png)

This pull update the [/main/template/default/learnpath/list.tpl](https://github.com/chamilo/chamilo-lms/blob/1.11.x/main/template/default/learnpath/list.tpl) template adding to the accordion view the "Time spent / Time required" fields (info_time_prerequisite)


**$_configuration['lp_category_accordion'] = true**

teacher view:

![imagen](https://user-images.githubusercontent.com/48205899/87521795-20b67580-c685-11ea-8a60-be62ba096273.png)

alumn view:

![imagen](https://user-images.githubusercontent.com/48205899/87521835-2ca23780-c685-11ea-9d90-b6bfb03dc768.png)
