### PR TITLE
Documentation: corrected link for each language of the manual

### DIFF
--- a/documentation/index.html
+++ b/documentation/index.html
@@ -54,13 +54,13 @@
             <h2>User guides</h2>
             <ul>
                 <li>
-                    <a href="https://docs.chamilo.org/en/">English manuals for teachers, admins and developers</a>
+                    <a href="https://docs.chamilo.org/">English manuals for teachers, admins and developers</a>
                 </li>
                 <li>
-                    <a href="https://docs.chamilo.org/es/">Guías para profesores, para administradores y para desarrolladores en español</a>
+                    <a href="https://docs.chamilo.org/v/1.11.x-es">Guías para profesores, para administradores y para desarrolladores en español</a>
                 </li>
                 <li>
-                    <a href="https://docs.chamilo.org/fr/">Guides pour professeurs/tuteurs et pour administrateurs en français</a>
+                    <a href="https://docs.chamilo.org/v/1.11.x-fr">Guides pour professeurs/tuteurs et pour administrateurs en français</a>
                 </li>
                 <li>
                     <a href="https://chamilo.org/forum">Chamilo Forum</a>


### PR DESCRIPTION
Actualmente, el index envia a https://docs.chamilo.org/es/ la cual es "pagina no encontrada", por lo tanto es cambiado a https://docs.chamilo.org/v/1.11.x-es.  Sucede lo mismo para el idioma francés.

En cuanto al inglés no existe pagina para en. sin embargo, https://docs.chamilo.org/ como inicio e en ingles para la version 1.11