### PR TITLE
Quiz: Replace [...] for select typo - refs #3485

### DIFF
--- a/main/exercise/fill_blanks.class.php
+++ b/main/exercise/fill_blanks.class.php
@@ -63,40 +63,40 @@ class FillBlanks extends Question
             }
         }
 
-        echo '<script>            
-            var firstTime = true;            
-            var originalOrder = new Array();   
+        echo '<script>
+            var firstTime = true;
+            var originalOrder = new Array();
             var blankSeparatorStart = "'.$blankSeparatorStart.'";
             var blankSeparatorEnd = "'.$blankSeparatorEnd.'";
             var blankSeparatorStartRegexp = getBlankSeparatorRegexp(blankSeparatorStart);
             var blankSeparatorEndRegexp = getBlankSeparatorRegexp(blankSeparatorEnd);
             var blanksRegexp = "/"+blankSeparatorStartRegexp+"[^"+blankSeparatorStartRegexp+"]*"+blankSeparatorEndRegexp+"/g";
-            
+
             CKEDITOR.on("instanceCreated", function(e) {
-                if (e.editor.name === "answer") {                  
+                if (e.editor.name === "answer") {
                     //e.editor.on("change", updateBlanks);
                     e.editor.on("change", function(){
                         updateBlanks();
                     });
                 }
             });
-            
+
             function updateBlanks()
-            {                
-                var answer;                
+            {
+                var answer;
                 if (firstTime) {
                     var field = document.getElementById("answer");
                     answer = field.value;
                 } else {
                     answer = CKEDITOR.instances["answer"].getData();
                 }
-                
+
                 // disable the save button, if not blanks have been created
                 $("button").attr("disabled", "disabled");
-                $("#defineoneblank").show();      
-                
-                var blanks = answer.match(eval(blanksRegexp));             
-                var fields = "<div class=\"form-group \">";                
+                $("#defineoneblank").show();
+
+                var blanks = answer.match(eval(blanksRegexp));
+                var fields = "<div class=\"form-group \">";
                 fields += "<label class=\"col-sm-2 control-label\"></label>";
                 fields += "<div class=\"col-sm-8\">";
                 fields += "<table class=\"data_table\">";
@@ -107,34 +107,34 @@ class FillBlanks extends Question
                 if (blanks != null) {
                     for (var i=0; i < blanks.length; i++) {
                         // remove forbidden characters that causes bugs
-                        blanks[i] = removeForbiddenChars(blanks[i]);                        
+                        blanks[i] = removeForbiddenChars(blanks[i]);
                         // trim blanks between brackets
                         blanks[i] = trimBlanksBetweenSeparator(blanks[i], blankSeparatorStart, blankSeparatorEnd);
-                        
+
                         // if the word is empty []
                         if (blanks[i] == blankSeparatorStartRegexp+blankSeparatorEndRegexp) {
                             break;
                         }
-                        
+
                         // get input size
-                        var inputSize = 100;                        
+                        var inputSize = 100;
                         var textValue = blanks[i].substr(1, blanks[i].length - 2);
                         var btoaValue = textValue.hashCode();
-                                                                      
+
                         if (firstTime == false) {
-                            var element = document.getElementById("samplesize["+i+"]");                                
+                            var element = document.getElementById("samplesize["+i+"]");
                             if (element) {
-                                inputSize = document.getElementById("sizeofinput["+i+"]").value;                                
+                                inputSize = document.getElementById("sizeofinput["+i+"]").value;
                             }
-                        }                                                                    
+                        }
 
                         if (document.getElementById("weighting["+i+"]")) {
                             var value = document.getElementById("weighting["+i+"]").value;
                         } else {
-                            var value = "1";    
-                        }                
+                            var value = "1";
+                        }
                         var blanksWithColor = trimBlanksBetweenSeparator(blanks[i], blankSeparatorStart, blankSeparatorEnd, 1);
-                        
+
                         fields += "<tr>";
                         fields += "<td>"+blanksWithColor+"</td>";
                         fields += "<td><input class=\"form-control\" style=\"width:60px\" value=\""+value+"\" type=\"text\" id=\"weighting["+i+"]\" name=\"weighting["+i+"]\" /></td>";
@@ -145,31 +145,31 @@ class FillBlanks extends Question
                         fields += "<input id=\"sizeofinput["+i+"]\" type=\"hidden\" value=\""+inputSize+"\" name=\"sizeofinput["+i+"]\"  />";
                         fields += "</td>";
                         fields += "</tr>";
-                        
+
                         // enable the save button
                         $("button").removeAttr("disabled");
                         $("#defineoneblank").hide();
                     }
-                }                         
-                
+                }
+
                 document.getElementById("blanks_weighting").innerHTML = fields + "</table></div></div>";
