### PR TITLE
Posibilidad de añadir información adicional en el correo de confirmación de pago por transferencia

### DIFF
--- a/main/exercise/export/aiken/aiken_import.inc.php
+++ b/main/exercise/export/aiken/aiken_import.inc.php
@@ -1,6 +1,7 @@
 <?php
 
 /* For licensing terms, see /license.txt */
+
 /**
  * Library for the import of Aiken format.
  *
@@ -97,9 +98,9 @@ function get_and_unzip_uploaded_exercise($baseWorkDir, $uploadPath)
         )
     ) {
         return true;
-    } else {
-        return false;
     }
+
+    return false;
 }
 
 /**
@@ -173,7 +174,7 @@ function aiken_import_exercise($file)
         return $result;
     }
 
-    // 1. Create exercise
+    // 1. Create exercise.
     $exercise = new Exercise();
     $exercise->exercise = $exercise_info['name'];
     $exercise->save();
@@ -181,10 +182,9 @@ function aiken_import_exercise($file)
     $tableQuestion = Database::get_course_table(TABLE_QUIZ_QUESTION);
     $tableAnswer = Database::get_course_table(TABLE_QUIZ_ANSWER);
     if (!empty($last_exercise_id)) {
-        // For each question found...
         $courseId = api_get_course_int_id();
         foreach ($exercise_info['question'] as $key => $question_array) {
-            // 2.create question
+            // 2. Create question.
             $question = new Aiken2Question();
             $question->type = $question_array['type'];
             $question->setAnswer();
@@ -257,9 +257,6 @@ function aiken_import_exercise($file)
             if (!empty($scoreFromFile)) {
                 $max_score = $scoreFromFile;
             }
-
-            //$answer->save();
-
             $params = ['ponderation' => $max_score];
             Database::update(
                 $tableQuestion,
@@ -299,22 +296,30 @@ function aiken_parse_file(&$exercise_info, $exercisePath, $file, $questionFile)
     if (!is_file($questionFilePath)) {
         return 'FileNotFound';
     }
-    $data = file($questionFilePath);
+
+    $text = file_get_contents($questionFilePath);
+    $detect = mb_detect_encoding($text, 'ASCII', true);
+    if ('ASCII' === $detect) {
+        $data = explode("\n", $text);
+    } else {
+        $text = str_ireplace(["\x0D", "\r\n"], "\n", $text); // Removes ^M char from win files.
+        $data = explode("\n\n", $text);
+    }
 
     $question_index = 0;
     $answers_array = [];
-    $new_question = true;
     foreach ($data as $line => $info) {
-        if ($question_index > 0 && $new_question == true && preg_match('/^(\r)?\n/', $info)) {
-            // double empty line
+        $info = trim($info);
+        if (empty($info)) {
             continue;
         }
-        $new_question = false;
+
         //make sure it is transformed from iso-8859-1 to utf-8 if in that form
         if (!mb_check_encoding($info, 'utf-8') && mb_check_encoding($info, 'iso-8859-1')) {
             $info = utf8_encode($info);
         }
         $exercise_info['question'][$question_index]['type'] = 'MCUA';
+
         if (preg_match('/^([A-Za-z])(\)|\.)\s(.*)/', $info, $matches)) {
             //adding one of the possible answers
             $exercise_info['question'][$question_index]['answer'][]['value'] = $matches[3];
@@ -325,14 +330,38 @@ function aiken_parse_file(&$exercise_info, $exercisePath, $file, $questionFile)
             $exercise_info['question'][$question_index]['correct_answers'][] = $correct_answer_index + 1;
             //weight for correct answer
             $exercise_info['question'][$question_index]['weighting'][$correct_answer_index] = 1;
+            $next = $line + 1;
+
+            if (false !== strpos($data[$next], 'ANSWER_EXPLANATION:')) {
+                continue;
+            }
+
+            // Check if next has score, otherwise loop too next question.
+            if (false === strpos($data[$next], 'SCORE:')) {
+                $answers_array = [];
+                $question_index++;
+                continue;
+            }
         } elseif (preg_match('/^SCORE:\s?(.*)/', $info, $matches)) {
             $exercise_info['question'][$question_index]['score'] = (float) $matches[1];
+            $answers_array = [];
+            $question_index++;
+            continue;
         } elseif (preg_match('/^DESCRIPTION:\s?(.*)/', $info, $matches)) {
             $exercise_info['question'][$question_index]['description'] = $matches[1];
         } elseif (preg_match('/^ANSWER_EXPLANATION:\s?(.*)/', $info, $matches)) {
-            //Comment of correct answer
+            // Comment of correct answer
             $correct_answer_index = array_search($matches[1], $answers_array);
             $exercise_info['question'][$question_index]['feedback'] = $matches[1];
+
+            $next = $line + 1;
+            // Check if next has score, otherwise loop too next question.
+            if (false === strpos($data[$next], 'SCORE:')) {
+                $answers_array = [];
+                $question_index++;
+                continue;
+            }
+
         } elseif (preg_match('/^TEXTO_CORRECTA:\s?(.*)/', $info, $matches)) {
             //Comment of correct answer (Spanish e-ducativa format)
             $correct_answer_index = array_search($matches[1], $answers_array);
@@ -347,7 +376,10 @@ function aiken_parse_file(&$exercise_info, $exercisePath, $file, $questionFile)
         } elseif (preg_match('/^ETIQUETAS:\s?([A-Z])\s?/', $info, $matches)) {
             //TAGS for chamilo >= 1.10 (Spanish e-ducativa format)
             $exercise_info['question'][$question_index]['answer_tags'] = explode(',', $matches[1]);
-        } elseif (preg_match('/^(\r)?\n/', $info)) {
+        } elseif (empty($info)) {
+            /*if (empty($exercise_info['question'][$question_index]['title'])) {
+                $exercise_info['question'][$question_index]['title'] = $info;
+            }
             //moving to next question (tolerate \r\n or just \n)
             if (empty($exercise_info['question'][$question_index]['correct_answers'])) {
                 error_log('Aiken: Error in question index '.$question_index.': no correct answer defined');
@@ -362,19 +394,28 @@ function aiken_parse_file(&$exercise_info, $exercisePath, $file, $questionFile)
             $question_index++;
             //emptying answers array when moving to next question
             $answers_array = [];
-            $new_question = true;
+            //$new_question = true;*/
         } else {
             if (empty($exercise_info['question'][$question_index]['title'])) {
                 $exercise_info['question'][$question_index]['title'] = $info;
             }
+            /*$question_index++;
+            //emptying answers array when moving to next question
+            $answers_array = [];
+            $new_question = true;*/
         }
     }
