### PR TITLE
Documents tool: Replace the $group_dir that may contain __0__1 which differs from the actual directory 

### DIFF
--- a/main/inc/lib/document.lib.php
+++ b/main/inc/lib/document.lib.php
@@ -5720,6 +5720,7 @@ class DocumentManager
                 }
             }
         } else {
+            $firstPath = '';
             foreach ($folders as $folder) {
                 if (($curdirpath != $folder) &&
                     ($folder != $move_file) &&
@@ -5727,8 +5728,16 @@ class DocumentManager
                 ) {
                     // Cannot copy dir into his own subdir
                     $path_displayed = self::get_titles_of_path($folder);
-                    $display_folder = substr($path_displayed, strlen($group_dir));
-                    $display_folder = $display_folder == '' ? get_lang('Documents') : $display_folder;
+                    if ($firstPath == '' && $path_displayed != '') {
+                        $firstPath = $path_displayed;
+                        $group_dir = $firstPath;
+                    }
+                    $display_folder = substr($path_displayed, strlen($group_dir) + 1);
+                    if ($display_folder != '') {
+                        $display_folder = ' &mdash; '.$display_folder;
+                    } else {
+                        $display_folder = get_lang('Documents');
+                    }
                     $options[$folder] = $display_folder;
                 }
             }

--- a/main/inc/lib/document.lib.php
+++ b/main/inc/lib/document.lib.php
@@ -5732,10 +5732,8 @@ class DocumentManager
                         $firstPath = $path_displayed;
                         $group_dir = $firstPath;
                     }
-                    $display_folder = substr($path_displayed, strlen($group_dir) + 1);
-                    if ($display_folder != '') {
-                        $display_folder = ' &mdash; '.$display_folder;
-                    } else {
+                    $display_folder = substr($path_displayed, strlen($group_dir));
+                    if ($display_folder == '') {
                         $display_folder = get_lang('Documents');
                     }
                     $options[$folder] = $display_folder;


### PR DESCRIPTION
En algunos casos, group_dirs es /Grupo-0001_groupdocs__0__1 en vez de /Grupo-0001_groupdocs, esto hace que el reemplazo de la cadena produzca ese fallo,  pues este conjunto "__0__1" hace que se corte, los fragmentos que le siguen.

Como ejemplo 
/Grupo-0001_groupdocs__0__1/hello-2__0__1 se ajustaria como 
/Grupo-0001_groupdocs/hello 2, al pasar el corte de caracteres solo mostraria "2".

 #3505 