-                
+
                 $(originalOrder).each(function(i, data) {
                      if (firstTime == false) {
-                        value = data.value;                        
-                        var d = $("input.sample[data-btoa=\'"+value+"\']");                        
-                        var id = d.attr("id");   
+                        value = data.value;
+                        var d = $("input.sample[data-btoa=\'"+value+"\']");
+                        var id = d.attr("id");
                         if (id) {
-                            var sizeInputId = id.replace("samplesize", "sizeofinput");                            
+                            var sizeInputId = id.replace("samplesize", "sizeofinput");
                             var sizeInputId = sizeInputId.replace("[", "\\\[");
-                            var sizeInputId = sizeInputId.replace("]", "\\\]");                                                         
-                            $("#"+sizeInputId).val(data.width);                        
+                            var sizeInputId = sizeInputId.replace("]", "\\\]");
+                            $("#"+sizeInputId).val(data.width);
                             d.outerWidth(data.width+"px");
                         }
                     }
                 });
-                
-                updateOrder(blanks);               
+
+                updateOrder(blanks);
 
                 if (firstTime) {
                     firstTime = false;
@@ -177,7 +177,7 @@ class FillBlanks extends Question
                 }
             }
 
-            window.onload = updateBlanks;            
+            window.onload = updateBlanks;
             String.prototype.hashCode = function() {
                 var hash = 0, i, chr, len;
                 if (this.length === 0) return hash;
@@ -188,35 +188,35 @@ class FillBlanks extends Question
                 }
                 return hash;
             };
-            
-            function updateOrder(blanks) 
+
+            function updateOrder(blanks)
             {
-                originalOrder = new Array();                
+                originalOrder = new Array();
                  if (blanks != null) {
                     for (var i=0; i < blanks.length; i++) {
                         // remove forbidden characters that causes bugs
-                        blanks[i] = removeForbiddenChars(blanks[i]);                        
+                        blanks[i] = removeForbiddenChars(blanks[i]);
                         // trim blanks between brackets
                         blanks[i] = trimBlanksBetweenSeparator(blanks[i], blankSeparatorStart, blankSeparatorEnd);
-                        
+
                         // if the word is empty []
                         if (blanks[i] == blankSeparatorStartRegexp+blankSeparatorEndRegexp) {
                             break;
-                        }                        
+                        }
                         var textValue = blanks[i].substr(1, blanks[i].length - 2);
                         var btoaValue = textValue.hashCode();
-                        
+
                         if (firstTime == false) {
-                            var element = document.getElementById("samplesize["+i+"]");                                
+                            var element = document.getElementById("samplesize["+i+"]");
                             if (element) {
                                 inputSize = document.getElementById("sizeofinput["+i+"]").value;
-                                originalOrder.push({ "width" : inputSize, "value": btoaValue });                                                                               
+                                originalOrder.push({ "width" : inputSize, "value": btoaValue });
                             }
                         }
                     }
                 }
             }
-            
+
             function changeInputSize(coef, inIdNum)
             {
                 if (firstTime) {
@@ -225,7 +225,7 @@ class FillBlanks extends Question
                 } else {
                     answer = CKEDITOR.instances["answer"].getData();
                 }
-                
+
                 var blanks = answer.match(eval(blanksRegexp));
                 var currentWidth = $("#samplesize\\\["+inIdNum+"\\\]").width();
                 var newWidth = currentWidth + coef * 20;
@@ -233,7 +233,7 @@ class FillBlanks extends Question
                 newWidth = Math.min(newWidth, 600);
                 $("#samplesize\\\["+inIdNum+"\\\]").outerWidth(newWidth);
                 $("#sizeofinput\\\["+inIdNum+"\\\]").attr("value", newWidth);
-                
+
                 updateOrder(blanks);
             }
 
