### PR TITLE
Adjustment for when you select a different amount of items per page when action is accessoverview

### DIFF
--- a/main/inc/lib/myspace.lib.php
+++ b/main/inc/lib/myspace.lib.php
@@ -3338,7 +3338,13 @@ class MySpace
      * @param int $sessionId
      * @param int $studentId
      */
-    public static function displayTrackingAccessOverView($courseId, $sessionId, $studentId)
+    public static function displayTrackingAccessOverView(
+        $courseId,
+        $sessionId,
+        $studentId,
+        $perPage = 20,
+        $dates = null
+    )
     {
         $courseId = (int) $courseId;
         $sessionId = (int) $sessionId;
@@ -3456,12 +3462,24 @@ class MySpace
         $form->addButton('submit', get_lang('Generate'), 'gear', 'primary');
 
         $table = null;
-        if ($form->validate()) {
+        if (!empty($dates)) {
+        //if ($form->validate()) {
             $table = new SortableTable(
                 'tracking_access_overview',
                 ['MySpace', 'getNumberOfTrackAccessOverview'],
                 ['MySpace', 'getUserDataAccessTrackingOverview'],
-                0
+                0,
+                $perPage
+            );
+            $table->set_additional_parameters(
+                [
+                    'course_id' => $courseId,
+                    'session_id' => $sessionId,
+                    'student_id' => $studentId,
+                    'date' => $dates,
+                    'tracking_access_overview_per_page' =>  $perPage,
+                    'display' => 'accessoverview',
+                ]
             );
             $table->set_header(0, get_lang('LoginDate'), true);
             $table->set_header(1, get_lang('Username'), true);

--- a/main/inc/lib/myspace.lib.php
+++ b/main/inc/lib/myspace.lib.php
@@ -3344,8 +3344,7 @@ class MySpace
         $studentId,
         $perPage = 20,
         $dates = null
-    )
-    {
+    ) {
         $courseId = (int) $courseId;
         $sessionId = (int) $sessionId;
         $studentId = (int) $studentId;
@@ -3463,7 +3462,7 @@ class MySpace
 
         $table = null;
         if (!empty($dates)) {
-        //if ($form->validate()) {
+            //if ($form->validate()) {
             $table = new SortableTable(
                 'tracking_access_overview',
                 ['MySpace', 'getNumberOfTrackAccessOverview'],
@@ -3477,7 +3476,7 @@ class MySpace
                     'session_id' => $sessionId,
                     'student_id' => $studentId,
                     'date' => $dates,
-                    'tracking_access_overview_per_page' =>  $perPage,
+                    'tracking_access_overview_per_page' => $perPage,
                     'display' => 'accessoverview',
                 ]
             );

--- a/main/mySpace/admin_view.php
+++ b/main/mySpace/admin_view.php
@@ -16,6 +16,9 @@ if (isset($_GET['export_csv']) && $exportCSV == false) {
 $startDate = isset($_GET['startDate']) ? $_GET['startDate'] : null;
 $endDate = isset($_GET['endDate']) ? $_GET['endDate'] : null;
 $display = isset($_GET['display']) ? Security::remove_XSS($_GET['display']) : null;
+if (isset($_POST['display']) && $display == null) {
+    $display = Security::remove_XSS($_POST['display']);
+}
 
 $htmlHeadXtra[] = api_get_jqgrid_js();
 $htmlHeadXtra[] = '<script
@@ -109,11 +112,29 @@ switch ($display) {
         MySpace::displayResumeLpByItem($startDate, $endDate);
         break;
     case 'accessoverview':
-        $courseId = isset($_GET['course_id']) ? (int) $_GET['course_id'] : 0;
-        $sessionId = isset($_GET['session_id']) ? (int) $_GET['session_id'] : 0;
-        $studentId = isset($_GET['student_id']) ? (int) $_GET['student_id'] : 0;
+        $courseId = isset($_GET['course_id']) ? (int)$_GET['course_id'] : 0;
+        if ($courseId == 0 && $_POST['course_id']) {
+            $courseId = (int)$_POST['course_id'];
+            $_GET['course_id'] = $courseId;
+        }
+        $sessionId = isset($_GET['session_id']) ? (int)$_GET['session_id'] : 0;
+        if ($sessionId == 0 && $_POST['session_id']) {
+            $sessionId = (int)$_POST['session_id'];
+            $_GET['session_id'] = $sessionId;
+        }
+        $studentId = isset($_GET['student_id']) ? (int)$_GET['student_id'] : 0;
+        if ($studentId == 0 && $_POST['student_id']) {
+            $studentId = (int)$_POST['student_id'];
+            $_GET['student_id'] = $studentId;
+        }
+        $perPage = isset($_GET['tracking_access_overview_per_page']) ? $_GET['tracking_access_overview_per_page'] : 20;
 
-        MySpace::displayTrackingAccessOverView($courseId, $sessionId, $studentId);
+        $dates = isset($_GET['date']) ? $_GET['date'] : null;
+        if ($dates == null && $_POST['date']) {
+            $dates = $_POST['date'];
+            $_GET['date'] = $dates;
+        }
+        MySpace::displayTrackingAccessOverView($courseId, $sessionId, $studentId, $perPage, $dates);
         break;
 }
 

--- a/main/mySpace/admin_view.php
+++ b/main/mySpace/admin_view.php
@@ -112,19 +112,19 @@ switch ($display) {
         MySpace::displayResumeLpByItem($startDate, $endDate);
         break;
     case 'accessoverview':
-        $courseId = isset($_GET['course_id']) ? (int)$_GET['course_id'] : 0;
+        $courseId = isset($_GET['course_id']) ? (int) $_GET['course_id'] : 0;
         if ($courseId == 0 && $_POST['course_id']) {
-            $courseId = (int)$_POST['course_id'];
+            $courseId = (int) $_POST['course_id'];
             $_GET['course_id'] = $courseId;
         }
-        $sessionId = isset($_GET['session_id']) ? (int)$_GET['session_id'] : 0;
+        $sessionId = isset($_GET['session_id']) ? (int) $_GET['session_id'] : 0;
         if ($sessionId == 0 && $_POST['session_id']) {
-            $sessionId = (int)$_POST['session_id'];
+            $sessionId = (int) $_POST['session_id'];
             $_GET['session_id'] = $sessionId;
         }
-        $studentId = isset($_GET['student_id']) ? (int)$_GET['student_id'] : 0;
+        $studentId = isset($_GET['student_id']) ? (int) $_GET['student_id'] : 0;
         if ($studentId == 0 && $_POST['student_id']) {
-            $studentId = (int)$_POST['student_id'];
+            $studentId = (int) $_POST['student_id'];
             $_GET['student_id'] = $studentId;
         }
         $perPage = isset($_GET['tracking_access_overview_per_page']) ? $_GET['tracking_access_overview_per_page'] : 20;


### PR DESCRIPTION
In the report of accesses by user, when the amount of elements that will be displayed per page is changed, it does not appear.

An adjustment is made to remove $ form-> validate () since when you change the amount of elements it is a link and not a delivery method. However, it is evaluated that it contains dates for the date range, thus preventing an empty query from being made.

Because it is a query as a link because of the shape of the table, the elements necessary for the query are added in a form corresponding to SortableTable with the property set_additional_parameters.
To prevent inconsistencies in this way, it is evaluated if a variable exists by get method, if it does not exist but if it exists by post method then said variable will be taken. It also conforms to the get method for the getUserDataAccessTrackingOverview function

![imagen](https://user-images.githubusercontent.com/18097392/100007856-ad431400-2d9a-11eb-9854-e40f7328f1f4.png)

#3529