### PR TITLE
Group categories : Missing option PrivateBetweenUsers #3542 - refs #3542

### DIFF
--- a/main/group/group_category.php
+++ b/main/group/group_category.php
@@ -303,6 +303,7 @@ $group = [
     $form->createElement('radio', 'announcements_state', get_lang('GroupAnnouncements'), get_lang('NotAvailable'), GroupManager::TOOL_NOT_AVAILABLE),
     $form->createElement('radio', 'announcements_state', null, get_lang('Public'), GroupManager::TOOL_PUBLIC),
     $form->createElement('radio', 'announcements_state', null, get_lang('Private'), GroupManager::TOOL_PRIVATE),
+    $form->createElement('radio', 'announcements_state', null, get_lang('PrivateBetweenUsers'), GroupManager::TOOL_PRIVATE_BETWEEN_USERS),
 ];
 $form->addGroup(
     $group,
@@ -398,6 +399,7 @@ if ($form->validate()) {
                 $values['id'],
                 $values['title'],
                 $values['description'],
+
                 $values['doc_state'],
                 $values['work_state'],
                 $values['calendar_state'],

--- a/main/group/group_category.php
+++ b/main/group/group_category.php
@@ -399,7 +399,6 @@ if ($form->validate()) {
                 $values['id'],
                 $values['title'],
                 $values['description'],
-
                 $values['doc_state'],
                 $values['work_state'],
                 $values['calendar_state'],


### PR DESCRIPTION
It is a bit difficult to observe it in detail, but in the course category there is a missing ad parameter, unlike the configuration.

To find the categories, you must enter into groups, in the default groups section, you will find a pencil which must be accessed
![imagen](https://user-images.githubusercontent.com/18097392/100375227-760f7580-2fdb-11eb-9737-130cbd7c41b6.png)
There, in the ads section, it lacks a parameter
![imagen](https://user-images.githubusercontent.com/18097392/100375148-57a97a00-2fdb-11eb-9c28-79f4c9aa4a17.png)
![imagen](https://user-images.githubusercontent.com/18097392/100375409-bd960180-2fdb-11eb-9c97-58a4c5c4f34a.png)


Adding the PrivateBetweenUsers option in the corresponding section shows the missing option