### PR TITLE
UserManager::updateUserFromLDAP bugfix - refs BT#17483

### DIFF
--- a/main/inc/lib/usermanager.lib.php
+++ b/main/inc/lib/usermanager.lib.php
@@ -874,7 +874,7 @@ class UserManager
             $userInfo['active'],
             $userInfo['creator_id'],
             $userInfo['hr_dept_id'],
-            0,
+            null,
             $userInfo['language']
         );
         if (false === $userId) {

--- a/main/inc/lib/usermanager.lib.php
+++ b/main/inc/lib/usermanager.lib.php
@@ -864,18 +864,18 @@ class UserManager
             $user["lastname"],
             $login,
             null,
-            null,
+            $userInfo['auth_source'],
             $user["email"],
             $userInfo['status'],
-            '',
-            '',
-            '',
-            null,
-            1,
-            null,
+            $userInfo['official_code'],
+            $userInfo['phone'],
+            $userInfo['picture_uri'],
+            $userInfo['expiration_date'],
+            $userInfo['active'],
+            $userInfo['creator_id'],
+            $userInfo['hr_dept_id'],
             0,
-            null,
-            ''
+            $userInfo['language']
         );
         if (false === $userId) {
             throw new Exception(get_lang('CouldNotUpdateUser'));


### PR DESCRIPTION
updateUserFromLDAP() used to reset picture_url, auth_source, official_code, phone, expiration_date, active, creator_id, hr_dept_id and language. This fixes it.