### PR TITLE
Plugin buycourses - Corregir maquetación vista de cursos y sesiones

### DIFF
--- a/plugin/buycourses/view/catalog.tpl
+++ b/plugin/buycourses/view/catalog.tpl
@@ -33,10 +33,10 @@
                             {% for course in courses %}
                                 {% set courseCounter = courseCounter + 1 %}
                                 {% if courseCounter == 4 %}
-                                    <div class="clearfix .d-sm-none .d-md-block"></div>
+                                    <div class="clearfix d-sm-none d-md-block"></div>
                                     {% set courseCounter = 0 %}
                                 {% elseif courseCounter == 3 %}
-                                    <div class="clearfix .d-md-none .d-lg-block"></div>
+                                    <div class="clearfix d-md-none d-lg-block"></div>
                                 {% endif %}
                                 <div class="col-md-4 col-sm-6">
                                     <article class="items-course">

--- a/plugin/buycourses/view/catalog.tpl
+++ b/plugin/buycourses/view/catalog.tpl
@@ -33,10 +33,10 @@
                             {% for course in courses %}
                                 {% set courseCounter = courseCounter + 1 %}
                                 {% if courseCounter == 4 %}
-                                    <div class="clearfix d-sm-none d-md-block"></div>
+                                    <div class="clearfix hidden-xs hidden-sm"></div>
                                     {% set courseCounter = 0 %}
                                 {% elseif courseCounter == 3 %}
-                                    <div class="clearfix d-md-none d-lg-block"></div>
+                                    <div class="clearfix hidden-xs hidden-md hidden-lg"></div>
                                 {% endif %}
                                 <div class="col-md-4 col-sm-6">
                                     <article class="items-course">

--- a/plugin/buycourses/view/catalog.tpl
+++ b/plugin/buycourses/view/catalog.tpl
@@ -29,7 +29,15 @@
                 <div class="col-md-9">
                     <div class="row grid-courses">
                         {% if showing_courses %}
+                            {% set courseCounter = 0 %}
                             {% for course in courses %}
+                                {% set courseCounter = courseCounter + 1 %}
+                                {% if courseCounter == 4 %}
+                                    <div class="clearfix .d-sm-none .d-md-block"></div>
+                                    {% set courseCounter = 0 %}
+                                {% elseif courseCounter == 3 %}
+                                    <div class="clearfix .d-md-none .d-lg-block"></div>
+                                {% endif %}
                                 <div class="col-md-4 col-sm-6">
                                     <article class="items-course">
                                         <div class="items-course-image">
@@ -81,7 +89,15 @@
                         {% endif %}
 
                         {% if showing_sessions %}
+                            {% set sessionCounter = 0 %}
                             {% for session in sessions %}
+                                {% set sessionCounter = sessionCounter + 1 %}
+                                {% if sessionCounter == 4 %}
+                                    <div class="clearfix hidden-xs hidden-sm"></div>
+                                    {% set sessionCounter = 0 %}
+                                {% elseif sessionCounter == 3 %}
+                                    <div class="clearfix hidden-xs hidden-md hidden-lg"></div>
+                                {% endif %}
                                 <div class="col-md-4 col-sm-6">
                                     <article class="items-course">
                                         <div class="items-course-image">


### PR DESCRIPTION
En el plugin buycourses si los elementos del catálogo (cursos o sesiones) tienen diferente altura la maquetación "se rompe", por ejemplo:

![imagen](https://user-images.githubusercontent.com/48205899/102248139-226cb980-3f01-11eb-833e-e4a770fd6471.png)

La solución pasa por intercalar un div con la clase _clearfix_ de bootstrap 3 cada número máximo de columnas por fila, por tanto, como tenemos por cada columna las clases de bootstrap _col-md-4_ y _col-sm-6_ se modifica la plantilla buycourses/view/catalog.tpl para que intercale un elemento clearfix cada dos columnas y que quede oculto para las resoluciones de más de 720 px (md) y otro cada tres que quede oculto para resoluciones menores de 720 px, para aseguramos el responsive, el resultado de aplicar este cambio sería el siguiente:

![imagen](https://user-images.githubusercontent.com/48205899/102246093-a7a29f00-3efe-11eb-96e6-ad3c9bc6a3e0.png)
