### PR TITLE
Doodle : Set utc time at save's moment of end and start date

### DIFF
--- a/main/survey/create_meeting.php
+++ b/main/survey/create_meeting.php
@@ -120,10 +120,12 @@ if ($form->validate()) {
     $values['survey_code'] = SurveyManager::generateSurveyCode($values['survey_title']);
     // see #3499
     if (isset($values['end_date'])) {
-        $values['end_date'] = api_get_utc_datetime($values['end_date'], true);
+        $temp = new DateTime(api_get_utc_datetime($values['end_date']));
+        $values['end_date'] = $temp->format('Y-m-d H:i');
     }
     if (isset($values['start_date'])) {
-        $values['start_date'] = api_get_utc_datetime($values['start_date'], true);
+        $temp = new DateTime(api_get_utc_datetime($values['start_date']));
+        $values['start_date'] = $temp->format('Y-m-d H:i');
     }
     // Storing the survey
     $surveyData = SurveyManager::store_survey($values);

--- a/main/survey/create_meeting.php
+++ b/main/survey/create_meeting.php
@@ -82,14 +82,14 @@ for ($i = 1; $i <= $maxEvents; $i++) {
 $form->addHtml('<script>
 $(function() {
     '.$hideList.'
-    var number = 3;    
+    var number = 3;
     $("#add_button").on("click", function() {
         number++;
         $("#time_" + number + "_date_time_wrapper").show();
     });
-    
+
     $("#remove_button").on("click", function() {
-        if (number > 1) {            
+        if (number > 1) {
             $("#time_" + number + "_date_time_wrapper").hide();
             number--;
         }
@@ -118,15 +118,6 @@ if ($form->validate()) {
     // Exporting the values
     $values = $form->getSubmitValues();
     $values['survey_code'] = SurveyManager::generateSurveyCode($values['survey_title']);
-    // see #3499
-    if (isset($values['end_date'])) {
-        $temp = new DateTime(api_get_utc_datetime($values['end_date']));
-        $values['end_date'] = $temp->format('Y-m-d H:i');
-    }
-    if (isset($values['start_date'])) {
-        $temp = new DateTime(api_get_utc_datetime($values['start_date']));
-        $values['start_date'] = $temp->format('Y-m-d H:i');
-    }
     // Storing the survey
     $surveyData = SurveyManager::store_survey($values);
 

--- a/main/survey/create_meeting.php
+++ b/main/survey/create_meeting.php
@@ -118,6 +118,13 @@ if ($form->validate()) {
     // Exporting the values
     $values = $form->getSubmitValues();
     $values['survey_code'] = SurveyManager::generateSurveyCode($values['survey_title']);
+    // see #3499
+    if (isset($values['end_date'])) {
+        $values['end_date'] = api_get_utc_datetime($values['end_date'], true);
+    }
+    if (isset($values['start_date'])) {
+        $values['start_date'] = api_get_utc_datetime($values['start_date'], true);
+    }
     // Storing the survey
     $surveyData = SurveyManager::store_survey($values);
 

--- a/main/survey/create_new_survey.php
+++ b/main/survey/create_new_survey.php
@@ -360,6 +360,13 @@ $form->setDefaults($defaults);
 if ($form->validate()) {
     // Exporting the values
     $values = $form->getSubmitValues();
+    // see #3499
+    if (isset($values['end_date'])) {
+        $values['end_date'] = api_get_utc_datetime($values['end_date'], true);
+    }
+    if (isset($values['start_date'])) {
+        $values['start_date'] = api_get_utc_datetime($values['start_date'], true);
+    }
     // Storing the survey
     $return = SurveyManager::store_survey($values);
     Skill::saveSkills($form, ITEM_TYPE_SURVEY, $return['id']);

--- a/main/survey/create_new_survey.php
+++ b/main/survey/create_new_survey.php
@@ -73,8 +73,8 @@ if ($action == 'edit' && isset($survey_id) && is_numeric($survey_id)) {
     $defaults['anonymous'] = $survey_data['anonymous'];
 
     if ($allowSurveyAvailabilityDatetime) {
-        $defaults['avail_from'] = api_get_local_time($defaults['avail_from'], null, 'UTC');
-        $defaults['avail_till'] = api_get_local_time($defaults['avail_till'], null, 'UTC');
+        $defaults['avail_from'] = api_get_local_time($defaults['avail_from']);
+        $defaults['avail_till'] = api_get_local_time($defaults['avail_till']);
         $defaults['start_date'] = $defaults['avail_from'];
         $defaults['end_date'] = $defaults['avail_till'];
     }
@@ -360,15 +360,6 @@ $form->setDefaults($defaults);
 if ($form->validate()) {
     // Exporting the values
     $values = $form->getSubmitValues();
-    // see #3499
-    if (isset($values['end_date'])) {
-        $temp = new DateTime(api_get_utc_datetime($values['end_date']));
-        $values['end_date'] = $temp->format('Y-m-d H:i');
-    }
-    if (isset($values['start_date'])) {
-        $temp = new DateTime(api_get_utc_datetime($values['start_date']));
-        $values['start_date'] = $temp->format('Y-m-d H:i');
-    }
     // Storing the survey
     $return = SurveyManager::store_survey($values);
     Skill::saveSkills($form, ITEM_TYPE_SURVEY, $return['id']);

--- a/main/survey/create_new_survey.php
+++ b/main/survey/create_new_survey.php
@@ -362,10 +362,12 @@ if ($form->validate()) {
     $values = $form->getSubmitValues();
     // see #3499
     if (isset($values['end_date'])) {
-        $values['end_date'] = api_get_utc_datetime($values['end_date'], true);
+        $temp = new DateTime(api_get_utc_datetime($values['end_date']));
+        $values['end_date'] = $temp->format('Y-m-d H:i');
     }
     if (isset($values['start_date'])) {
-        $values['start_date'] = api_get_utc_datetime($values['start_date'], true);
+        $temp = new DateTime(api_get_utc_datetime($values['start_date']));
+        $values['start_date'] = $temp->format('Y-m-d H:i');
     }
     // Storing the survey
     $return = SurveyManager::store_survey($values);

--- a/main/survey/edit_meeting.php
+++ b/main/survey/edit_meeting.php
@@ -152,6 +152,13 @@ if ($form->validate()) {
 
     $values['survey_id'] = $surveyId;
     $values['survey_code'] = SurveyManager::generateSurveyCode($values['survey_title']);
+    // see #3499
+    if (isset($values['end_date'])) {
+        $values['end_date'] = api_get_utc_datetime($values['end_date'], true);
+    }
+    if (isset($values['start_date'])) {
+        $values['start_date'] = api_get_utc_datetime($values['start_date'], true);
+    }
     // Storing the survey
     SurveyManager::store_survey($values);
 

--- a/main/survey/edit_meeting.php
+++ b/main/survey/edit_meeting.php
@@ -154,10 +154,12 @@ if ($form->validate()) {
     $values['survey_code'] = SurveyManager::generateSurveyCode($values['survey_title']);
     // see #3499
     if (isset($values['end_date'])) {
-        $values['end_date'] = api_get_utc_datetime($values['end_date'], true);
+        $temp = new DateTime(api_get_utc_datetime($values['end_date']));
+        $values['end_date'] = $temp->format('Y-m-d H:i');
     }
     if (isset($values['start_date'])) {
-        $values['start_date'] = api_get_utc_datetime($values['start_date'], true);
+        $temp = new DateTime(api_get_utc_datetime($values['start_date']));
+        $values['start_date'] = $temp->format('Y-m-d H:i');
     }
     // Storing the survey
     SurveyManager::store_survey($values);

--- a/main/survey/edit_meeting.php
+++ b/main/survey/edit_meeting.php
@@ -107,7 +107,7 @@ for ($i = $currentQuestionsCount; $i <= $maxEvents; $i++) {
 $form->addHtml('<script>
 $(function() {
     '.$hideList.'
-    var number = "'.--$currentQuestionsCount.'";    
+    var number = "'.--$currentQuestionsCount.'";
     $("#add_button").on("click", function() {
         number++;
         $("#time_" + number + "_date_time_wrapper").show();
@@ -115,15 +115,15 @@ $(function() {
         $("#time_" + number + "_time_range_end").val("");
         $("#time_" + number + "_alt").val("");
     });
-    
+
     $("#remove_button").on("click", function() {
-        if (number > 1) {      
+        if (number > 1) {
             console.log("#time_" + number + "_time_range_start");
             $("#time_" + number + "_date_time_wrapper").hide();
             $("#time_" + number).val("delete");
-            
+
             $("#time_" + number + "_alt").val("delete");
-            $("#time_" + number + "_time_range_start").val("delete");                        
+            $("#time_" + number + "_time_range_start").val("delete");
             number--;
         }
     });
@@ -152,15 +152,6 @@ if ($form->validate()) {
 
     $values['survey_id'] = $surveyId;
     $values['survey_code'] = SurveyManager::generateSurveyCode($values['survey_title']);
-    // see #3499
-    if (isset($values['end_date'])) {
-        $temp = new DateTime(api_get_utc_datetime($values['end_date']));
-        $values['end_date'] = $temp->format('Y-m-d H:i');
-    }
-    if (isset($values['start_date'])) {
-        $temp = new DateTime(api_get_utc_datetime($values['start_date']));
-        $values['start_date'] = $temp->format('Y-m-d H:i');
-    }
     // Storing the survey
     SurveyManager::store_survey($values);
 

--- a/main/survey/edit_meeting.php
+++ b/main/survey/edit_meeting.php
@@ -142,7 +142,8 @@ $form->addLabel(
 );
 
 $form->addButtonUpdate(get_lang('Edit'), 'submit_survey');
-
+$surveyData['start_date'] = api_get_local_time($surveyData['start_date']);
+$surveyData['end_date'] = api_get_local_time($surveyData['end_date']);
 $form->setDefaults($surveyData);
 
 // The validation or display

--- a/main/survey/surveyUtil.class.php
+++ b/main/survey/surveyUtil.class.php
@@ -3423,7 +3423,6 @@ class SurveyUtil
             $array[5] = '';
 
             if (!empty($survey[5]) && $survey[5] !== '0000-00-00' && $survey[5] !== '0000-00-00 00:00:00') {
-                $survey[5] = api_get_local_time($survey[5]);
                 $array[5] = api_convert_and_format_date(
                     $survey[5],
                     $allowSurveyAvailabilityDatetime ? DATE_TIME_FORMAT_LONG : DATE_FORMAT_LONG
@@ -3432,7 +3431,6 @@ class SurveyUtil
 
             $array[6] = '';
             if (!empty($survey[6]) && $survey[6] !== '0000-00-00' && $survey[6] !== '0000-00-00 00:00:00') {
-                $survey[6] = api_get_local_time($survey[6]);
                 $array[6] = api_convert_and_format_date(
                     $survey[6],
                     $allowSurveyAvailabilityDatetime ? DATE_TIME_FORMAT_LONG : DATE_FORMAT_LONG

--- a/main/survey/surveyUtil.class.php
+++ b/main/survey/surveyUtil.class.php
@@ -3423,6 +3423,7 @@ class SurveyUtil
             $array[5] = '';
 
             if (!empty($survey[5]) && $survey[5] !== '0000-00-00' && $survey[5] !== '0000-00-00 00:00:00') {
+                $survey[5] = api_get_local_time($survey[5]);
                 $array[5] = api_convert_and_format_date(
                     $survey[5],
                     $allowSurveyAvailabilityDatetime ? DATE_TIME_FORMAT_LONG : DATE_FORMAT_LONG
@@ -3431,6 +3432,7 @@ class SurveyUtil
 
             $array[6] = '';
             if (!empty($survey[6]) && $survey[6] !== '0000-00-00' && $survey[6] !== '0000-00-00 00:00:00') {
+                $survey[6] = api_get_local_time($survey[6]);
                 $array[6] = api_convert_and_format_date(
                     $survey[6],
                     $allowSurveyAvailabilityDatetime ? DATE_TIME_FORMAT_LONG : DATE_FORMAT_LONG


### PR DESCRIPTION
In the course surveys, it is saved in local time instead of utc time. For this reason, the value of start_date and end_date is changed to adjust the utc time in Y-m-d H: i format since with seconds it saves null in the fields avail_from, avail_till of c_survey

