### PR TITLE
Document : Comment basename($document_to_move['path']) to prevent twice folde

### DIFF
--- a/main/document/document.php
+++ b/main/document/document.php
@@ -1165,7 +1165,7 @@ if ($isAllowedToEdit || $groupMemberWithUploadRights ||
                     DocumentManager::updateDbInfo(
                         'update',
                         $document_to_move['path'],
-                        $moveTo.'/'.basename($document_to_move['path'])
+                        $moveTo.'/' // .basename($document_to_move['path'])
                     );
 
                     // Update database item property

--- a/main/document/document.php
+++ b/main/document/document.php
@@ -1165,8 +1165,10 @@ if ($isAllowedToEdit || $groupMemberWithUploadRights ||
                     DocumentManager::updateDbInfo(
                         'update',
                         $document_to_move['path'],
-                        $moveTo.'/' // .basename($document_to_move['path'])
+                        $moveTo.'/',
+                        $doc_id
                     );
+                    // $moveTo.'/' .basename($document_to_move['path'])
 
                     // Update database item property
                     api_item_property_update(

--- a/main/inc/lib/document.lib.php
+++ b/main/inc/lib/document.lib.php
@@ -6328,14 +6328,16 @@ class DocumentManager
      *
      * @author - Hugues Peeters <peeters@ipm.ucl.ac.be>
      *
-     * @param string $action   - action type require : 'delete' or 'update'
-     * @param string $old_path - old path info stored to change
-     * @param string $new_path - new path info to substitute
+     * @param string $action     - action type require : 'delete' or 'update'
+     * @param string $old_path   - old path info stored to change
+     * @param string $new_path   - new path info to substitute
+     * @param Int    $documentId - Id of specific document
      *
      * @desc Update the file or directory path in the document db document table
      */
-    public static function updateDbInfo($action, $old_path, $new_path = '')
+    public static function updateDbInfo($action, $old_path, $new_path = '', $documentId = 0)
     {
+        $documentId = (int) $documentId;
         $dbTable = Database::get_course_table(TABLE_DOCUMENT);
         $course_id = api_get_course_int_id();
         $old_path = Database::escape_string($old_path);
@@ -6363,6 +6365,9 @@ class DocumentManager
                           WHERE
                                 c_id = $course_id AND
                                 (path LIKE BINARY '".$old_path."' OR path LIKE BINARY '".$old_path."/%')";
+                if ($documentId != 0) {
+                    $query .= " AND id = $documentId";
+                }
                 Database::query($query);
                 break;
         }


### PR DESCRIPTION
When $ _configuration ['enable_add_file_link'] = true; files can be uploaded to the cloud using the url. Then when you want to move to another folder, a failure occurs when placing the destination folder and also the current folder in the database.

In the DocumentManager :: updateDbInfo function it has been modified so that only the path to which it will be moved is set.
![imagen](https://user-images.githubusercontent.com/18097392/99999702-8979d100-2d8e-11eb-81f6-a5b47133d644.png)
For previous events, the corresponding paths must be verified in the c_document table to set the "path" field in the correct location if there are problems with the current links
#3596