### PR TITLE
Chamilo lms 3008

### DIFF
--- a/main/course_progress/thematic_controller.php
+++ b/main/course_progress/thematic_controller.php
@@ -366,7 +366,7 @@ class ThematicController
             $thematic_plan_data = $thematic->get_thematic_plan_data();
 
             // Third column
-            $thematic_advance_data = $thematic->get_thematic_advance_list(null, null, true);
+            $thematic_advance_data = $thematic->get_thematic_advance_list(null, null, true, true);
 
             $data['thematic_plan_div'] = $thematic->get_thematic_plan_array($thematic_plan_data);
             $data['thematic_advance_div'] = $thematic->get_thematic_advance_div($thematic_advance_data);

--- a/main/inc/introductionSection.inc.php
+++ b/main/inc/introductionSection.inc.php
@@ -219,11 +219,12 @@ if ($tool == TOOL_COURSE_HOMEPAGE && !isset($_GET['intro_cmdEdit'])) {
         $thematic_info = $thematic->get_thematic_list($thematic_advance_info['thematic_id']);
         $thematic_info['title'] = isset($thematic_info['title']) ? $thematic_info['title'] : '';
 
-        /*
-        $thematic_advance_info['start_date'] = api_get_local_time(
-            $thematic_advance_info['start_date']
-        );
-        */
+        if (!empty($thematic_advance_info['start_date'])) {
+            $thematic_advance_info['start_date'] = api_get_local_time(
+                $thematic_advance_info['start_date']
+            );
+        }
+
         $thematic_advance_info['start_date'] = api_format_date(
             $thematic_advance_info['start_date'],
             DATE_TIME_FORMAT_LONG

--- a/main/inc/lib/thematic.lib.php
+++ b/main/inc/lib/thematic.lib.php
@@ -702,13 +702,15 @@ class Thematic
      * @param int    $thematic_advance_id Thematic advance id (optional), get data by thematic advance list
      * @param string $course_code         Course code (optional)
      * @param bool   $force_session_id    Force to have a session id
+     * @param bool   $withLocalTime    Force start_date to local time
      *
      * @return array $data
      */
     public function get_thematic_advance_list(
         $thematic_advance_id = null,
         $course_code = null,
-        $force_session_id = false
+        $force_session_id = false,
+        $withLocalTime = false
     ) {
         $course_info = api_get_course_info($course_code);
         $tbl_thematic_advance = Database::get_course_table(TABLE_THEMATIC_ADVANCE);
@@ -746,6 +748,9 @@ class Thematic
                 // group all data group by thematic id
                 $tmp = [];
                 while ($row = Database::fetch_array($res, 'ASSOC')) {
+                    if($withLocalTime == true) {
+                        $row['start_date'] = api_get_local_time($row['start_date']);
+                    }
                     $tmp[] = $row['thematic_id'];
                     if (in_array($row['thematic_id'], $tmp)) {
                         if ($force_session_id) {


### PR DESCRIPTION
En el curso, cuando se habilita "Mostrar información sobre el último avance temático hecho y el siguiente por hacer." en la configuración didáctica, se mostraba la fecha actual (en rojo) cuando no se había iniciado, y una fecha sin diferencia horaria (en amarillo) para la siguiente actividad.
![image](https://user-images.githubusercontent.com/18097392/89931360-ae787880-dbd1-11ea-9a9b-e8c74ea450cb.png)

En la programación didáctica, luego de haber seleccionado la hoja de asistencia, se mostraba una fecha errónea (para este caso se mostraba las 10 am) 

![image](https://user-images.githubusercontent.com/18097392/89931519-e1227100-dbd1-11ea-8c7d-8c07ac9762b9.png)

para este caso se añadió en get_thematic_advance_list la variable $withLocalTime para establecer el cambio de hora al momento de recoger los datos de la base de datos