### PR TITLE
Feature/improved ldap integration

### DIFF
--- a/app/config/auth.conf.dist.php
+++ b/app/config/auth.conf.dist.php
@@ -99,9 +99,9 @@ $extldap_user_correspondance = array(
     'username' => 'uid',
     'language' => '!english',
     'password' => 'userPassword',
-    'status' => '!5', // Forcing status to 5; To change this set 'status' => 'func' abd implement $extldap_get_status($ldap_array)
-    'active' => '!1', // Forcing active to 1; To change this set 'status' => 'func' abd implement $extldap_get_active($ldap_array)
-    'admin' => 'func' // Using $extldap_get_admin function to check if user is an administrator based on some ldap user record value
+    'status' => '!5', // Forcing status to 5; To change this set 'status' => 'func' and implement an extldap_get_status($ldap_array) function
+    'active' => '!1', // Forcing active to 1; To change this set 'status' => 'func' and implement an extldap_get_active($ldap_array) function
+    'admin' => 'func' // Using the extldap_get_admin() function to check if user is an administrator based on some ldap user record value
     /* Extras example
     'extra' => array(
         'title' => 'title',
@@ -114,7 +114,7 @@ $extldap_user_correspondance = array(
 );
 
 /**
- * Example Method, please implement your logic inside
+ * Example method to get whether the user is an admin or not. Please implement your logic inside.
  */
 function extldap_get_admin($ldap_array)
 {

--- a/app/config/auth.conf.dist.php
+++ b/app/config/auth.conf.dist.php
@@ -88,7 +88,7 @@ $extldap_config = array(
  *
  * If <ldap_field> is an array then its value will be an array of values with the same rules as above
  *
- * Please Note that Chamilo expects some attributes that maight not be present in your user ldap record
+ * Please Note that Chamilo expects some attributes that might not be present in your user ldap record
  *
  **/
 $extldap_user_correspondance = array(

--- a/app/config/auth.conf.dist.php
+++ b/app/config/auth.conf.dist.php
@@ -48,20 +48,26 @@ $extldap_config = array(
   //ldap host
   'host' => array('1.2.3.4', '2.3.4.5', '3.4.5.6'),
   // filter
-//  'filter' => '', // no () arround the string
+  'filter' => '', // no () arround the string
   //'port' => , default on 389
+  'port' => 389,
   //protocl version (2 or 3)
   'protocol_version' => 3,
   // set this to 0 to connect to AD server
   'referrals' => 0,
   //String used to search the user in ldap. %username will ber replaced by the username.
   //See extldap_get_user_search_string() function below
-//  'user_search' => 'sAMAccountName=%username%',  // no () arround the string
-  'user_search' => 'uid=%username%',  // no () arround the string
+  // For Active Directory: 'user_search' => 'sAMAccountName=%username%',  // no () arround the string
+  // For OpenLDAP: 'user_search' => 'uid=%username%',  // no () arround the string
+  'user_search' => 'uid=%username%',
   //encoding used in ldap (most common are UTF-8 and ISO-8859-1
   'encoding' => 'UTF-8',
   //Set to true if user info have to be update at each login
-  'update_userinfo' => true
+  'update_userinfo' => true,
+  // Define user_search_import_all_users variable to control main/auth/external_login/ldap.inc.php
+  // Active Directory: 'user_search_import_all_users' => 'sAMAccountName=$char1$char2*'
+  // OpenLDAP: 'user_search_import_all_users' => 'uid=*'
+  'user_search_import_all_users' => 'uid=*'
 );
 
 
@@ -82,17 +88,21 @@ $extldap_config = array(
  *
  * If <ldap_field> is an array then its value will be an array of values with the same rules as above
  *
+ * Please Note that Chamilo expects some attributes that maight not be present in your user ldap record
+ *
  **/
 $extldap_user_correspondance = array(
     'firstname' => 'givenName',
     'lastname' => 'sn',
-    'status' => 'func',
-    'admin' => 'func',
     'email' => 'mail',
     'auth_source' => '!extldap',
-    //'username' => ,
+    'username' => 'uid',
     'language' => '!english',
-    'password' => '!PLACEHOLDER',
+    'password' => 'userPassword',
+    'status' => '!5', // Forcing status to 5; To change this set 'status' => 'func' abd implement $extldap_get_status($ldap_array)
+    'active' => '!1', // Forcing active to 1; To change this set 'status' => 'func' abd implement $extldap_get_active($ldap_array)
+    'admin' => 'func' // Using $extldap_get_admin function to check if user is an administrator based on some ldap user record value
+    /* Extras example
     'extra' => array(
         'title' => 'title',
         'globalid' => 'employeeID',
@@ -100,8 +110,16 @@ $extldap_user_correspondance = array(
         'country' => 'co',
         'bu' => 'Company',
         'cas_user' => 'uid',
-    )
+    ) */
 );
+
+/**
+ * Example Method, please implement your logic inside
+ */
+function extldap_get_admin($ldap_array)
+{
+    return 0; // By default users comming from ldap are not Administrators
+}
 
 /**
  * OpenID

--- a/main/auth/external_login/ldap.inc.php
+++ b/main/auth/external_login/ldap.inc.php
@@ -315,8 +315,7 @@ function extldap_import_all_users()
     }
     foreach ($alphanum as $char1) {
         foreach ($alphanum as $char2) {
-            //$user_search = "uid=*";
-            $user_search = "sAMAccountName=$char1$char2*";
+            $user_search = $extldap_config['user_search_import_all_users'];
             //Search distinguish name of user
             $sr = ldap_search($ds, $extldap_config['base_dn'], $user_search);
             if (!$sr) {

--- a/main/auth/external_login/login.ldap.php
+++ b/main/auth/external_login/login.ldap.php
@@ -57,7 +57,7 @@ if ($ldap_user !== false) {
         error_log("chamilo_user found user_id: {$uData['user_id']}");
     }
 
-    //U pdate user info
+    //Update user info
     if (isset($extldap_config['update_userinfo']) && $extldap_config['update_userinfo']) {
         external_update_user($chamilo_user);
         if ($debug) {

--- a/main/auth/external_login/login.ldap.php
+++ b/main/auth/external_login/login.ldap.php
@@ -5,7 +5,7 @@
 use ChamiloSession as Session;
 
 /**
- * This file is included in main/inc/local.inc.php at user login if the user have 'external_ldap' in
+ * This file is included in main/inc/local.inc.php at user login if the user have 'extldap' in
  * his auth_source field instead of platform.
  *
  * Variables that can be used :


### PR DESCRIPTION
Minor comment space fixed

Added some extra comments and some default values to help admins configure external LDAP user authentication. Some values are forced to just make it work (OpenLDAP). An empty function is provided as an example to ease implementation.

A new config param added to $extldap_config array so main/auth/external_login/ldap.inc.php behavior can be parametriced , an alternative would be to use the value set in user_search config param in app/config/auth.conf.php $extldap_config = array to assign this value , sadly I dont have experience in PHP development, help is welcome ;-)

Min change in the comment, former value 'external_ldap' confused me, so changed it to match the example in app/config/auth.config.php $extldap_user_correspondance array.