### PR TITLE
iOS devices like iPhone - Registration and login pages are not aligned correctly #3270

### DIFF
--- a/app/Resources/public/css/base.css
+++ b/app/Resources/public/css/base.css
@@ -10480,4 +10480,5 @@ ul.dropdown-menu.inner > li > a {
 #registration input.register-profile[value='1']:after
 {
     top:-5px;
+    left: -2px;
 }

--- a/app/Resources/public/css/base.css
+++ b/app/Resources/public/css/base.css
@@ -10470,3 +10470,9 @@ ul.dropdown-menu.inner > li > a {
         clear: left;
     }
 }
+
+/* Only adjust class radio to student or profesor into /main/auth/inscription.php*/
+#registration > fieldset > #status-group .radio {
+    min-height: 145px;
+    min-width: 145px;
+}

--- a/app/Resources/public/css/base.css
+++ b/app/Resources/public/css/base.css
@@ -10476,3 +10476,8 @@ ul.dropdown-menu.inner > li > a {
     min-height: 145px;
     min-width: 145px;
 }
+#registration input.register-profile[value='5']:after,
+#registration input.register-profile[value='1']:after
+{
+    top:-5px;
+}


### PR DESCRIPTION
At the css level, it was modified so that the background image rises 10px from the current position and the radius class of this block has a minimum of 145px so that the logo shows well in ios.

This without affecting the current views in chrome and firefox since it is adjusted only by css.


![image](https://user-images.githubusercontent.com/18097392/89450401-19343a80-d720-11ea-83f2-9879f31a17d9.png)

#3270 