### PR TITLE
Directory order changed of natsort to natcasesort

### DIFF
--- a/main/inc/lib/document.lib.php
+++ b/main/inc/lib/document.lib.php
@@ -835,7 +835,8 @@ class DocumentManager
                 }
 
                 if (!empty($document_folders)) {
-                    natsort($document_folders);
+                    // natsort($document_folders);
+                     natcasesort ($document_folders);
                 }
 
                 return $document_folders;
@@ -924,11 +925,13 @@ class DocumentManager
             // If both results are arrays -> //calculate the difference between the 2 arrays -> only visible folders are left :)
             if (is_array($visibleFolders) && is_array($invisibleFolders)) {
                 $document_folders = array_diff($visibleFolders, $invisibleFolders);
-                natsort($document_folders);
+                // natsort($document_folders);
+                natcasesort ($document_folders);
 
                 return $document_folders;
             } elseif (is_array($visibleFolders)) {
-                natsort($visibleFolders);
+                natcasesort($visibleFolders);
+                // natsort($visibleFolders);
 
                 return $visibleFolders;
             } else {

--- a/main/inc/lib/document.lib.php
+++ b/main/inc/lib/document.lib.php
@@ -836,7 +836,7 @@ class DocumentManager
 
                 if (!empty($document_folders)) {
                     // natsort($document_folders);
-                     natcasesort ($document_folders);
+                    natcasesort($document_folders);
                 }
 
                 return $document_folders;
@@ -926,7 +926,7 @@ class DocumentManager
             if (is_array($visibleFolders) && is_array($invisibleFolders)) {
                 $document_folders = array_diff($visibleFolders, $invisibleFolders);
                 // natsort($document_folders);
-                natcasesort ($document_folders);
+                natcasesort($document_folders);
 
                 return $document_folders;
             } elseif (is_array($visibleFolders)) {


### PR DESCRIPTION
En la seccion de documentos de un curso, el selector ordena los directorios mediante https://www.php.net/manual/en/function.natsort.php  el cual, ordena determinando mayusculas y minusculas
![imagen](https://user-images.githubusercontent.com/18097392/102284809-e2a6d180-3f02-11eb-85fb-c29c3a27394e.png)

Sin embargo, cuando existen carpetas con mayusculas puede no ordenarlo coherentemente para un humano y puede notarse como un bug. 

Es posible omitir el caso sensivo a mayusculas mediante https://www.php.net/manual/en/function.natcasesort.php manteniendo el orden natural
![imagen](https://user-images.githubusercontent.com/18097392/102284942-32859880-3f03-11eb-864e-29ee97938a8a.png)


#3620 