### PR TITLE
Agenda: Repeated "All day" events show on full day span after first occurence #3394

### DIFF
--- a/main/inc/lib/agenda.lib.php
+++ b/main/inc/lib/agenda.lib.php
@@ -246,7 +246,7 @@ class Agenda
     ) {
         $start = api_get_utc_datetime($start);
         $end = api_get_utc_datetime($end);
-        $allDay = isset($allDay) && ($allDay === 'true' or $allDay == 1) ? 1 : 0;
+        $allDay = isset($allDay) && ($allDay === 'true' || $allDay == 1) ? 1 : 0;
         $id = null;
 
         switch ($this->type) {

--- a/main/inc/lib/agenda.lib.php
+++ b/main/inc/lib/agenda.lib.php
@@ -246,7 +246,7 @@ class Agenda
     ) {
         $start = api_get_utc_datetime($start);
         $end = api_get_utc_datetime($end);
-        $allDay = isset($allDay) && $allDay === 'true' ? 1 : 0;
+        $allDay = isset($allDay) && ($allDay === 'true' or $allDay == 1) ? 1 : 0;
         $id = null;
 
         switch ($this->type) {


### PR DESCRIPTION
Agenda: Repeated "All day" events show on full day span after first occurence #3394

From the second round, allDay changes from true to 1, as compared to the string true, it will not validate the date for its continuation.

Validation against 1 is added directly to compare against numeric value 1 that can be assumed to be true.

The database all_day field in table c_calendar_event is set to 1 correctly.