### PR TITLE
Plugin: BuyCourses: Prevented design breakage for cards

### DIFF
--- a/plugin/buycourses/resources/css/style.css
+++ b/plugin/buycourses/resources/css/style.css
@@ -395,8 +395,8 @@ div.items-course-info h4.title{
     overflow: hidden;
 }
 
-@media (max-width: 991px) {
-    .pagination {
-        padding-bottom: 90px;
+@media (min-width: 991px) {
+    .col-sm-6 .items-course .items-course-image figure {
+        max-height: 135px;
     }
 }

--- a/plugin/buycourses/view/catalog.tpl
+++ b/plugin/buycourses/view/catalog.tpl
@@ -35,8 +35,11 @@
                                 <div class="col-md-4 col-sm-6">
                                     <article class="items-course">
                                         <div class="items-course-image">
-                                            <img alt="{{ course.title }}" class="img-responsive"
-                                                 src="{{ course.course_img ? course.course_img : 'session_default.png'|icon() }}">
+                                            <figure  class="img-responsive">
+                                                <img alt="{{ course.title }}"
+                                                     class="img-responsive"
+                                                     src="{{ course.course_img ? course.course_img : 'session_default.png'|icon() }}">
+                                            </figure>
                                         </div>
                                         <div class="items-course-info">
                                             {% set course_description_url = _p.web_ajax ~ 'course_home.ajax.php?' ~ {'code': course.code, 'a': 'show_course_information'}|url_encode() %}
@@ -84,8 +87,10 @@
                                 <div class="col-md-4 col-sm-6">
                                     <article class="items-course">
                                         <div class="items-course-image">
-                                            <img alt="{{ session.name }}" class="img-responsive"
-                                                 src="{{ session.image ? session.image : 'session_default.png'|icon() }}">
+                                            <figure  class="img-responsive">
+                                                <img alt="{{ session.name }}" class="img-responsive"
+                                                     src="{{ session.image ? session.image : 'session_default.png'|icon() }}">
+                                            </figure>
                                         </div>
                                         <div class="items-course-info">
                                             <h4 class="title">
@@ -142,9 +147,12 @@
                                     <div class="items-course">
                                         <div class="items-course-image">
                                             <a href="{{ _p.web }}service/{{ service.id }}">
-                                                <img alt="{{ service.name }}"
-                                                    class="img-responsive"
-                                                    src="{{ service.image ? service.image : 'session_default.png'|icon() }}"></a>
+                                                <figure class="img-responsive">
+                                                    <img alt="{{ service.name }}"
+                                                         class="img-responsive"
+                                                         src="{{ service.image ? service.image : 'session_default.png'|icon() }}">
+                                                </figure>
+                                            </a>
                                         </div>
                                         <div class="items-course-info">
                                             <h4 class="title">


### PR DESCRIPTION
Into https://campus.chamilo.org/plugin/buycourses/src/session_catalog.php?&page=5 
![imagen](https://user-images.githubusercontent.com/18097392/100659873-42a45200-331f-11eb-99fd-30a80ec03dfa.png)

It can be seen that, despite being 6 cards, the design is broken, this is because in one of the cards, the image does not respect the aspect by 1 px.
![imagen](https://user-images.githubusercontent.com/18097392/100660045-7a12fe80-331f-11eb-8f79-ad8372dae174.png)

The height property differs from the other images
![imagen](https://user-images.githubusercontent.com/18097392/100660205-adee2400-331f-11eb-9f43-22057b236fcf.png)


This pixel causes the images to not be ordered well.

A change is proposed for max-height. The image is encapsulated in a figure so that the image maintains its shape, however the figure is the one who will be the appropriate responsive container so that it does not break the design.
![imagen](https://user-images.githubusercontent.com/18097392/100660307-d83fe180-331f-11eb-92ec-936576ae282a.png)


This way, even with resolutions of 3600 px wide, the original design will not be broken.
![imagen](https://user-images.githubusercontent.com/18097392/100660434-032a3580-3320-11eb-9262-77f70ca0457f.png)

BT#17957