+
     $total_questions = count($exercise_info['question']);
     $total_weight = !empty($_POST['total_weight']) ? (int) ($_POST['total_weight']) : 20;
     foreach ($exercise_info['question'] as $key => $question) {
+        if (!isset($exercise_info['question'][$key]['weighting'])) {
+            continue;
+        }
         $exercise_info['question'][$key]['weighting'][current(array_keys($exercise_info['question'][$key]['weighting']))] = $total_weight / $total_questions;
     }
 
+    //exit;
     return true;
 }
 

--- a/plugin/buycourses/README.md
+++ b/plugin/buycourses/README.md
@@ -11,3 +11,8 @@ and lets the user proceed with the purchase.
 
 Finally, the user receives an e-mail confirming the purchase and him/her is can access to the
 course/session.
+
+*****************************************************
+Update Note
+=========================================
+It is necessary to execute the update.php file for those installations that were in production after updating the code.

--- a/plugin/buycourses/database.php
+++ b/plugin/buycourses/database.php
@@ -379,6 +379,7 @@ if (false === $sm->tablesExist(BuyCoursesPlugin::TABLE_GLOBAL_CONFIG)) {
     $globalTable->addColumn('next_number_invoice', \Doctrine\DBAL\Types\Type::INTEGER);
     $globalTable->addColumn('invoice_series', \Doctrine\DBAL\Types\Type::STRING);
     $globalTable->addColumn('sale_email', \Doctrine\DBAL\Types\Type::STRING);
+    $globalTable->addColumn('info_email_extra', \Doctrine\DBAL\Types\Type::TEXT);
     $globalTable->setPrimaryKey(['id']);
 }
 

--- a/plugin/buycourses/lang/english.php
+++ b/plugin/buycourses/lang/english.php
@@ -205,3 +205,4 @@ $strings['kc'] = "Secret encryption key";
 $strings['url_redsys'] = "Redsys connection URL";
 $strings['url_redsys_sandbox'] = "Redsys connection URL (Sandbox)";
 $strings['InfoTpvRedsysApiCredentials'] = "You must complete the following fields of the form with the information provided by the Redsys POS Technical Support:";
+$strings['InfoEmailExtra'] = "Email extra info ";

--- a/plugin/buycourses/lang/spanish.php
+++ b/plugin/buycourses/lang/spanish.php
@@ -226,3 +226,4 @@ $strings['kc'] = "Clave secreta de encriptación";
 $strings['url_redsys'] = "URL conexión Redsys";
 $strings['url_redsys_sandbox'] = "URL conexión Redsys (Pruebas)";
 $strings['InfoTpvRedsysApiCredentials'] = "Deberá completar los siguientes campos del formulario con la información que les facilite el Soporte Técnico del TPV Redsys:";
+$strings['InfoEmailExtra'] = "Información extra en e-mail";

--- a/plugin/buycourses/src/buy_course_plugin.class.php
+++ b/plugin/buycourses/src/buy_course_plugin.class.php
@@ -206,6 +206,17 @@ class BuyCoursesPlugin extends Plugin
                 echo Display::return_message($this->get_lang('ErrorUpdateFieldDB'), 'warning');
             }
         }
+        
+        $sql = "SHOW COLUMNS FROM $table WHERE Field = 'info_email_extra'";
+        $res = Database::query($sql);
+
+        if (Database::num_rows($res) === 0) {
+            $sql = "ALTER TABLE $table ADD (info_email_extra TEXT NOT NULL)";
+            $res = Database::query($sql);
+            if (!$res) {
+                echo Display::return_message($this->get_lang('ErrorUpdateFieldDB'), 'warning');
+            }
+        }
 
         $table = self::TABLE_ITEM;
         $sql = "SHOW COLUMNS FROM $table WHERE Field = 'tax_perc'";
