### PR TITLE
Extra Field: The selector will not write the index 0, but will add the rest of the options set

### DIFF
--- a/main/inc/lib/extra_field.lib.php
+++ b/main/inc/lib/extra_field.lib.php
@@ -3334,7 +3334,7 @@ JAVASCRIPT;
         if (!empty($options)) {
             foreach ($options as $option) {
                 foreach ($option as $sub_option) {
-                    if ('0' != $sub_option['option_value']) {
+                    if ('0' == $sub_option['option_value']) {
                         continue;
                     }
 


### PR DESCRIPTION
Si el valor option_value de la opción es igual a 0, no hace nada, en caso contrario, añade los elementos establecidos. 

Afecta la funcion addSelectWithTextFieldElement de extrafield