### PR TITLE
Exercise result: Exporting pdf is impossible #3222

### DIFF
--- a/main/exercise/exercise_show.php
+++ b/main/exercise/exercise_show.php
@@ -939,8 +939,7 @@ if ($show_results) {
 if ('export' === $action) {
     $content = ob_get_clean();
     // needed in order to mpdf to work
-    ob_clean();
-
+    if (ob_get_contents()) ob_clean();
     $params = [
         'filename' => api_replace_dangerous_char(
             $objExercise->name.' '.


### PR DESCRIPTION
Possible fix to
"Notice: ob_clean(): failed to delete buffer. No buffer to delete in /furanet/sites/11.chamilo.org/web/htdocs/main/exercise/exercise_show.php on line 942"

https://www.php.net/manual/en/function.ob-clean.php#Hcom114967

Check if had buffer.