@@ -535,6 +546,37 @@ class BuyCoursesPlugin extends Plugin
                 'account' => $params['taccount'],
                 'swift' => $params['tswift'],
             ]
+        );
+    }
+
+    /**
+     * Save email message information in transfer.
+     *
+     * @param array $params The transfer message
+     *
+     * @return int Rows affected. Otherwise return false
+     */
+    public function saveTransferInfoEmail($params)
+    {
+        return Database::update(
+            Database::get_main_table(self::TABLE_GLOBAL_CONFIG),
+            ['info_email_extra' => $params['tinfo_email_extra']],
+            ['id = ?' => 1]
+        );
+    }
+
+    /**
+     * Gets message information for transfer email.
+     *
+     * @return array
+     */
+    public function getTransferInfoExtra()
+    {
+        return Database::select(
+            'info_email_extra AS tinfo_email_extra',
+            Database::get_main_table(self::TABLE_GLOBAL_CONFIG),
+            ['id = ?' => 1],
+            'first'
         );
     }
 

--- a/plugin/buycourses/src/paymentsetup.php
+++ b/plugin/buycourses/src/paymentsetup.php
@@ -338,6 +338,30 @@ $transferForm->addButtonCreate(get_lang('Add'));
 
 $transferAccounts = $plugin->getTransferAccounts();
 
+$transferInfoForm = new FormValidator('transfer_info');
+
+if ($transferInfoForm->validate()) {
+    $transferInfoFormValues = $transferInfoForm->getSubmitValues();
+
+    $plugin->saveTransferInfoEmail($transferInfoFormValues);
+
+    Display::addFlash(
+        Display::return_message(get_lang('Saved'), 'success')
+    );
+
+    header('Location:'.api_get_self());
+    exit;
+}
+$transferInfoForm->addHtmlEditor(
+    'tinfo_email_extra',
+    $plugin->get_lang('InfoEmailExtra'),
+    false,
+    false,
+    ['ToolbarSet' => 'Minimal']
+);
+$transferInfoForm->addButtonCreate(get_lang('Save'));
+$transferInfoForm->setDefaults($plugin->getTransferInfoExtra());
+
 // Culqi main configuration
 
 $culqiForm = new FormValidator('culqi_config');
@@ -384,6 +408,7 @@ $tpl->assign('global_config_form', $globalSettingForm->returnForm());
 $tpl->assign('paypal_form', $paypalForm->returnForm());
 $tpl->assign('commission_form', $commissionForm->returnForm());
 $tpl->assign('transfer_form', $transferForm->returnForm());
+$tpl->assign('transfer_info_form', $transferInfoForm->returnForm());
 $tpl->assign('culqi_form', $culqiForm->returnForm());
 $tpl->assign('transfer_accounts', $transferAccounts);
 $tpl->assign('paypal_enable', $paypalEnable);

--- a/plugin/buycourses/src/process_confirm.php
+++ b/plugin/buycourses/src/process_confirm.php
@@ -104,6 +104,7 @@ switch ($sale['payment_type']) {
         }
 
         $transferAccounts = $plugin->getTransferAccounts();
+        $infoEmailExtra = $plugin->getTransferInfoExtra()['tinfo_email_extra'];
 
         $form = new FormValidator(
             'success',
@@ -139,6 +140,7 @@ switch ($sale['payment_type']) {
                 ]
             );
             $messageTemplate->assign('transfer_accounts', $transferAccounts);
+            $messageTemplate->assign('info_email_extra', $infoEmailExtra);
 
             MessageManager::send_message_simple(
                 $userInfo['user_id'],

--- a/plugin/buycourses/view/message_transfer.tpl
+++ b/plugin/buycourses/view/message_transfer.tpl
@@ -32,5 +32,6 @@
         {% endfor %}
         </tbody>
     </table>
+    <p>{{ info_email_extra }}</p>
     <p>{{ 'PurchaseDetailsEnd'|get_plugin_lang('BuyCoursesPlugin') }}</p>
 </div>

--- a/plugin/buycourses/view/paymentsetup.tpl
+++ b/plugin/buycourses/view/paymentsetup.tpl
@@ -113,6 +113,9 @@
                         </table>
                     </div>
                 </div>
+                <div class="col-md-12">
+                    {{ transfer_info_form }}
+                </div>
             </div>
         </div>
     </div>


### PR DESCRIPTION
En la mayoría de las situaciones el usuario que configura el pago por transferencia quieres añadir un mensaje adicional para indicar el procedimiento o las instrucciones del pago para agilizar el proceso. 
Hasta ahora la única posibilidad era editar la cadena de texto "PurchaseDetailsEnd" por lo que requería editar el fichero vía ftp.
Lo que se propone es añadir un campo de texto en la página de "Configuración  de Pagos"
![image](https://user-images.githubusercontent.com/5868981/100335519-5ffeb680-2fd5-11eb-9a8f-8c722734f6f6.png)
