### PR TITLE
Adjustment to correctly validate the admin when editing the item  - BT 17943

### DIFF
--- a/main/inc/lib/extra_field.lib.php
+++ b/main/inc/lib/extra_field.lib.php
@@ -994,19 +994,6 @@ class ExtraField extends Model
                         continue;
                     }
                 }
-                // see  BT#17943
-                $authors = false;
-                if (
-                    $field_details['variable'] == 'authors'
-                    || $field_details['variable'] == 'authorlp'
-                    || $field_details['variable'] == 'authorlpitem'
-                    || $field_details['variable'] == 'price'
-                ) {
-                    $authors = true;
-                }
-                if (!api_is_platform_admin() && $authors == true) {
-                    continue;
-                }
 
                 // Getting default value id if is set
                 $defaultValueId = null;

--- a/main/inc/lib/extra_field_value.lib.php
+++ b/main/inc/lib/extra_field_value.lib.php
@@ -160,20 +160,6 @@ class ExtraFieldValue extends Model
                 continue;
             }
 
-            // see  BT#17943
-            $authors = false;
-            if (
-                $extraFieldInfo['variable'] == 'authors'
-                || $extraFieldInfo['variable'] == 'authorlp'
-                || $extraFieldInfo['variable'] == 'authorlpitem'
-                || $extraFieldInfo['variable'] == 'price'
-            ) {
-                $authors = true;
-            }
-            if (!api_is_platform_admin() && $authors == true) {
-                continue;
-            }
-
             $commentVariable = 'extra_'.$field_variable.'_comment';
             $comment = isset($params[$commentVariable]) ? $params[$commentVariable] : null;
             $dirPermissions = api_get_permissions_for_new_directories();

--- a/main/lp/learnpath.class.php
+++ b/main/lp/learnpath.class.php
@@ -7335,7 +7335,7 @@ class learnpath
      */
     public function display_edit_item(
         $item_id,
-        $exclude = []
+        $excludeExtraFields = []
     ) {
         $course_id = api_get_course_int_id();
         $return = '';
@@ -7361,8 +7361,7 @@ class learnpath
                         get_lang('EditCurrentChapter').' :',
                         'edit',
                         $item_id,
-                        $row,
-                        $exclude
+                        $row
                     );
                 } else {
                     $return .= $this->display_item_form(
@@ -7394,7 +7393,8 @@ class learnpath
                         $item_id,
                         $row_step,
                         null,
-                        $exclude);
+                        $excludeExtraFields
+                    );
                 }
 
                 if ($row['item_type'] === TOOL_READOUT_TEXT) {
@@ -7422,7 +7422,7 @@ class learnpath
                     }
                 }
                 $return .= $this->display_manipulate($item_id, $row['item_type']);
-                $return .= $this->display_link_form('edit', $item_id, $row, null, $exclude);
+                $return .= $this->display_link_form('edit', $item_id, $row, null, $excludeExtraFields);
                 break;
             case TOOL_LP_FINAL_ITEM:
                 Session::write('finalItem', true);
@@ -7437,11 +7437,11 @@ class learnpath
                 $res_step = Database::query($sql);
                 $row_step = Database::fetch_array($res_step, 'ASSOC');
                 $return .= $this->display_manipulate($item_id, $row['item_type']);
-                $return .= $this->display_document_form('edit', $item_id, $row_step, $exclude);
+                $return .= $this->display_document_form('edit', $item_id, $row_step, $excludeExtraFields);
                 break;
             case TOOL_QUIZ:
                 $return .= $this->display_manipulate($item_id, $row['item_type']);
-                $return .= $this->display_quiz_form('edit', $item_id, $row, $exclude);
+                $return .= $this->display_quiz_form('edit', $item_id, $row, $excludeExtraFields);
                 break;
             case TOOL_HOTPOTATOES:
                 $return .= $this->display_manipulate($item_id, $row['item_type']);
@@ -7591,7 +7591,7 @@ class learnpath
         $action = 'add',
         $id = 0,
         $extra_info = '',
