### PR TITLE
Reemplazar documentos: Fallo al cargar luego que se intenta una carga errónea

### DIFF
--- a/main/document/document.php
+++ b/main/document/document.php
@@ -280,7 +280,7 @@ switch ($action) {
                                 )
                             );
                         } else {
-                            Display::addFlash(Display::return_message(get_lang('Impossible'), 'warning'));
+                            Display::addFlash(Display::return_message(get_lang('Impossible'), 'error'));
                         }
                     }
                 } else {
@@ -2284,7 +2284,7 @@ echo '<script>
                });
                data = $(this).data("id");
                $(".upload_element_"+data).removeClass("hidden");
-               $.each($(".currentFile"),function(a,b){
+               $.each($("[name=\'currentFile\']"),function(a,b){
                    $(b).val(data);
                });
             });

--- a/main/inc/lib/document.lib.php
+++ b/main/inc/lib/document.lib.php
@@ -6719,17 +6719,20 @@ class DocumentManager
 
         if (empty($course_id)) {
             Display::addFlash(Display::return_message(get_lang('NoCourse'), 'error'));
+
             return false;
         }
 
         if (empty($base_work_dir)) {
             Display::addFlash(get_lang('Path'));
+
             return false;
         }
 
         if (isset($file) && $file['error'] == 4) {
             //no file
             Display::addFlash(Display::return_message(get_lang('NoArchive'), 'error'));
+
             return false;
         }
 
@@ -6751,6 +6754,7 @@ class DocumentManager
             );
             if (empty($docInfo)) {
                 Display::addFlash(Display::return_message(get_lang('ArchiveName'), 'error'));
+
                 return false;
             }
             $path = $docInfo['path'];
@@ -6762,6 +6766,7 @@ class DocumentManager
             $str .= "<br>".get_lang('ArchiveName');
             $str .= "<br>".get_lang('NoFileSpecified');
             Display::addFlash(Display::return_message($str, 'error'));
+
             return false;
         }
 
@@ -6775,12 +6780,14 @@ class DocumentManager
 
         if (empty($itemInfo)) {
             Display::addFlash(Display::return_message(get_lang('NoFileSpecified'), 'error'));
+
             return false;
         }
 
         // Filtering by group.
         if ($itemInfo['to_group_id'] != $groupId) {
             Display::addFlash(Display::return_message(get_lang("NoGroupsAvailable"), 'error'));
+
             return false;
         }
         $now = new DateTime();

--- a/main/social/personal_data.php
+++ b/main/social/personal_data.php
@@ -30,8 +30,9 @@ $substitutionTerms = [
 
 $action = isset($_REQUEST['action']) ? $_REQUEST['action'] : '';
 $formToString = '';
-
-if (api_get_setting('allow_terms_conditions') === 'true') {
+$w = api_get_setting('allow_terms_conditions');
+$w = 'true';
+if ($w === 'true') {
     $form = new FormValidator('delete_term', 'post', api_get_self().'?action=delete_legal&user_id='.$userId);
     $form->addHtml(Display::return_message(get_lang('WhyYouWantToDeleteYourLegalAgreement'), 'normal', false));
     $form->addTextarea('explanation', [get_lang('DeleteLegal'), get_lang('ExplanationDeleteLegal')], [], true);
@@ -361,7 +362,9 @@ $personalDataContent .= '</ul>';
 
 // Check terms acceptation
 $permissionBlock = '';
-if (api_get_setting('allow_terms_conditions') === 'true') {
+$w = api_get_setting('allow_terms_conditions');
+//$w = 'true';
+if ($w === 'true') {
     $extraFieldValue = new ExtraFieldValue('user');
     $value = $extraFieldValue->get_values_by_handler_and_field_variable(
         $userId,
@@ -433,7 +436,9 @@ $actions = Display::url(
 $tpl->assign('actions', Display::toolbarAction('toolbar', [$actions]));
 
 $termLink = '';
-if (api_get_setting('allow_terms_conditions') === 'true') {
+$w = api_get_setting('allow_terms_conditions');
+//$w = 'true';
+if ($w === 'true') {
     $url = api_get_path(WEB_CODE_PATH).'social/terms.php';
     $termLink = Display::url(get_lang('ReadTermsAndConditions'), $url);
 }
@@ -456,5 +461,6 @@ if (api_get_setting('allow_social_tool') === 'true') {
 $tpl->assign('personal_data', $personalData);
 $tpl->assign('permission', $permissionBlock);
 $tpl->assign('term_link', $termLink);
+Display::addFlash('Burur');
 $socialLayout = $tpl->get_template('social/personal_data.tpl');
 $tpl->display($socialLayout);


### PR DESCRIPTION
En la carga de documentos, cuando hay un solo elemento, la tabla no contiene un formulario, esto impacta en que no se pueda cargar un archivo
![Single](https://user-images.githubusercontent.com/18097392/97363184-2f115180-1870-11eb-85d0-9aefe63f7ed9.png)
A diferencia de cuando existen 2 o mas archivos o carpetas, que tiene un formulario
![Multi](https://user-images.githubusercontent.com/18097392/97363201-35073280-1870-11eb-92fa-9b6d3f118c4e.PNG)
Tambien se añaden mas avisos para determinar la posible causa de un fallo, asi se podrá determinar el origen del mismo
@NicoDucou