### PR TITLE
Quiz :  Lock back in browser when quiz_prevent_backwards_move is active

### DIFF
--- a/main/exercise/exercise_result.php
+++ b/main/exercise/exercise_result.php
@@ -24,10 +24,13 @@ $this_section = SECTION_COURSES;
 
 api_protect_course_script(true);
 $origin = api_get_origin();
-
+$clearExercise = false;
 /** @var Exercise $objExercise */
 if (empty($objExercise)) {
     $objExercise = Session::read('objExercise');
+    if ($objExercise->getPreventBackwards()) {
+        $clearExercise = true;
+    }
 }
 
 $exeId = isset($_REQUEST['exe_id']) ? (int) $_REQUEST['exe_id'] : 0;
@@ -287,6 +290,16 @@ if (!in_array($origin, ['learnpath', 'embeddable', 'mobileapp'])) {
     $pageBottom .= "<script>window.parent.API.void_save_asset('$total_score', '$max_score', 0, 'completed');</script>";
     $pageBottom .= '<script type="text/javascript">'.$href.'</script>';
     $showFooter = false;
+}
+
+if ($clearExercise == true) {
+    $pageBottom .= "<script>
+window.history.pushState(null, '', window.location.href);
+window.onpopstate = function () {
+    window.history.pushState(null, '', window.location.href);
+};
+</script>  ";
+
 }
 
 $template = new Template($nameTools, $showHeader, $showFooter);

--- a/main/exercise/exercise_result.php
+++ b/main/exercise/exercise_result.php
@@ -299,7 +299,6 @@ window.onpopstate = function () {
     window.history.pushState(null, '', window.location.href);
 };
 </script>  ";
-
 }
 
 $template = new Template($nameTools, $showHeader, $showFooter);

--- a/main/exercise/exercise_result.php
+++ b/main/exercise/exercise_result.php
@@ -28,8 +28,10 @@ $clearExercise = false;
 /** @var Exercise $objExercise */
 if (empty($objExercise)) {
     $objExercise = Session::read('objExercise');
-    if ($objExercise->getPreventBackwards()) {
-        $clearExercise = true;
+    if (function_exists('getPreventBackwards')) {
+        if ($objExercise->getPreventBackwards()) {
+            $clearExercise = true;
+        }
     }
 }
 


### PR DESCRIPTION
When the option quiz_prevent_backwards_move is active, it prevents you from returning to the previous question when you are solving an exercise, which is correct.

However it can create confusion for students when they finish the exam and press back on the browser, they create another attempt which can create confusion for the student.

It seeks to block the back action of the browsers to prevent this from happening from the end of the exercise page and the option quiz_prevent_backwards_move is activated

NOTE: Validation is required since normally the back action of the browser should not be blocked (@AngelFQC )