### PR TITLE
solución a problema del cierre de sala al finalizar la videoconferencia

### DIFF
--- a/plugin/bbb/lib/bbb.lib.php
+++ b/plugin/bbb/lib/bbb.lib.php
@@ -1230,11 +1230,13 @@ class bbb
 
         foreach ($roomList as $roomDB) {
             $roomId = $roomDB['id'];
-            Database::update(
-                $roomTable,
-                ['out_at' => api_get_utc_datetime(), 'close' => BBBPlugin::ROOM_CLOSE],
-                ['id = ? ' => $roomId]
-            );
+            if (!empty($roomId)) {
+                Database::update(
+                    $roomTable,
+                    ['out_at' => api_get_utc_datetime(), 'close' => BBBPlugin::ROOM_CLOSE],
+                    ['id = ? ' => $roomId]
+                );
+            }
         }
 
         // Close all meeting rooms with meeting ID

--- a/plugin/bbb/lib/bbb.lib.php
+++ b/plugin/bbb/lib/bbb.lib.php
@@ -1221,7 +1221,7 @@ class bbb
 
         // Update users with in_at y ou_at field equal
         $roomTable = Database::get_main_table('plugin_bbb_room');
-        $conditions['where'] = ['meeting_id=? AND in_at=out_at' => [$id]];
+        $conditions['where'] = ['meeting_id=? AND in_at=out_at AND close=?' => [$id, BBBPlugin::ROOM_OPEN]];
         $roomList = Database::select(
             '*',
             $roomTable,

--- a/plugin/bbb/listing.php
+++ b/plugin/bbb/listing.php
@@ -219,11 +219,13 @@ if ($conferenceManager) {
 
                                         if (!empty($roomData)) {
                                             $roomId = $roomData['id'];
-                                            Database::update(
-                                                $roomTable,
-                                                ['out_at' => api_get_utc_datetime()],
-                                                ['id = ? ' => $roomId]
-                                            );
+                                            if (!empty($roomId)) {
+                                                Database::update(
+                                                    $roomTable,
+                                                    ['out_at' => api_get_utc_datetime()],
+                                                    ['id = ? ' => $roomId]
+                                                );
+                                            }
                                         }
                                         $i++;
                                     }
@@ -246,11 +248,13 @@ if ($conferenceManager) {
 
                 if (!empty($roomData)) {
                     $roomId = $roomData['id'];
-                    Database::update(
-                        $roomTable,
-                        ['out_at' => api_get_utc_datetime(), 'close' => BBBPlugin::ROOM_CLOSE],
-                        ['id = ? ' => $roomId]
-                    );
+                    if (!empty($roomId)) {
+                        Database::update(
+                            $roomTable,
+                            ['out_at' => api_get_utc_datetime(), 'close' => BBBPlugin::ROOM_CLOSE],
+                            ['id = ? ' => $roomId]
+                        );
+                    }
                 }
 
                 $message = Display::return_message(
@@ -300,17 +304,19 @@ if ($conferenceManager) {
 
             $i = 0;
             foreach ($roomData as $item) {
-                $roomId = $roomData['id'];
-                if ($i == 0) {
-                    Database::update(
-                        $roomTable,
-                        ['out_at' => api_get_utc_datetime()],
-                        ['id = ? ' => $roomId]
-                    );
-                } else {
-                    Database::update($roomTable, ['close' => BBBPlugin::ROOM_CLOSE], ['id = ? ' => $roomId]);
+                $roomId = $item['id'];
+                if (!empty($roomId)) {
+                    if ($i == 0) {
+                        Database::update(
+                            $roomTable,
+                            ['out_at' => api_get_utc_datetime(), 'close' => BBBPlugin::ROOM_CLOSE],
+                            ['id = ? ' => $roomId]
+                        );
+                    } else {
+                        Database::update($roomTable, ['close' => BBBPlugin::ROOM_CLOSE], ['id = ? ' => $roomId]);
+                    }
+                    $i++;
                 }
-                $i++;
             }
 
             $message = Display::return_message(


### PR DESCRIPTION
Al finalizar la sesión de videoconferencia la función encargada del cierre del meeting, chequea en la tabla plugin_bbb_room por meetingId y por los que tienen la misma fecha de entrada y salida. Se ha añadido en el sql una variable más de control para que solo actualice aquellos registros que están marcados sin cerrar (BBBPlugin::ROOM_OPEN).
Este desarrollo está relacionado con la tarea #3552 