### PR TITLE
Reemplazar documentos: Fallo al cargar luego que se intenta una carga errónea #3588

### DIFF
--- a/main/document/document.php
+++ b/main/document/document.php
@@ -280,7 +280,7 @@ switch ($action) {
                                 )
                             );
                         } else {
-                            Display::addFlash(Display::return_message(get_lang('Impossible'), 'warning'));
+                            Display::addFlash(Display::return_message(get_lang('Impossible'), 'error'));
                         }
                     }
                 } else {
@@ -1808,7 +1808,7 @@ if ($isAllowedToEdit ||
         );
     } else {
         $actionsLeft .= Display::url(
-            Display::return_icon('upload_file.png', get_lang('UplUploadDocument'), '', ICON_SIZE_MEDIUM),
+            Display::return_icon('upload_file.png', get_lang('FileToUpload'), '', ICON_SIZE_MEDIUM),
             api_get_path(WEB_CODE_PATH).'document/upload.php?'.api_get_cidreq().'&id='.$current_folder_id
         );
     }
@@ -2284,7 +2284,7 @@ echo '<script>
                });
                data = $(this).data("id");
                $(".upload_element_"+data).removeClass("hidden");
-               $.each($(".currentFile"),function(a,b){
+               $.each($("[name=\'currentFile\']"),function(a,b){
                    $(b).val(data);
                });
             });

--- a/main/inc/lib/document.lib.php
+++ b/main/inc/lib/document.lib.php
@@ -5683,40 +5683,26 @@ class DocumentManager
                     'class' => 'removeHiddenFile',
                 ]
             );
-            $html = "
-            <div class='replaceIndividualFile upload_element_".$randomUploadName." hidden'>
-                <div class='form-group ' id='file_file'>
-                    <label class='col-sm-2 control-label' for='file_".$randomUploadName."'>
-                        ".get_lang('File')."
-                    </label>
-                    <div class='col-sm-8'>
-                        <input class='' name='file_".$randomUploadName."' style='width: 250px' type='file'>
-                    </div>
-                    <div class='col-sm-2'></div>
-                </div>
-                <div class='form-group '>
-                    <label class='col-sm-2 control-label' for='upload_".$randomUploadName."_submitDocument'>
+            $form = new FormValidator(
+                'upload',
+                'POST',
+                api_get_self().'?'.api_get_cidreq(),
+                '',
+                ['enctype' => 'multipart/form-data']
+            );
+            $form->addElement('html', "<div class='replaceIndividualFile upload_element_".$randomUploadName." hidden'>");
+            $form->addElement('hidden', 'id_'.$randomUploadName, $randomUploadName);
+            $form->addElement('hidden', 'currentFile', $randomUploadName);
+            $form->addElement('hidden', 'currentUrl', api_get_self().'?'.api_get_cidreq().'&id='.$document_id);
+            $form->addElement('hidden', 'id_'.$randomUploadName, $document_id);
+            $label = '';
+            $form->addElement('file', 'file_'.$randomUploadName, [get_lang('File'), $label], 'style="width: 250px" id="user_upload"');
+            $form->addButtonSend(get_lang('SendDocument'), 'submitDocument');
+            $form->addProgress('DocumentUpload', 'file');
+            $form->addElement('html', '</div>');
 
-                    </label>
-                    <div class='col-sm-8'>
+            $html = $form->returnForm();
 
-                        <button class=' btn btn-primary ' id='upload_".$randomUploadName."_submitDocument'
-                        name='submitDocument'
-                                type='submit'>
-                                <em class='fa fa-paper-plane'></em> ".get_lang('ReplaceFile')."
-                        </button>
-                    </div>
-                    <div class='col-sm-2'></div>
-                </div>
-                <input class='currentFile' name='currentFile' type='hidden' >
-
-                <input id='upload_".$randomUploadName."__qf__upload_".$randomUploadName."' name='_qf__upload_".$randomUploadName."'
-                       type='hidden'
-                       value=''>
-                <input id='upload_".$randomUploadName."_id' name='id_$randomUploadName' type='hidden' value='$id'>
-                <input id='upload_".$randomUploadName."_MAX_FILE_SIZE' name='MAX_FILE_SIZE' type='hidden' value='".ini_get('upload_max_filesize')."'>
-            </div>
-            ";
             $modify_icons[] = $html;
         }
 