-        $exclude = []
+        $excludeExtraFields = []
     ) {
         $course_id = api_get_course_int_id();
         $id = (int) $id;
@@ -7740,7 +7740,7 @@ class learnpath
 
         if ('edit' === $action) {
             $extraField = new ExtraField('lp_item');
-            $extraField->addElements($form, $id, $exclude);
+            $extraField->addElements($form, $id, $excludeExtraFields);
         }
 
         if ($action === 'add') {
@@ -8614,7 +8614,7 @@ class learnpath
         $id = 0,
         $extra_info = 'new',
         $item = null,
-        $exclude = []
+        $excludeExtraFields = []
     ) {
         $course_id = api_get_course_int_id();
         $_course = api_get_course_info();
@@ -8844,7 +8844,7 @@ class learnpath
 
         if ('edit' === $action) {
             $extraField = new ExtraField('lp_item');
-            $extraField->addElements($form, $id, $exclude );
+            $extraField->addElements($form, $id, $excludeExtraFields );
         }
 
         if ($action !== 'move') {
@@ -9434,7 +9434,7 @@ class learnpath
         $id = 0,
         $extra_info = '',
         $item = null,
-        $exclude = []
+        $excludeExtraFields = []
     ) {
         $course_id = api_get_course_int_id();
         $tbl_link = Database::get_course_table(TABLE_LINK);
@@ -9590,7 +9590,7 @@ class learnpath
 
         if ('edit' === $action) {
             $extraField = new ExtraField('lp_item');
-            $extraField->addElements($form, $id, $exclude);
+            $extraField->addElements($form, $id, $excludeExtraFields);
         }
 
         if ($action === 'add') {

--- a/main/lp/learnpath.class.php
+++ b/main/lp/learnpath.class.php
@@ -7437,7 +7437,13 @@ class learnpath
                 $res_step = Database::query($sql);
                 $row_step = Database::fetch_array($res_step, 'ASSOC');
                 $return .= $this->display_manipulate($item_id, $row['item_type']);
-                $return .= $this->display_document_form('edit', $item_id, $row_step, $excludeExtraFields);
+                $return .= $this->display_document_form(
+                    'edit',
+                    $item_id,
+                    $row_step,
+                    null,
+                    $excludeExtraFields
+                );
                 break;
             case TOOL_QUIZ:
                 $return .= $this->display_manipulate($item_id, $row['item_type']);
@@ -7449,11 +7455,11 @@ class learnpath
                 break;
             case TOOL_STUDENTPUBLICATION:
                 $return .= $this->display_manipulate($item_id, $row['item_type']);
-                $return .= $this->display_student_publication_form('edit', $item_id, $row);
+                $return .= $this->display_student_publication_form('edit', $item_id, $row,null,$excludeExtraFields);
                 break;
             case TOOL_FORUM:
                 $return .= $this->display_manipulate($item_id, $row['item_type']);
-                $return .= $this->display_forum_form('edit', $item_id, $row);
+                $return .= $this->display_forum_form('edit', $item_id, $row, $excludeExtraFields);
                 break;
             case TOOL_THREAD:
                 $return .= $this->display_manipulate($item_id, $row['item_type']);
@@ -7944,7 +7950,12 @@ class learnpath
      *
      * @return string HTML form
      */
-    public function display_forum_form($action = 'add', $id = 0, $extra_info = '')
+    public function display_forum_form(
+        $action = 'add',
+        $id = 0,
+        $extra_info = '',
+        $excludeExtraFields = []
+    )
     {
         $course_id = api_get_course_int_id();
         $tbl_forum = Database::get_course_table(TABLE_FORUM);
@@ -8098,7 +8109,7 @@ class learnpath
 
         if ('edit' === $action) {
             $extraField = new ExtraField('lp_item');
-            $extraField->addElements($form, $id);
+            $extraField->addElements($form, $id, $excludeExtraFields);
         }
 
         if ($action == 'add') {
@@ -9631,7 +9642,8 @@ class learnpath
         $action = 'add',
         $id = 0,
         $extra_info = '',
-        $item = null
+        $item = null,
+        $excludeExtraFields = []
     ) {
         $course_id = api_get_course_int_id();
         $tbl_publication = Database::get_course_table(TABLE_STUDENT_PUBLICATION);
@@ -9760,7 +9772,7 @@ class learnpath
 
         if ('edit' === $action) {
             $extraField = new ExtraField('lp_item');
-            $extraField->addElements($form, $id);
+            $extraField->addElements($form, $id, $excludeExtraFields);
         }
 
         if ($action === 'add') {

--- a/main/lp/learnpath.class.php
+++ b/main/lp/learnpath.class.php
@@ -7370,8 +7370,7 @@ class learnpath
                         get_lang('EditCurrentChapter').' :',
                         'edit_item',
                         $item_id,
-                        $row,
-                        $exclude
+                        $row
                     );
                 }
                 break;

--- a/main/lp/learnpath.class.php
+++ b/main/lp/learnpath.class.php
@@ -7455,7 +7455,7 @@ class learnpath
                 break;
             case TOOL_STUDENTPUBLICATION:
                 $return .= $this->display_manipulate($item_id, $row['item_type']);
-                $return .= $this->display_student_publication_form('edit', $item_id, $row,null,$excludeExtraFields);
+                $return .= $this->display_student_publication_form('edit', $item_id, $row, null, $excludeExtraFields);
                 break;
             case TOOL_FORUM:
                 $return .= $this->display_manipulate($item_id, $row['item_type']);
@@ -7955,8 +7955,7 @@ class learnpath
         $id = 0,
         $extra_info = '',
         $excludeExtraFields = []
-    )
-    {
+    ) {
         $course_id = api_get_course_int_id();
         $tbl_forum = Database::get_course_table(TABLE_FORUM);
 
@@ -8855,7 +8854,7 @@ class learnpath
 
         if ('edit' === $action) {
             $extraField = new ExtraField('lp_item');
-            $extraField->addElements($form, $id, $excludeExtraFields );
+            $extraField->addElements($form, $id, $excludeExtraFields);
         }
 
         if ($action !== 'move') {

--- a/main/lp/learnpath.class.php
+++ b/main/lp/learnpath.class.php
@@ -7333,8 +7333,10 @@ class learnpath
      *
      * @return string
      */
-    public function display_edit_item($item_id)
-    {
+    public function display_edit_item(
+        $item_id,
+        $exclude = []
+    ) {
         $course_id = api_get_course_int_id();
         $return = '';
         $item_id = (int) $item_id;
@@ -7359,7 +7361,8 @@ class learnpath
                         get_lang('EditCurrentChapter').' :',
                         'edit',
                         $item_id,
-                        $row
+                        $row,
+                        $exclude
                     );
                 } else {
                     $return .= $this->display_item_form(
@@ -7367,7 +7370,8 @@ class learnpath
                         get_lang('EditCurrentChapter').' :',
                         'edit_item',
                         $item_id,
-                        $row
+                        $row,
+                        $exclude
                     );
                 }
                 break;
@@ -7386,7 +7390,12 @@ class learnpath
                 $return .= $this->display_manipulate($item_id, $row['item_type']);
 
                 if ($row['item_type'] === TOOL_DOCUMENT) {
-                    $return .= $this->display_document_form('edit', $item_id, $row_step);
+                    $return .= $this->display_document_form(
+                        'edit',
+                        $item_id,
+                        $row_step,
+                        null,
+                        $exclude);
                 }
 
                 if ($row['item_type'] === TOOL_READOUT_TEXT) {
@@ -7414,7 +7423,7 @@ class learnpath
                     }
                 }
                 $return .= $this->display_manipulate($item_id, $row['item_type']);
-                $return .= $this->display_link_form('edit', $item_id, $row);
+                $return .= $this->display_link_form('edit', $item_id, $row, null, $exclude);
                 break;
             case TOOL_LP_FINAL_ITEM:
                 Session::write('finalItem', true);
@@ -7429,11 +7438,11 @@ class learnpath
                 $res_step = Database::query($sql);
                 $row_step = Database::fetch_array($res_step, 'ASSOC');
                 $return .= $this->display_manipulate($item_id, $row['item_type']);
-                $return .= $this->display_document_form('edit', $item_id, $row_step);
+                $return .= $this->display_document_form('edit', $item_id, $row_step, $exclude);
                 break;
             case TOOL_QUIZ:
                 $return .= $this->display_manipulate($item_id, $row['item_type']);
-                $return .= $this->display_quiz_form('edit', $item_id, $row);
+                $return .= $this->display_quiz_form('edit', $item_id, $row, $exclude);
                 break;
             case TOOL_HOTPOTATOES:
                 $return .= $this->display_manipulate($item_id, $row['item_type']);
@@ -7579,8 +7588,12 @@ class learnpath
      *
      * @return string HTML form
      */
-    public function display_quiz_form($action = 'add', $id = 0, $extra_info = '')
-    {
+    public function display_quiz_form(
+        $action = 'add',
+        $id = 0,
+        $extra_info = '',
+        $exclude = []
+    ) {
         $course_id = api_get_course_int_id();
         $id = (int) $id;
         $tbl_quiz = Database::get_course_table(TABLE_QUIZ_TEST);
@@ -7728,7 +7741,7 @@ class learnpath
 
         if ('edit' === $action) {
             $extraField = new ExtraField('lp_item');
-            $extraField->addElements($form, $id);
+            $extraField->addElements($form, $id, $exclude);
         }
 
         if ($action === 'add') {
@@ -8597,8 +8610,13 @@ class learnpath
      *
      * @return string HTML form
      */
-    public function display_document_form($action = 'add', $id = 0, $extra_info = 'new', $item = null)
-    {
+    public function display_document_form(
+        $action = 'add',
+        $id = 0,
+        $extra_info = 'new',
+        $item = null,
+        $exclude = []
+    ) {
         $course_id = api_get_course_int_id();
         $_course = api_get_course_info();
         $tbl_doc = Database::get_course_table(TABLE_DOCUMENT);
@@ -8827,7 +8845,7 @@ class learnpath
 
         if ('edit' === $action) {
             $extraField = new ExtraField('lp_item');
-            $extraField->addElements($form, $id);
+            $extraField->addElements($form, $id, $exclude );
         }
 
         if ($action !== 'move') {
@@ -9412,8 +9430,13 @@ class learnpath
      *
      * @return string HTML form
      */
-    public function display_link_form($action = 'add', $id = 0, $extra_info = '', $item = null)
-    {
+    public function display_link_form(
+        $action = 'add',
+        $id = 0,
+        $extra_info = '',
+        $item = null,
+        $exclude = []
+    ) {
         $course_id = api_get_course_int_id();
         $tbl_link = Database::get_course_table(TABLE_LINK);
 
@@ -9568,7 +9591,7 @@ class learnpath
 
         if ('edit' === $action) {
             $extraField = new ExtraField('lp_item');
-            $extraField->addElements($form, $id);
+            $extraField->addElements($form, $id, $exclude);
         }
 
         if ($action === 'add') {

--- a/main/lp/lp_admin_view.php
+++ b/main/lp/lp_admin_view.php
@@ -29,6 +29,17 @@ $learnpath_id = (int) $_REQUEST['lp_id'];
 $submit = isset($_POST['submit_button']) ? $_POST['submit_button'] : null;
 $_course = api_get_course_info();
 
+$excludeExtraFields = [
+    'authors',
+    'authorlp',
+    'authorlpitem',
+    'price',
+];
+if (api_is_platform_admin() ) {
+    // Only admins can edit this items
+    $excludeExtraFields = [];
+}
+
 if (!$is_allowed_to_edit || $isStudentView) {
     header('location:lp_controller.php?action=view&lp_id='.$learnpath_id);
     exit;
@@ -271,7 +282,10 @@ switch ($_GET['action']) {
                 'confirm'
             );
         } else {
-            echo $learnPath->display_edit_item($_GET['id']);
+            echo $learnPath->display_edit_item(
+                $_GET['id'],
+                $excludeExtraFields
+            );
         }
         break;
     case 'delete_item':

--- a/main/lp/lp_admin_view.php
+++ b/main/lp/lp_admin_view.php
@@ -35,7 +35,7 @@ $excludeExtraFields = [
     'authorlpitem',
     'price',
 ];
-if (api_is_platform_admin() ) {
+if (api_is_platform_admin()) {
     // Only admins can edit this items
     $excludeExtraFields = [];
 }

--- a/main/lp/lp_controller.php
+++ b/main/lp/lp_controller.php
@@ -912,7 +912,7 @@ switch ($action) {
                 $is_success = true;
 
                 $extraFieldValues = new ExtraFieldValue('lp_item');
-                $extraFieldValues->saveFieldValues($_POST);
+                $extraFieldValues->saveFieldValues($_POST, true);
 
                 Display::addFlash(Display::return_message(get_lang('Updated')));
                 $url = api_get_self().'?action=add_item&type=step&lp_id='.intval($_SESSION['oLP']->lp_id).'&'.api_get_cidreq();

--- a/main/lp/lp_edit_item.php
+++ b/main/lp/lp_edit_item.php
@@ -160,7 +160,7 @@ if (!empty($path_file) && isset($path_parts['extension']) && $path_parts['extens
 echo '</div>';
 echo '<div id="doc_form" class="col-md-8">';
 
-$exclude = [
+$excludeExtraFields = [
     'authors',
     'authorlp',
     'authorlpitem',
@@ -168,7 +168,7 @@ $exclude = [
 ];
 if (api_is_platform_admin() ) {
     // Only admins can edit this items
-     $exclude = [];
+    $excludeExtraFields = [];
 }
 if (isset($is_success) && $is_success === true) {
     $msg = '<div class="lp_message" style="margin-bottom:10px;">';
@@ -179,7 +179,7 @@ if (isset($is_success) && $is_success === true) {
     $item = $learnPath->getItem($_GET['id']);
     echo $learnPath->display_edit_item(
         $item->getIid(),
-        $exclude
+        $excludeExtraFields
     );
     $finalItem = Session::read('finalItem');
     if ($finalItem) {

--- a/main/lp/lp_edit_item.php
+++ b/main/lp/lp_edit_item.php
@@ -160,6 +160,16 @@ if (!empty($path_file) && isset($path_parts['extension']) && $path_parts['extens
 echo '</div>';
 echo '<div id="doc_form" class="col-md-8">';
 
+$exclude = [
+    'authors',
+    'authorlp',
+    'authorlpitem',
+    'price',
+];
+if (api_is_platform_admin() ) {
+    // Only admins can edit this items
+     $exclude = [];
+}
 if (isset($is_success) && $is_success === true) {
     $msg = '<div class="lp_message" style="margin-bottom:10px;">';
     $msg .= 'The item has been edited.';
@@ -167,7 +177,10 @@ if (isset($is_success) && $is_success === true) {
     echo $learnPath->display_item($_GET['id'], $msg);
 } else {
     $item = $learnPath->getItem($_GET['id']);
-    echo $learnPath->display_edit_item($item->getIid());
+    echo $learnPath->display_edit_item(
+        $item->getIid(),
+        $exclude
+    );
     $finalItem = Session::read('finalItem');
     if ($finalItem) {
         echo '<script>$("#frmModel").remove()</script>';

--- a/main/lp/lp_edit_item.php
+++ b/main/lp/lp_edit_item.php
@@ -166,7 +166,7 @@ $excludeExtraFields = [
     'authorlpitem',
     'price',
 ];
-if (api_is_platform_admin() ) {
+if (api_is_platform_admin()) {
     // Only admins can edit this items
     $excludeExtraFields = [];
 }


### PR DESCRIPTION
En lp_controller.php se cambia el metodo de validacion al momento de guardar la edicion del item en el lp_controller, habilitando asi solo los elementos que se enviaron y no todos los extra field.


Para mostrar los elementos, se establece los campos que no se mostraran al momento de editar el item:

Documentos
Enlace
Quiz

Por los momentos faltarian de ser necesario

Foros
thread
STUDENTPUBLICATION
HOTPOTATOES

PD: Ajustes comentados en https://github.com/chamilo/chamilo-lms/commit/ca7af57dbd0e0895a137e137e1a5ed1f1298c8ac#commitcomment-44947814