### PR TITLE
Usar el valor de 'noheader' en la variable origin que se manda en la url para ocultar cabeceras

### DIFF
--- a/main/course_home/last_course.php
+++ b/main/course_home/last_course.php
@@ -20,7 +20,7 @@ $sql = "SELECT c_id, session_id
 
 $result = Database::query($sql);
 
-if (Database::num_rows($result )) {
+if (Database::num_rows($result)) {
     $result = Database::fetch_array($result, 'ASSOC');
     $courseId = (int) $result['c_id'];
     $sessionId = (int) $result['session_id'];

--- a/main/exercise/exercise.php
+++ b/main/exercise/exercise.php
@@ -506,7 +506,7 @@ if ($is_allowedToEdit) {
     }
 }
 
-if ($origin !== 'learnpath') {
+if (!in_array($origin, ['learnpath', 'noheader'])) {
     //so we are not in learnpath tool
     Display::display_header($nameTools, get_lang('Exercise'));
     if (isset($_GET['message']) && in_array($_GET['message'], ['ExerciseEdited'])) {

--- a/main/exercise/exercise.php
+++ b/main/exercise/exercise.php
@@ -506,7 +506,7 @@ if ($is_allowedToEdit) {
     }
 }
 
-if (!in_array($origin, ['learnpath', 'noheader'])) {
+if (!in_array($origin, ['learnpath', 'mobileapp'])) {
     //so we are not in learnpath tool
     Display::display_header($nameTools, get_lang('Exercise'));
     if (isset($_GET['message']) && in_array($_GET['message'], ['ExerciseEdited'])) {

--- a/main/exercise/exercise_result.php
+++ b/main/exercise/exercise_result.php
@@ -89,7 +89,7 @@ $pageTop = '';
 $pageBottom = '';
 $pageContent = '';
 
-if (!in_array($origin, ['learnpath', 'embeddable'])) {
+if (!in_array($origin, ['learnpath', 'embeddable', 'noheader'])) {
     // So we are not in learnpath tool
     $showHeader = true;
 }
@@ -240,7 +240,7 @@ ExerciseLib::exercise_time_control_delete(
 
 ExerciseLib::delete_chat_exercise_session($exe_id);
 
-if (!in_array($origin, ['learnpath', 'embeddable'])) {
+if (!in_array($origin, ['learnpath', 'embeddable', 'noheader'])) {
     $pageBottom .= '<div class="question-return">';
     $pageBottom .= Display::url(
         get_lang('ReturnToCourseHomepage'),
@@ -254,7 +254,7 @@ if (!in_array($origin, ['learnpath', 'embeddable'])) {
     }
 
     $showFooter = true;
-} elseif ($origin === 'embeddable') {
+} elseif (in_array($origin, ['embeddable', 'noheader'])) {
     if (api_is_allowed_to_session_edit()) {
         Exercise::cleanSessionVariables();
     }

--- a/main/exercise/exercise_result.php
+++ b/main/exercise/exercise_result.php
@@ -89,7 +89,7 @@ $pageTop = '';
 $pageBottom = '';
 $pageContent = '';
 
-if (!in_array($origin, ['learnpath', 'embeddable', 'noheader'])) {
+if (!in_array($origin, ['learnpath', 'embeddable', 'mobileapp'])) {
     // So we are not in learnpath tool
     $showHeader = true;
 }
@@ -240,7 +240,7 @@ ExerciseLib::exercise_time_control_delete(
 
 ExerciseLib::delete_chat_exercise_session($exe_id);
 
-if (!in_array($origin, ['learnpath', 'embeddable', 'noheader'])) {
+if (!in_array($origin, ['learnpath', 'embeddable', 'mobileapp'])) {
     $pageBottom .= '<div class="question-return">';
     $pageBottom .= Display::url(
         get_lang('ReturnToCourseHomepage'),
@@ -254,7 +254,7 @@ if (!in_array($origin, ['learnpath', 'embeddable', 'noheader'])) {
     }
 
     $showFooter = true;
-} elseif (in_array($origin, ['embeddable', 'noheader'])) {
+} elseif (in_array($origin, ['embeddable', 'mobileapp'])) {
     if (api_is_allowed_to_session_edit()) {
         Exercise::cleanSessionVariables();
     }

--- a/main/exercise/exercise_submit.php
+++ b/main/exercise/exercise_submit.php
@@ -879,7 +879,7 @@ $interbreadcrumb[] = [
 ];
 $interbreadcrumb[] = ['url' => '#', 'name' => $objExercise->selectTitle(true)];
 
-if (!in_array($origin, ['learnpath', 'embeddable'])) { //so we are not in learnpath tool
+if (!in_array($origin, ['learnpath', 'embeddable', 'noheader'])) { //so we are not in learnpath tool
     if (!api_is_allowed_to_session_edit()) {
         Display::addFlash(
             Display::return_message(get_lang('SessionIsReadOnly'), 'warning')
@@ -890,6 +890,13 @@ if (!in_array($origin, ['learnpath', 'embeddable'])) { //so we are not in learnp
 } else {
     Display::display_reduced_header();
     echo '<div style="height:10px">&nbsp;</div>';
+}
+
+if ($origin == 'noheader') {
+    echo '<div class="actions">';
+    echo '<a href="javascript:window.history.go(-1);">'.
+        Display::return_icon('back.png', get_lang('GoBackToQuestionList'), [], 32).'</a>';
+    echo '</div>';
 }
 
 $show_quiz_edition = $objExercise->added_in_lp();

--- a/main/exercise/exercise_submit.php
+++ b/main/exercise/exercise_submit.php
@@ -79,7 +79,7 @@ if ('true' === api_get_setting('enable_record_audio')) {
 }
 
 $zoomOptions = api_get_configuration_value('quiz_image_zoom');
-if (isset($zoomOptions['options']) && !in_array($origin, ['embeddable', 'noheader'])) {
+if (isset($zoomOptions['options']) && !in_array($origin, ['embeddable', 'mobileapp'])) {
     $options = $zoomOptions['options'];
     $htmlHeadXtra[] = '<script src="'.api_get_path(WEB_LIBRARY_JS_PATH).'jquery.elevatezoom.js"></script>';
     $htmlHeadXtra[] = '<script>
@@ -879,7 +879,7 @@ $interbreadcrumb[] = [
 ];
 $interbreadcrumb[] = ['url' => '#', 'name' => $objExercise->selectTitle(true)];
 
-if (!in_array($origin, ['learnpath', 'embeddable', 'noheader'])) { //so we are not in learnpath tool
+if (!in_array($origin, ['learnpath', 'embeddable', 'mobileapp'])) { //so we are not in learnpath tool
     if (!api_is_allowed_to_session_edit()) {
         Display::addFlash(
             Display::return_message(get_lang('SessionIsReadOnly'), 'warning')
@@ -892,7 +892,7 @@ if (!in_array($origin, ['learnpath', 'embeddable', 'noheader'])) { //so we are n
     echo '<div style="height:10px">&nbsp;</div>';
 }
 
-if ($origin == 'noheader') {
+if ($origin == 'mobileapp') {
     echo '<div class="actions">';
     echo '<a href="javascript:window.history.go(-1);">'.
         Display::return_icon('back.png', get_lang('GoBackToQuestionList'), [], 32).'</a>';

--- a/main/exercise/overview.php
+++ b/main/exercise/overview.php
@@ -71,7 +71,7 @@ if ($time_control) {
     $htmlHeadXtra[] = $objExercise->showTimeControlJS($time_left);
 }
 
-if (!in_array($origin, ['learnpath', 'embeddable'])) {
+if (!in_array($origin, ['learnpath', 'embeddable', 'noheader'])) {
     Display::display_header();
 } else {
     $htmlHeadXtra[] = "
@@ -80,6 +80,13 @@ if (!in_array($origin, ['learnpath', 'embeddable'])) {
     </style>
     ";
     Display::display_reduced_header();
+}
+
+if ($origin == 'noheader') {
+    echo '<div class="actions">';
+    echo '<a href="javascript:window.history.go(-1);">'.
+        Display::return_icon('back.png', get_lang('GoBackToQuestionList'), [], 32).'</a>';
+    echo '</div>';
 }
 
 $html = '';

--- a/main/exercise/overview.php
+++ b/main/exercise/overview.php
@@ -71,7 +71,7 @@ if ($time_control) {
     $htmlHeadXtra[] = $objExercise->showTimeControlJS($time_left);
 }
 
-if (!in_array($origin, ['learnpath', 'embeddable', 'noheader'])) {
+if (!in_array($origin, ['learnpath', 'embeddable', 'mobileapp'])) {
     Display::display_header();
 } else {
     $htmlHeadXtra[] = "
@@ -82,7 +82,7 @@ if (!in_array($origin, ['learnpath', 'embeddable', 'noheader'])) {
     Display::display_reduced_header();
 }
 
-if ($origin == 'noheader') {
+if ($origin == 'mobileapp') {
     echo '<div class="actions">';
     echo '<a href="javascript:window.history.go(-1);">'.
         Display::return_icon('back.png', get_lang('GoBackToQuestionList'), [], 32).'</a>';

--- a/main/exercise/result.php
+++ b/main/exercise/result.php
@@ -77,7 +77,7 @@ if ($show_headers) {
     $htmlHeadXtra[] = '<style>
         body { background: none;}
     </style>';
-    
+
     if ($origin == 'noheader') {
         echo '<div class="actions">';
         echo '<a href="javascript:window.history.go(-1);">'.

--- a/main/exercise/result.php
+++ b/main/exercise/result.php
@@ -15,7 +15,7 @@ $id = isset($_REQUEST['id']) ? (int) $_GET['id'] : 0; // exe id
 $show_headers = isset($_REQUEST['show_headers']) ? (int) $_REQUEST['show_headers'] : null;
 $origin = api_get_origin();
 
-if (in_array($origin, ['learnpath', 'embeddable'])) {
+if (in_array($origin, ['learnpath', 'embeddable', 'noheader'])) {
     $show_headers = false;
 }
 
@@ -77,6 +77,13 @@ if ($show_headers) {
     $htmlHeadXtra[] = '<style>
         body { background: none;}
     </style>';
+    
+    if ($origin == 'noheader') {
+        echo '<div class="actions">';
+        echo '<a href="javascript:window.history.go(-1);">'.
+            Display::return_icon('back.png', get_lang('GoBackToQuestionList'), [], 32).'</a>';
+        echo '</div>';
+    }
 }
 
 $message = Session::read('attempt_remaining');

--- a/main/exercise/result.php
+++ b/main/exercise/result.php
@@ -15,7 +15,7 @@ $id = isset($_REQUEST['id']) ? (int) $_GET['id'] : 0; // exe id
 $show_headers = isset($_REQUEST['show_headers']) ? (int) $_REQUEST['show_headers'] : null;
 $origin = api_get_origin();
 
-if (in_array($origin, ['learnpath', 'embeddable', 'noheader'])) {
+if (in_array($origin, ['learnpath', 'embeddable', 'mobileapp'])) {
     $show_headers = false;
 }
 
@@ -78,7 +78,7 @@ if ($show_headers) {
         body { background: none;}
     </style>';
 
-    if ($origin == 'noheader') {
+    if ($origin == 'mobileapp') {
         echo '<div class="actions">';
         echo '<a href="javascript:window.history.go(-1);">'.
             Display::return_icon('back.png', get_lang('GoBackToQuestionList'), [], 32).'</a>';

--- a/main/inc/lib/display.lib.php
+++ b/main/inc/lib/display.lib.php
@@ -64,7 +64,11 @@ class Display
     ) {
         $origin = api_get_origin();
         $showHeader = true;
-        if (isset($origin) && $origin == 'learnpath') {
+        if (isset($origin) && ($origin == 'learnpath' || $origin == 'noheader')) {
+            $showHeader = false;
+        }
+
+        if (Session::read('origin') == 'noheader') {
             $showHeader = false;
         }
 

--- a/main/inc/lib/display.lib.php
+++ b/main/inc/lib/display.lib.php
@@ -64,11 +64,11 @@ class Display
     ) {
         $origin = api_get_origin();
         $showHeader = true;
-        if (isset($origin) && ($origin == 'learnpath' || $origin == 'noheader')) {
+        if (isset($origin) && ($origin == 'learnpath' || $origin == 'mobileapp')) {
             $showHeader = false;
         }
 
-        if (Session::read('origin') == 'noheader') {
+        if (Session::read('origin') == 'mobileapp') {
             $showHeader = false;
         }
 


### PR DESCRIPTION
En determinadas secciones de la app (en concreto Ejercicios y Encuestas) se incrusta el contenido directamente de la plataforma. Para ocultar la cabecera de Chamilo y no interferir en la navegación en el dispositivo movil, se utiliza el valor de "noheader" en la variable $origin