@@ -6732,15 +6718,21 @@ class DocumentManager
         $course_id = $_course['real_id'];
 
         if (empty($course_id)) {
+            Display::addFlash(Display::return_message(get_lang('NoCourse'), 'error'));
+
             return false;
         }
 
         if (empty($base_work_dir)) {
+            Display::addFlash(get_lang('Path'));
+
             return false;
         }
 
         if (isset($file) && $file['error'] == 4) {
             //no file
+            Display::addFlash(Display::return_message(get_lang('NoArchive'), 'error'));
+
             return false;
         }
 
@@ -6761,12 +6753,20 @@ class DocumentManager
                 $sessionId
             );
             if (empty($docInfo)) {
+                Display::addFlash(Display::return_message(get_lang('ArchiveName'), 'error'));
+
                 return false;
             }
             $path = $docInfo['path'];
         }
 
         if (empty($path) || empty($docInfo) || empty($documentId)) {
+            $str = '';
+            $str .= "<br>".get_lang('Path');
+            $str .= "<br>".get_lang('ArchiveName');
+            $str .= "<br>".get_lang('NoFileSpecified');
+            Display::addFlash(Display::return_message($str, 'error'));
+
             return false;
         }
 
@@ -6779,11 +6779,15 @@ class DocumentManager
         );
 
         if (empty($itemInfo)) {
+            Display::addFlash(Display::return_message(get_lang('NoFileSpecified'), 'error'));
+
             return false;
         }
 
         // Filtering by group.
         if ($itemInfo['to_group_id'] != $groupId) {
+            Display::addFlash(Display::return_message(get_lang("NoGroupsAvailable"), 'error'));
+
             return false;
         }
         $now = new DateTime();
@@ -6798,7 +6802,7 @@ class DocumentManager
         $originalMime = self::file_get_mime_type($base_work_dir.$path);
         $newMime = finfo_file(finfo_open(FILEINFO_MIME_TYPE), $file['tmp_name']);
         if ($originalMime != $newMime) {
-            Display::addFlash(Display::return_message(get_lang('FileError'), 'warning'));
+            Display::addFlash(Display::return_message(get_lang('FileError'), 'error'));
 
             return false;
         }
@@ -6810,6 +6814,7 @@ class DocumentManager
                     $file_renamed_from_disk = true;
                 } else {
                     // Couldn't rename - file permissions problem?
+                    Display::addFlash(Display::return_message(get_lang('ErrorImportingFile'), 'error'));
                     error_log(
                         __FILE__.' '.__LINE__.': Error renaming '.$base_work_dir.$path.' to '
                         .$base_work_dir.$new_path.'. This is probably due to file permissions',
@@ -6837,6 +6842,7 @@ class DocumentManager
         ) {
             return true;
         } else {
+            Display::addFlash(Display::return_message(get_lang('ErrorImportingFile'), 'warning'));
             //Something went wrong
             //The file or directory isn't there anymore (on the filesystem)
             // This means it has been removed externally. To prevent a


### PR DESCRIPTION
En la carga de documentos, cuando hay un solo elemento, la tabla no contiene un formulario, esto impacta en que no se pueda cargar un archivo
![Single](https://user-images.githubusercontent.com/18097392/97363184-2f115180-1870-11eb-85d0-9aefe63f7ed9.png)
A diferencia de cuando existen 2 o mas archivos o carpetas, que tiene un formulario

![Single](https://user-images.githubusercontent.com/18097392/97363201-35073280-1870-11eb-92fa-9b6d3f118c4e.PNG)
Tambien se añaden mas avisos para determinar la posible causa de un fallo, asi se podrá determinar el origen del mismo
@NicoDucou

El pr base esta aqui con la definicion https://github.com/chamilo/chamilo-lms/pull/3588/ para que este sea un pr sin un archivo extra