@@ -247,12 +247,17 @@ class FillBlanks extends Question
                 outTxt = outTxt.replace(/&nbsp;/g, " ");
                 outTxt = outTxt.replace(/^ +/, "");
                 outTxt = outTxt.replace(/ +$/, "");
-                
+
                 return outTxt;
             }
 
             function changeBlankSeparator()
             {
+                /* get current select blank type and replaced into #defineoneblank */
+                var definedSeparator = $("[name=select_separator] option:selected").text();
+                $("[name=select_separator] option").each(function (index, value) {
+                    $("#defineoneblank").html($("#defineoneblank").html().replace($(value).html(), definedSeparator))
+                });
                 var separatorNumber = $("#select_separator").val();
                 var tabSeparator = getSeparatorFromNumber(separatorNumber);
                 blankSeparatorStart = tabSeparator[0];
@@ -298,11 +303,11 @@ class FillBlanks extends Question
                 result = result.replace(inSeparatorStart, "");
                 result = result.replace(inSeparatorEnd, "");
                 result = result.trim();
-                
+
                 if (addColor == 1) {
                     var resultParts = result.split("|");
-                    var partsToString = "";                    
-                    resultParts.forEach(function(item, index) {                        
+                    var partsToString = "";
+                    resultParts.forEach(function(item, index) {
                         if (index == 0) {
                             item = "<b><font style=\"color:green\"> " + item +"</font></b>";
                         }
@@ -313,10 +318,10 @@ class FillBlanks extends Question
                     });
                     result = partsToString;
                 }
-                
+
                 return inSeparatorStart+result+inSeparatorEnd;
             }
-            
+
         </script>';
 
         // answer
@@ -887,15 +892,15 @@ class FillBlanks extends Question
         // we got the less recent attempt first
         $sql = 'SELECT * FROM '.$tblTrackEAttempt.' tea
                 LEFT JOIN '.$tblTrackEExercise.' tee
-                ON 
-                    tee.exe_id = tea.exe_id AND 
-                    tea.c_id = '.$courseId.' AND 
-                    exe_exo_id = '.$testId.'    
-               WHERE 
-                    tee.c_id = '.$courseId.' AND 
-                    question_id = '.$questionId.' AND 
-                    tea.user_id IN ('.implode(',', $studentsIdList).')  AND 
-                    tea.tms >= "'.$startDate.'" AND 
+                ON
+                    tee.exe_id = tea.exe_id AND
+                    tea.c_id = '.$courseId.' AND
+                    exe_exo_id = '.$testId.'
+               WHERE
+                    tee.c_id = '.$courseId.' AND
+                    question_id = '.$questionId.' AND
+                    tea.user_id IN ('.implode(',', $studentsIdList).')  AND
+                    tea.tms >= "'.$startDate.'" AND
                     tea.tms <= "'.$endDate.'"
                ORDER BY user_id, tea.exe_id;
         ';
@@ -1254,8 +1259,8 @@ class FillBlanks extends Question
         }
 
         if ($hideExpectedAnswer) {
-            $correctAnswerHtml = "<span 
-                class='feedback-green' 
+            $correctAnswerHtml = "<span
+                class='feedback-green'
                 title='".get_lang('ExerciseWithFeedbackWithoutCorrectionComment')."'> &#8212; </span>";
         }
 


### PR DESCRIPTION
En una pregunta abierta, con separador en blanco para exámenes, aparece un mensaje rojo cuando no se detecta  el marcador para espacios en blanco. Esta definido por la variable de idioma ***$DefineBlanks***

Este cambio hace que [...] se modifique a {...} o cualquier otro que se seleccione, siendo un ajuste al momento de cambiarse el marcador, pasaría de [...] como la imagen

![image](https://user-images.githubusercontent.com/18097392/93260360-e477c200-f766-11ea-94f7-01671b8512b0.png)

y se modifica a {...}

![image](https://user-images.githubusercontent.com/18097392/93260415-f8bbbf00-f766-11ea-94b6-31da39593311.png)

Sin embargo seria conveniente que la variable ***$DefineBlanks*** no contenga la palabra ***" corchetes"*** para que sea mas coherente con el contenido