### PR TITLE
WIP: Plugin Remedial and Advance Course BT# 18165

### DIFF
--- a/main/exercise/exercise.class.php
+++ b/main/exercise/exercise.class.php
@@ -11064,28 +11064,6 @@ class Exercise
     }
 
     /**
-     * Get number of questions in exercise by user attempt.
-     *
-     * @return int
-     */
-    private function countQuestionsInExercise()
-    {
-        $lpId = isset($_REQUEST['learnpath_id']) ? (int) $_REQUEST['learnpath_id'] : 0;
-        $lpItemId = isset($_REQUEST['learnpath_item_id']) ? (int) $_REQUEST['learnpath_item_id'] : 0;
-        $lpItemViewId = isset($_REQUEST['learnpath_item_view_id']) ? (int) $_REQUEST['learnpath_item_view_id'] : 0;
-
-        $trackInfo = $this->get_stat_track_exercise_info($lpId, $lpItemId, $lpItemViewId);
-
-        if (!empty($trackInfo)) {
-            $questionIds = explode(',', $trackInfo['data_tracking']);
-
-            return count($questionIds);
-        }
-
-        return $this->getQuestionCount();
-    }
-
-    /**
      * Gets the question list ordered by the question_order setting (drag and drop).
      *
      * @param bool $adminView Optional.

--- a/main/exercise/exercise.class.php
+++ b/main/exercise/exercise.class.php
@@ -10891,7 +10891,13 @@ class Exercise
         }
         $canRemedial = ($pass == false) ? true : false;
         // Advance Course
-        if ($canRemedial == false) {
+        $extraFieldValue = new ExtraFieldValue('exercise');
+        $advanceCourseExcerciseField = $extraFieldValue->get_values_by_handler_and_field_variable(
+            $this->iId,
+            'advancedcourselist'
+        );
+
+        if ($canRemedial == false && isset($advanceCourseExcerciseField['value'])) {
             $coursesIds = explode(';', $advanceCourseExcerciseField['value']);
             $courses = [];
             foreach ($coursesIds as $course) {

--- a/main/exercise/exercise.class.php
+++ b/main/exercise/exercise.class.php
@@ -2520,7 +2520,7 @@ class Exercise
                         $courseList = SessionManager::getCoursesInSession($sessionId);
                         foreach ($courseList as $course) {
                             $courseSession = api_get_course_info_by_id($course);
-                            if(isset($courseSession['real_id'])) {
+                            if (isset($courseSession['real_id'])) {
                                 $courseId = $courseSession['real_id'];
                                 if (api_get_course_int_id() != $courseId) {
                                     $optionRemedial[$courseId] = $courseSession['title'];
@@ -2537,7 +2537,7 @@ class Exercise
                             false
                         );
                         foreach ($courseList as $course) {
-                            if(isset($course['real_id'])) {
+                            if (isset($course['real_id'])) {
                                 $courseId = $course['real_id'];
                                 if (api_get_course_int_id() != $courseId) {
                                     $optionRemedial[$courseId] = $course['title'];

--- a/main/exercise/exercise.class.php
+++ b/main/exercise/exercise.class.php
@@ -6615,8 +6615,13 @@ class Exercise
         $lpId = 0,
         $lpItemId = 0,
         $lpItemViewId = 0,
-        $filterByAdmin = true
+        $filterByAdmin = true,
+        $sessionId = 0
     ) {
+        $sessionId = (int) $sessionId;
+        if ($sessionId == 0) {
+            $sessionId = $this->sessionId;
+        }
         // 1. By default the exercise is visible
         $isVisible = true;
         $message = null;
@@ -6837,7 +6842,7 @@ class Exercise
                             api_get_user_id(),
                             $this->iId,
                             $this->course_id,
-                            $this->sessionId,
+                            $sessionId,
                             $lpId,
                             $lpItemId
                         );

--- a/main/exercise/exercise.class.php
+++ b/main/exercise/exercise.class.php
@@ -10817,7 +10817,8 @@ class Exercise
      * When a student takes an exam, and he gets an acceptable grade, he is enrolled in a series of courses that
      * represent the next level BT#18165.
      *
-     * @return string|null
+     * @param int $userId
+     *
      */
     public function advanceCourseList($userId = 0)
     {
@@ -10918,14 +10919,16 @@ class Exercise
      * When a student completes the number of attempts and fails the exam, she is enrolled in a series of remedial
      * courses BT#18165.
      *
-     * @return string|null
+     * @param int $userId
+     * @param bool $review
+     *
      */
     public function remedialCourseList($userId = 0, $review = false)
     {
         $questionExcluded = [
             FREE_ANSWER,
             ORAL_EXPRESSION,
-            ANNOTATION
+            ANNOTATION,
         ];
         $userId = ((int) $userId == 0) ? $userId : api_get_user_id();
         $extraMessage = null;

--- a/main/exercise/exercise.class.php
+++ b/main/exercise/exercise.class.php
@@ -2504,17 +2504,16 @@ class Exercise
                 'remedialcourselist' => 'remedialCourseList',
                 'advancedcourselist' => 'advancedCoursList',
             ];
-            $extraFieldExercice = new ExtraFieldValue('exercise');
-            foreach ($remedialList as $item => $label) {
-                $remedialField = $extraFieldExercice->get_handler_field_info_by_field_variable($item);
-                $sessionId = api_get_session_id();
-                if (
-                    isset($remedialField['default_value']) &&
-                    1 == $remedialField['default_value'] // if the plugin is activated
-                ) {
+            $extraFieldExercice = new ExtraField('exercise');
+            $extraFieldExerciceValue = new ExtraFieldValue('exercise');
+            $pluginRemedial = api_get_plugin_setting('remedial_course', 'enabled') === 'true';
+            if ($pluginRemedial) {
+                foreach ($remedialList as $item => $label) {
+                    $remedialField = $extraFieldExercice->get_handler_field_info_by_field_variable($item);
+                    $sessionId = api_get_session_id();
                     $optionRemedial = [];
                     $defaults[$item] = [];
-                    $remedialExtraValue = $extraFieldExercice->get_values_by_handler_and_field_id($this->iId, $remedialField['id']);
+                    $remedialExtraValue = $extraFieldExerciceValue->get_values_by_handler_and_field_id($this->iId, $remedialField['id']);
                     $defaults[$item] = isset($remedialExtraValue['value']) ? explode(';', $remedialExtraValue['value']) : [];
                     if ($sessionId != 0) {
                         $courseList = SessionManager::getCoursesInSession($sessionId);
@@ -2537,7 +2536,7 @@ class Exercise
                         foreach ($courseList as $course) {
                             $courseId = $course['real_id'];
                             if (api_get_course_int_id() != $courseId) {
-                                $optionRemedial[$courseId] =  $course['title'];
+                                $optionRemedial[$courseId] = $course['title'];
                             }
                         }
                     }
@@ -10824,20 +10823,18 @@ class Exercise
      * represent the next level BT#18165.
      *
      * @param int $userId
+     * @param int $sessionId
      */
     public function advanceCourseList($userId = 0, $sessionId = 0)
     {
+        $pluginRemedial = api_get_plugin_setting('remedial_course', 'enabled') === 'true';
+        if(!$pluginRemedial){
+            return null;
+        }
         $field = new ExtraField('exercise');
         $advancedCourseField = $field->get_handler_field_info_by_field_variable('advancedcourselist');
-        $active = 0;
-        if (
-            false != $advancedCourseField &&
-            isset($advancedCourseField['default_value']) &&
-            1 == $advancedCourseField['default_value'] // if the plugin is activated
-        ) {
-            $active = 1;
-        }
-        if (0 == $active) {
+
+        if (false === $advancedCourseField) {
             return null;
         }
         $userId = empty($userId) ? api_get_user_id() : (int) $userId;
@@ -10928,20 +10925,18 @@ class Exercise
      *
      * @param int  $userId
      * @param bool $review
+     * @param int $sessionId
      */
     public function remedialCourseList($userId = 0, $review = false, $sessionId = 0)
     {
+        $pluginRemedial = api_get_plugin_setting('remedial_course', 'enabled') === 'true';
+        if(!$pluginRemedial){
+            return null;
+        }
         $field = new ExtraField('exercise');
         $remedialField = $field->get_handler_field_info_by_field_variable('remedialcourselist');
-        $active = 0;
-        if (
-            false != $remedialField &&
-            isset($remedialField['default_value']) &&
-            1 == $remedialField['default_value'] // if the plugin is activated
-        ) {
-            $active = 1;
-        }
-        if (0 == $active) {
+
+        if (false === $remedialField) {
             return null;
         }
         $questionExcluded = [

--- a/main/exercise/exercise.class.php
+++ b/main/exercise/exercise.class.php
@@ -10945,12 +10945,6 @@ class Exercise
         if (false === $remedialField) {
             return null;
         }
-        // Check blocking exercise.
-        $extraFieldValue = new ExtraFieldValue('exercise');
-        $blockExercise = $extraFieldValue->get_values_by_handler_and_field_variable(
-            $this->iId,
-            'blocking_percentage'
-        );
         $questionExcluded = [
             FREE_ANSWER,
             ORAL_EXPRESSION,
@@ -10988,14 +10982,6 @@ class Exercise
                             return null;
                         }
                     }
-                }
-            }
-            // Check blocking exercise.
-            if ($blockExercise && isset($blockExercise['value']) && !empty($blockExercise['value'])) {
-                $blockPercentage = (int)$blockExercise['value'];
-                if ($attemp['total_percentage'] <= $blockPercentage) {
-                    return null;
-
                 }
             }
         }

--- a/main/exercise/exercise.class.php
+++ b/main/exercise/exercise.class.php
@@ -6842,7 +6842,7 @@ class Exercise
                                 );
                                 $isVisible = false;
                                 // See BT#18165
-                                $message .= $this->remedialCourseList(api_get_user_id(), false, api_get_session_id());
+                                $message .= $this->remedialCourseList(api_get_user_id(), false, api_get_session_id(), true);
                             }
                         }
                     }
@@ -10934,8 +10934,9 @@ class Exercise
      * @param int  $userId
      * @param bool $review
      * @param int  $sessionId
+     * @param bool  $blockPercentage
      */
-    public function remedialCourseList($userId = 0, $review = false, $sessionId = 0)
+    public function remedialCourseList($userId = 0, $review = false, $sessionId = 0, $blockPercentage = false)
     {
         $pluginRemedial = api_get_plugin_setting('remedial_course', 'enabled') === 'true';
         if (!$pluginRemedial) {
@@ -10975,6 +10976,10 @@ class Exercise
                             $questionOpen = 1;
                             break;
                         }
+                    }
+                    if($blockPercentage == true){
+                        // With blocking percentage, it does not matter if there is an open question
+                        $questionOpen = 0;
                     }
                     if (1 == $questionOpen) {
                         $score = $attemp['exe_result'];

--- a/main/exercise/exercise.class.php
+++ b/main/exercise/exercise.class.php
@@ -2528,14 +2528,7 @@ class Exercise
                             }
                         }
                     } else {
-                        $courseList = CourseManager::get_courses_list_by_user_id(
-                            $userId,
-                            false,
-                            false,
-                            true,
-                            [],
-                            false
-                        );
+                        $courseList = CourseManager::get_course_list();
                         foreach ($courseList as $course) {
                             if (!empty($course) && isset($course['real_id'])) {
                                 $courseId = $course['real_id'];
@@ -10961,7 +10954,6 @@ class Exercise
         $userId = (int) $userId;
         $sessionId = (int) $sessionId;
         $pluginRemedial = api_get_plugin_setting('remedial_course', 'enabled') === 'true';
-        echo "<br>/*".__LINE__."*/<br> Session $sessionId. Usuario $userId. Inicio remedial<br>";
         if (!$pluginRemedial) {
             return null;
         }

--- a/main/exercise/exercise.class.php
+++ b/main/exercise/exercise.class.php
@@ -6842,7 +6842,7 @@ class Exercise
                                 );
                                 $isVisible = false;
                                 // See BT#18165
-                                $message .= $this->remedialCourseList(api_get_user_id(), false, api_get_session_id(), true);
+                                $message .= $this->remedialCourseList(api_get_user_id(), false, api_get_session_id());
                             }
                         }
                     }
@@ -10936,7 +10936,7 @@ class Exercise
      * @param int  $sessionId
      * @param bool  $blockPercentage
      */
-    public function remedialCourseList($userId = 0, $review = false, $sessionId = 0, $blockPercentage = false)
+    public function remedialCourseList($userId = 0, $review = false, $sessionId = 0)
     {
         $pluginRemedial = api_get_plugin_setting('remedial_course', 'enabled') === 'true';
         if (!$pluginRemedial) {
@@ -10976,10 +10976,6 @@ class Exercise
                             $questionOpen = 1;
                             break;
                         }
-                    }
-                    if($blockPercentage == true){
-                        // With blocking percentage, it does not matter if there is an open question
-                        $questionOpen = 0;
                     }
                     if (1 == $questionOpen) {
                         $score = $attemp['exe_result'];

--- a/main/exercise/exercise.class.php
+++ b/main/exercise/exercise.class.php
@@ -6854,9 +6854,9 @@ class Exercise
                 $lpItemId,
                 $lpItemViewId
             );
-            $message .= $this->advanceCourseList($userId,api_get_session_id());
+            $message .= $this->advanceCourseList($userId, api_get_session_id());
             if ($attemptCount >= $exerciseAttempts) {
-                $message .= $this->remedialCourseList($userId, false , api_get_session_id());
+                $message .= $this->remedialCourseList($userId, false, api_get_session_id());
             }
         }
 
@@ -10830,7 +10830,7 @@ class Exercise
     public function advanceCourseList($userId = 0, $sessionId = 0)
     {
         $pluginRemedial = api_get_plugin_setting('remedial_course', 'enabled') === 'true';
-        if(!$pluginRemedial){
+        if (!$pluginRemedial) {
             return null;
         }
         $field = new ExtraField('exercise');
@@ -10927,12 +10927,12 @@ class Exercise
      *
      * @param int  $userId
      * @param bool $review
-     * @param int $sessionId
+     * @param int  $sessionId
      */
     public function remedialCourseList($userId = 0, $review = false, $sessionId = 0)
     {
         $pluginRemedial = api_get_plugin_setting('remedial_course', 'enabled') === 'true';
-        if(!$pluginRemedial){
+        if (!$pluginRemedial) {
             return null;
         }
         $field = new ExtraField('exercise');

--- a/main/exercise/exercise.class.php
+++ b/main/exercise/exercise.class.php
@@ -10843,8 +10843,8 @@ class Exercise
         if ($active == 0) {
             return null;
         }
-        $userId = (int) $userId ;
-        if($userId == 0){
+        $userId = (int) $userId;
+        if ($userId == 0) {
             $userId = api_get_user_id();
         }
         $extraMessage = null;
@@ -10891,7 +10891,7 @@ class Exercise
         }
         $canRemedial = ($pass == false) ? true : false;
         // Advance Course
-        if ($canRemedial == false ) {
+        if ($canRemedial == false) {
             $coursesIds = explode(';', $advanceCourseExcerciseField['value']);
             $courses = [];
             foreach ($coursesIds as $course) {
@@ -10951,7 +10951,7 @@ class Exercise
             ANNOTATION,
         ];
         $userId = (int) $userId;
-        if($userId == 0){
+        if ($userId == 0) {
             $userId = api_get_user_id();
         }
         $extraMessage = null;
@@ -11002,7 +11002,7 @@ class Exercise
         );
 
         // Remedial course
-        if ($canRemedial ) {
+        if ($canRemedial) {
             $coursesIds = explode(';', $remedialExcerciseField['value']);
             $courses = [];
             foreach ($coursesIds as $course) {

--- a/main/exercise/exercise.class.php
+++ b/main/exercise/exercise.class.php
@@ -10973,22 +10973,21 @@ class Exercise
             if ($attemp['exe_result'] >= $bestAttempt['exe_result']) {
                 $bestAttempt = $attemp;
             }
-            // The action is blocked if there is still an open question to evaluate
             if (isset($attemp['question_list'])) {
                 foreach ($attemp['question_list'] as $questionId => $answer) {
                     $question = Question::read($questionId, api_get_course_info_by_id($attemp['c_id']));
                     $questionOpen = 0;
                     // in_array($question->type, $questionExcluded, true) dont work here
-                    for($i=0;$i<count($questionExcluded);$i++){
-                        if($question->type == (int)$questionExcluded[$i]){
+                    for ($i = 0; $i < count($questionExcluded); $i++) {
+                        if ($question->type == (int)$questionExcluded[$i]) {
                             $questionOpen = 1;
                             break;
                         }
                     }
-                    if ($questionOpen == 1 ) {
+                    if ($questionOpen == 1) {
                         $score = $attemp['exe_result'];
                         $comments = Event::get_comments($this->id, $questionId);
-                        if (empty($comments) || $score == 0)
+                        if (empty($comments) || $score == 0) {
                             return null;
                         }
                     }

--- a/main/exercise/exercise.class.php
+++ b/main/exercise/exercise.class.php
@@ -10979,7 +10979,7 @@ class Exercise
                     $questionOpen = 0;
                     // in_array($question->type, $questionExcluded, true) dont work here
                     for ($i = 0; $i < count($questionExcluded); $i++) {
-                        if ($question->type == (int)$questionExcluded[$i]) {
+                        if ($question->type == (int) $questionExcluded[$i]) {
                             $questionOpen = 1;
                             break;
                         }

--- a/main/exercise/exercise.class.php
+++ b/main/exercise/exercise.class.php
@@ -10946,20 +10946,23 @@ class Exercise
     }
 
     /**
-     * Returns true if the exercise is locked by percentage. an exercise attempt must be passed
+     * Returns true if the exercise is locked by percentage. an exercise attempt must be passed.
      *
      * @param array $attemp
      *
      * @return bool
      */
-    public function isBlockedByPercentage($attemp = []){
-        if(empty($attemp)) return false;
+    public function isBlockedByPercentage($attemp = [])
+    {
+        if (empty($attemp)) {
+            return false;
+        }
         $extraFieldValue = new ExtraFieldValue('exercise');
         $blockExercise = $extraFieldValue->get_values_by_handler_and_field_variable(
             $this->iId,
             'blocking_percentage'
         );
-        $blockPercentage= 0;
+        $blockPercentage = 0;
         if ($blockExercise && isset($blockExercise['value']) && !empty($blockExercise['value'])) {
             $blockPercentage = (int) $blockExercise['value'];
         }
@@ -10969,7 +10972,6 @@ class Exercise
 
         return false;
     }
-
 
     /**
      * When a student completes the number of attempts and fails the exam, she is enrolled in a series of remedial

--- a/main/exercise/exercise.class.php
+++ b/main/exercise/exercise.class.php
@@ -11021,16 +11021,18 @@ class Exercise
         if (count($bestAttempt) == 0) {
             return null;
         }
-        $percentSuccess = $this->selectPassPercentage();
-        $pass = ExerciseLib::isPassPercentageAttemptPassed(
-            $this,
-            $bestAttempt['exe_result'],
-            $bestAttempt['exe_weighting']
-        );
-        if (0 == $percentSuccess && false == $pass) {
-            return null;
+        $canRemedial = false;
+        if(isset($bestAttempt['exe_result']) && $bestAttempt['exe_result'] !=0 ) {
+            $pass = ExerciseLib::isPassPercentageAttemptPassed(
+                $this,
+                $bestAttempt['exe_result'],
+                $bestAttempt['exe_weighting']
+            );
+            $canRemedial = false === $pass;
+            if (false == $canRemedial) {
+                return null;
+            }
         }
-        $canRemedial = false === $pass;
         $extraFieldValue = new ExtraFieldValue('exercise');
         $remedialExcerciseField = $extraFieldValue->get_values_by_handler_and_field_variable(
             $this->iId,

--- a/main/exercise/exercise.class.php
+++ b/main/exercise/exercise.class.php
@@ -10959,8 +10959,6 @@ class Exercise
                 }
             }
         }
-
-        $total = ;
         $objExercise = new Exercise();
         $objExercise->read($bestAttempt['exe_id']);
         $percentSuccess = (float) $objExercise->selectPassPercentage();

--- a/main/exercise/exercise.class.php
+++ b/main/exercise/exercise.class.php
@@ -10908,17 +10908,17 @@ class Exercise
             if ('' == $advanceCourseExcerciseField['value'] || count($coursesIds) == 0) {
                 return null;
             }
-            $isInASession = (0==$sessionId)?false:true;
+            $isInASession = (0 == $sessionId) ? false : true;
             $courses = [];
             foreach ($coursesIds as $course) {
                 $courseData = api_get_course_info_by_id($course);
                 if (!empty($courseData) && isset($courseData['real_id'])) {
                     // if session is 0, always will be true
                     $courseExistsInSession = true;
-                    if($isInASession){
+                    if ($isInASession) {
                         $courseExistsInSession = SessionManager::sessionHasCourse($sessionId, $courseData['code']);
                     }
-                    if($courseExistsInSession) {
+                    if ($courseExistsInSession) {
                         $isSubscribed = CourseManager::is_user_subscribed_in_course(
                             $userId,
                             $courseData['code'],
@@ -11045,16 +11045,16 @@ class Exercise
                 return null;
             }
             $courses = [];
-            $isInASession = (0==$sessionId)?false:true;
+            $isInASession = (0 == $sessionId) ? false : true;
             foreach ($coursesIds as $course) {
                 $courseData = api_get_course_info_by_id($course);
                 if (!empty($courseData) && isset($courseData['real_id'])) {
                     // if session is 0, always will be true
                     $courseExistsInSession = true;
-                    if($isInASession){
+                    if ($isInASession) {
                         $courseExistsInSession = SessionManager::sessionHasCourse($sessionId, $courseData['code']);
                     }
-                    if($courseExistsInSession) {
+                    if ($courseExistsInSession) {
                         $isSubscribed = CourseManager::is_user_subscribed_in_course(
                             $userId,
                             $courseData['code'],

--- a/main/exercise/exercise.class.php
+++ b/main/exercise/exercise.class.php
@@ -2508,9 +2508,10 @@ class Exercise
             $extraFieldExerciceValue = new ExtraFieldValue('exercise');
             $pluginRemedial = api_get_plugin_setting('remedial_course', 'enabled') === 'true';
             if ($pluginRemedial) {
+                $sessionId = api_get_session_id();
+                $userId = api_get_user_id();
                 foreach ($remedialList as $item => $label) {
                     $remedialField = $extraFieldExercice->get_handler_field_info_by_field_variable($item);
-                    $sessionId = api_get_session_id();
                     $optionRemedial = [];
                     $defaults[$item] = [];
                     $remedialExtraValue = $extraFieldExerciceValue->get_values_by_handler_and_field_id($this->iId, $remedialField['id']);
@@ -2526,7 +2527,7 @@ class Exercise
                         }
                     } else {
                         $courseList = CourseManager::get_courses_list_by_user_id(
-                            api_get_user_id(),
+                            $userId,
                             false,
                             false,
                             true,
@@ -6845,16 +6846,17 @@ class Exercise
         // BT#18165
         $exerciseAttempts = $this->selectAttempts();
         if ($exerciseAttempts > 0) {
+            $userId = api_get_user_id();
             $attemptCount = Event::get_attempt_count_not_finished(
-                api_get_user_id(),
+                $userId,
                 $this->id,
                 $lpId,
                 $lpItemId,
                 $lpItemViewId
             );
-            $message .= $this->advanceCourseList(api_get_user_id(),api_get_session_id());
+            $message .= $this->advanceCourseList($userId,api_get_session_id());
             if ($attemptCount >= $exerciseAttempts) {
-                $message .= $this->remedialCourseList(api_get_user_id(), false , api_get_session_id());
+                $message .= $this->remedialCourseList($userId, false , api_get_session_id());
             }
         }
 
@@ -10879,7 +10881,7 @@ class Exercise
         if (0 == $percentSuccess && false == $pass) {
             return null;
         }
-        $canRemedial = (false === $pass) ? true : false;
+        $canRemedial = false === $pass;
         // Advance Course
         $extraFieldValue = new ExtraFieldValue('exercise');
         $advanceCourseExcerciseField = $extraFieldValue->get_values_by_handler_and_field_variable(
@@ -10988,7 +10990,7 @@ class Exercise
         if (0 == $percentSuccess && false == $pass) {
             return '';
         }
-        $canRemedial = (false == $pass) ? true : false;
+        $canRemedial = false === $pass;
         $extraFieldValue = new ExtraFieldValue('exercise');
         $remedialExcerciseField = $extraFieldValue->get_values_by_handler_and_field_variable(
             $this->iId,

--- a/main/exercise/exercise.class.php
+++ b/main/exercise/exercise.class.php
@@ -10959,7 +10959,7 @@ class Exercise
             ORAL_EXPRESSION,
             ANNOTATION,
         ];
-        $userId = ((int)$userId == 0) ? $userId : api_get_user_id();
+        $userId = ((int) $userId == 0) ? $userId : api_get_user_id();
         $extraMessage = null;
         $bestAttempt = [];
         $exercise_stat_info = Event::getExerciseResultsByUser(

--- a/main/exercise/exercise.class.php
+++ b/main/exercise/exercise.class.php
@@ -11013,7 +11013,7 @@ class Exercise
                 }
             }
         }
-        if (count($bestAttempt)==0) {
+        if (count($bestAttempt) == 0) {
             return null;
         }
         $percentSuccess = $this->selectPassPercentage();

--- a/main/exercise/exercise.class.php
+++ b/main/exercise/exercise.class.php
@@ -11043,8 +11043,6 @@ class Exercise
             foreach ($coursesIds as $course) {
                 $courseData = api_get_course_info_by_id($course);
                 if (!empty($courseData) && isset($courseData['real_id'])) {
-                    // if session is 0, always will be true
-                    $courseExistsInSession = true;
                     if ($isInASession) {
                         $courseExistsInSession = SessionManager::sessionHasCourse($sessionId, $courseData['code']);
                         if ($courseExistsInSession) {

--- a/main/exercise/exercise.class.php
+++ b/main/exercise/exercise.class.php
@@ -6856,7 +6856,7 @@ class Exercise
         if (
             ($remedialField != false && isset($remedialField['default_value']) && $remedialField['default_value'] == 1 // if the plugin is activated
             ) || (
-                $advancedCourseField != false &&  isset($advancedCourseField['default_value']) && $advancedCourseField['default_value'] == 1 // if the plugin is activated
+                $advancedCourseField != false && isset($advancedCourseField['default_value']) && $advancedCourseField['default_value'] == 1 // if the plugin is activated
             )
         ) {
             $exerciseAttempts = $this->selectAttempts();
@@ -6868,7 +6868,7 @@ class Exercise
                     $lpItemId,
                     $lpItemViewId
                 );
-                $message .=  $this->advanceCourseList(api_get_user_id());
+                $message .= $this->advanceCourseList(api_get_user_id());
                 if ($attemptCount >= $exerciseAttempts) {
                     $message .= $this->remedialCourseList(api_get_user_id());
                 }
@@ -10840,7 +10840,6 @@ class Exercise
      * represent the next level BT#18165.
      *
      * @param int $userId
-     *
      */
     public function advanceCourseList($userId = 0)
     {
@@ -10937,9 +10936,8 @@ class Exercise
      * When a student completes the number of attempts and fails the exam, she is enrolled in a series of remedial
      * courses BT#18165.
      *
-     * @param int $userId
+     * @param int  $userId
      * @param bool $review
-     *
      */
     public function remedialCourseList($userId = 0, $review = false)
     {

--- a/main/exercise/exercise.class.php
+++ b/main/exercise/exercise.class.php
@@ -6808,7 +6808,7 @@ class Exercise
             );
             $message .= $this->advanceCourseList($userId, api_get_session_id());
             if ($attemptCount >= $exerciseAttempts) {
-                $message .= $this->remedialCourseList($userId,  api_get_session_id());
+                $message .= $this->remedialCourseList($userId, api_get_session_id());
             }
         }
         // 4. We check if the student have attempts
@@ -6856,7 +6856,7 @@ class Exercise
                                     get_lang('ExerciseBlockBecausePercentageX'),
                                     $blockPercentage
                                 );
-                                $isVisible = false;// See BT#18165
+                                $isVisible = false; // See BT#18165
                                 $message .= $this->remedialCourseList(api_get_user_id(), api_get_session_id());
                             }
                         }
@@ -10856,14 +10856,14 @@ class Exercise
         if (!isset($bestAttempt['exe_result'])) {
             // In the case that the result is 0, get_best_attempt_exercise_results_per_user does not return data,
             // for that this block is used
-            if(count($attemp)==0) {
+            if (count($attemp) == 0) {
                 $exerciseStatInfo = Event::getExerciseResultsByUser(
                     $userId,
                     $this->id,
                     $this->course_id,
                     $sessionId
                 );
-            }else{
+            } else {
                 $exerciseStatInfo = $attemp;
             }
 
@@ -10903,7 +10903,9 @@ class Exercise
 
         if (false === $canRemedial && isset($advanceCourseExcerciseField['value'])) {
             $coursesIds = explode(';', $advanceCourseExcerciseField['value']);
-            if ('' == $advanceCourseExcerciseField['value'] || count($coursesIds)==0) return null;
+            if ('' == $advanceCourseExcerciseField['value'] || count($coursesIds) == 0) {
+                return null;
+            }
             $isInASession = !empty($sessionId);
             $courses = [];
             foreach ($coursesIds as $course) {
@@ -10960,11 +10962,11 @@ class Exercise
             ORAL_EXPRESSION,
             ANNOTATION,
         ];
-        $userId = empty($userId) ? api_get_user_id() : (int)$userId;
+        $userId = empty($userId) ? api_get_user_id() : (int) $userId;
         $extraMessage = null;
-        if(count($attemp)!= 0){
+        if (count($attemp) != 0) {
             $exercise_stat_info = $attemp;
-        }else{
+        } else {
             $exercise_stat_info = Event::getExerciseResultsByUser(
                 $userId,
                 $this->id,
@@ -10988,12 +10990,12 @@ class Exercise
                     $questionOpen = 0;
                     $totalQuestionExcluded = count($questionExcluded);
                     for ($i = 0; $i < $totalQuestionExcluded; $i++) {
-                        if ($question->type == (int)$questionExcluded[$i]) {
+                        if ($question->type == (int) $questionExcluded[$i]) {
                             $questionOpen = 1;
                             break;
                         }
                     }
-                    if($review == true){
+                    if ($review == true) {
                         $questionOpen = 0;
                     }
                     if (1 == $questionOpen) {
@@ -11025,7 +11027,9 @@ class Exercise
         // Remedial course
         if ($canRemedial) {
             $coursesIds = explode(';', $remedialExcerciseField['value']);
-            if ('' == $remedialExcerciseField['value'] || count($coursesIds)==0) return null;
+            if ('' == $remedialExcerciseField['value'] || count($coursesIds) == 0) {
+                return null;
+            }
             $courses = [];
             $isInASession = !empty($sessionId);
             foreach ($coursesIds as $course) {

--- a/main/exercise/exercise.class.php
+++ b/main/exercise/exercise.class.php
@@ -10967,9 +10967,9 @@ class Exercise
             $blockPercentage = (int) $blockExercise['value'];
         }
         $percentage = 0;
-        if ($blockPercentage !=0) {
-            if(isset($attemp['exe_result']) && isset($attemp['exe_weighting'])){
-                $weigh = (int)$attemp['exe_weighting'];
+        if ($blockPercentage != 0) {
+            if (isset($attemp['exe_result']) && isset($attemp['exe_weighting'])) {
+                $weigh = (int) $attemp['exe_weighting'];
                 $weigh = (0 == $weigh) ? 1 : $weigh;
                 $percentage = float_format(
                     ($attemp['exe_result'] / $weigh) * 100,

--- a/main/exercise/exercise.class.php
+++ b/main/exercise/exercise.class.php
@@ -10850,7 +10850,7 @@ class Exercise
             $userId,
             $this->id,
             $this->course_id,
-            $this->sessionId
+            api_get_session_id()
         );
         if (!isset($bestAttempt['exe_result'])) {
             // In the case that the result is 0, get_best_attempt_exercise_results_per_user does not return data,
@@ -10859,7 +10859,7 @@ class Exercise
                 $userId,
                 $this->id,
                 $this->course_id,
-                $this->sessionId
+                api_get_session_id()
             );
             $bestAttempt['exe_result'] = 0;
             foreach ($exercise_stat_info as $attemp) {
@@ -10910,7 +10910,7 @@ class Exercise
                     $userId,
                     $courseData['code'],
                     $isInASession,
-                    $this->sessionId
+                    api_get_session_id()
                 );
 
                 if (!$isSubscribed) {
@@ -10918,7 +10918,7 @@ class Exercise
                         $userId,
                         $courseData['code'],
                         STUDENT,
-                        $this->sessionId
+                        api_get_session_id()
                     );
                 }
                 $courses[] = $courseData['title'];
@@ -10953,7 +10953,7 @@ class Exercise
             $userId,
             $this->iId,
             $this->course_id,
-            $this->sessionId
+            api_get_session_id()
         );
         $bestAttempt['exe_result'] = 0;
         foreach ($exercise_stat_info as $attemp) {
@@ -11012,7 +11012,7 @@ class Exercise
                     $userId,
                     $courseData['code'],
                     $isInASession,
-                    $this->sessionId
+                    api_get_session_id()
                 );
 
                 if (!$isSubscribed) {
@@ -11020,7 +11020,7 @@ class Exercise
                         $userId,
                         $courseData['code'],
                         STUDENT,
-                        $this->sessionId
+                        api_get_session_id()
                     );
 
                     $courses[] = $courseData['title'];

--- a/main/exercise/exercise.class.php
+++ b/main/exercise/exercise.class.php
@@ -2520,9 +2520,11 @@ class Exercise
                         $courseList = SessionManager::getCoursesInSession($sessionId);
                         foreach ($courseList as $course) {
                             $courseSession = api_get_course_info_by_id($course);
-                            $courseId = $courseSession['real_id'];
-                            if (api_get_course_int_id() != $courseId) {
-                                $optionRemedial[$courseId] = $courseSession['title'];
+                            if(isset($courseSession['real_id'])) {
+                                $courseId = $courseSession['real_id'];
+                                if (api_get_course_int_id() != $courseId) {
+                                    $optionRemedial[$courseId] = $courseSession['title'];
+                                }
                             }
                         }
                     } else {
@@ -2535,9 +2537,11 @@ class Exercise
                             false
                         );
                         foreach ($courseList as $course) {
-                            $courseId = $course['real_id'];
-                            if (api_get_course_int_id() != $courseId) {
-                                $optionRemedial[$courseId] = $course['title'];
+                            if(isset($course['real_id'])) {
+                                $courseId = $course['real_id'];
+                                if (api_get_course_int_id() != $courseId) {
+                                    $optionRemedial[$courseId] = $course['title'];
+                                }
                             }
                         }
                     }

--- a/main/exercise/exercise.class.php
+++ b/main/exercise/exercise.class.php
@@ -6847,31 +6847,18 @@ class Exercise
             }
         }
         // BT#18165
-        $field = new ExtraField('exercise');
-        $advancedCourseField = $field->get_handler_field_info_by_field_variable('advancedcourselist');
-
-        $field = new ExtraField('exercise');
-        $remedialField = $field->get_handler_field_info_by_field_variable('remedialcourselist');
-
-        if (
-            ($remedialField != false && isset($remedialField['default_value']) && $remedialField['default_value'] == 1 // if the plugin is activated
-            ) || (
-                $advancedCourseField != false && isset($advancedCourseField['default_value']) && $advancedCourseField['default_value'] == 1 // if the plugin is activated
-            )
-        ) {
-            $exerciseAttempts = $this->selectAttempts();
-            if ($exerciseAttempts > 0) {
-                $attemptCount = Event::get_attempt_count_not_finished(
-                    api_get_user_id(),
-                    $this->id,
-                    $lpId,
-                    $lpItemId,
-                    $lpItemViewId
-                );
-                $message .= $this->advanceCourseList(api_get_user_id());
-                if ($attemptCount >= $exerciseAttempts) {
-                    $message .= $this->remedialCourseList(api_get_user_id());
-                }
+        $exerciseAttempts = $this->selectAttempts();
+        if ($exerciseAttempts > 0) {
+            $attemptCount = Event::get_attempt_count_not_finished(
+                api_get_user_id(),
+                $this->id,
+                $lpId,
+                $lpItemId,
+                $lpItemViewId
+            );
+            $message .= $this->advanceCourseList(api_get_user_id());
+            if ($attemptCount >= $exerciseAttempts) {
+                $message .= $this->remedialCourseList(api_get_user_id());
             }
         }
 
@@ -10843,6 +10830,19 @@ class Exercise
      */
     public function advanceCourseList($userId = 0)
     {
+        $field = new ExtraField('exercise');
+        $advancedCourseField = $field->get_handler_field_info_by_field_variable('advancedcourselist');
+        $active = 0;
+        if (
+            $advancedCourseField != false &&
+            isset($advancedCourseField['default_value']) &&
+            $advancedCourseField['default_value'] == 1 // if the plugin is activated
+        ) {
+            $active = 1;
+        }
+        if ($active == 0) {
+            return null;
+        }
         $userId = ((int) $userId == 0) ? $userId : api_get_user_id();
         $extraMessage = null;
 
@@ -10941,12 +10941,25 @@ class Exercise
      */
     public function remedialCourseList($userId = 0, $review = false)
     {
+        $field = new ExtraField('exercise');
+        $remedialField = $field->get_handler_field_info_by_field_variable('remedialcourselist');
+        $active = 0;
+        if (
+            $remedialField != false &&
+            isset($remedialField['default_value']) &&
+            $remedialField['default_value'] == 1 // if the plugin is activated
+        ) {
+            $active = 1;
+        }
+        if ($active == 0) {
+            return null;
+        }
         $questionExcluded = [
             FREE_ANSWER,
             ORAL_EXPRESSION,
             ANNOTATION,
         ];
-        $userId = ((int) $userId == 0) ? $userId : api_get_user_id();
+        $userId = ((int)$userId == 0) ? $userId : api_get_user_id();
         $extraMessage = null;
         $bestAttempt = [];
         $exercise_stat_info = Event::getExerciseResultsByUser(

--- a/main/exercise/exercise.class.php
+++ b/main/exercise/exercise.class.php
@@ -10966,8 +10966,19 @@ class Exercise
         if ($blockExercise && isset($blockExercise['value']) && !empty($blockExercise['value'])) {
             $blockPercentage = (int) $blockExercise['value'];
         }
-        if ($attemp['exe_result'] <= $blockPercentage && $blockPercentage != 0) {
-            return true;
+        $percentage = 0;
+        if ($blockPercentage !=0) {
+            if(isset($attemp['exe_result']) && isset($attemp['exe_weighting'])){
+                $weigh = (int)$attemp['exe_weighting'];
+                $weigh = (0 == $weigh) ? 1 : $weigh;
+                $percentage = float_format(
+                    ($attemp['exe_result'] / $weigh) * 100,
+                    1
+                );
+            }
+            if ($percentage <= $blockPercentage && 0 != $percentage) {
+                return true;
+            }
         }
 
         return false;

--- a/main/exercise/exercise.class.php
+++ b/main/exercise/exercise.class.php
@@ -11022,7 +11022,7 @@ class Exercise
             return null;
         }
         $canRemedial = false;
-        if(isset($bestAttempt['exe_result']) && $bestAttempt['exe_result'] !=0 ) {
+        if (isset($bestAttempt['exe_result']) && $bestAttempt['exe_result'] != 0) {
             $pass = ExerciseLib::isPassPercentageAttemptPassed(
                 $this,
                 $bestAttempt['exe_result'],

--- a/main/exercise/exercise.class.php
+++ b/main/exercise/exercise.class.php
@@ -10945,12 +10945,18 @@ class Exercise
         if (false === $remedialField) {
             return null;
         }
+        // Check blocking exercise.
+        $extraFieldValue = new ExtraFieldValue('exercise');
+        $blockExercise = $extraFieldValue->get_values_by_handler_and_field_variable(
+            $this->iId,
+            'blocking_percentage'
+        );
         $questionExcluded = [
             FREE_ANSWER,
             ORAL_EXPRESSION,
             ANNOTATION,
         ];
-        $userId = empty($userId) ? api_get_user_id() : (int) $userId;
+        $userId = empty($userId) ? api_get_user_id() : (int)$userId;
         $extraMessage = null;
         $bestAttempt = [];
         $exercise_stat_info = Event::getExerciseResultsByUser(
@@ -10982,6 +10988,14 @@ class Exercise
                             return null;
                         }
                     }
+                }
+            }
+            // Check blocking exercise.
+            if ($blockExercise && isset($blockExercise['value']) && !empty($blockExercise['value'])) {
+                $blockPercentage = (int)$blockExercise['value'];
+                if ($attemp['total_percentage'] <= $blockPercentage) {
+                    return null;
+
                 }
             }
         }

--- a/main/exercise/exercise.class.php
+++ b/main/exercise/exercise.class.php
@@ -10974,17 +10974,21 @@ class Exercise
                 $bestAttempt = $attemp;
             }
             // The action is blocked if there is still an open question to evaluate
-            if (isset($bestAttempt['question_list'])) {
-                foreach ($bestAttempt['question_list'] as $questionId => $answer) {
-                    $question = Question::read($questionId, api_get_course_info_by_id($bestAttempt['c_id']));
-                    if (in_array($question->type, $questionExcluded, true) >= 0 && $review == false) {
-                        $score = $bestAttempt['exe_result'];
-                        $comments = Event::get_comments($this->id, $questionId);
-                        $waitingForReview = false;
-                        if (empty($comments) || $score == 0) {
-                            $waitingForReview = true;
+            if (isset($attemp['question_list'])) {
+                foreach ($attemp['question_list'] as $questionId => $answer) {
+                    $question = Question::read($questionId, api_get_course_info_by_id($attemp['c_id']));
+                    $questionOpen = 0;
+                    // in_array($question->type, $questionExcluded, true) dont work here
+                    for($i=0;$i<count($questionExcluded);$i++){
+                        if($question->type == (int)$questionExcluded[$i]){
+                            $questionOpen = 1;
+                            break;
                         }
-                        if (true === $waitingForReview) {
+                    }
+                    if ($questionOpen == 1 ) {
+                        $score = $attemp['exe_result'];
+                        $comments = Event::get_comments($this->id, $questionId);
+                        if (empty($comments) || $score == 0)
                             return null;
                         }
                     }

--- a/main/exercise/exercise.class.php
+++ b/main/exercise/exercise.class.php
@@ -6841,6 +6841,8 @@ class Exercise
                                     $blockPercentage
                                 );
                                 $isVisible = false;
+                                // See BT#18165
+                                $message .= $this->remedialCourseList(api_get_user_id(), false, api_get_session_id());
                             }
                         }
                     }
@@ -10968,7 +10970,6 @@ class Exercise
                 foreach ($attemp['question_list'] as $questionId => $answer) {
                     $question = Question::read($questionId, api_get_course_info_by_id($attemp['c_id']));
                     $questionOpen = 0;
-                    // in_array($question->type, $questionExcluded, true) dont work here
                     for ($i = 0; $i < count($questionExcluded); $i++) {
                         if ($question->type == (int) $questionExcluded[$i]) {
                             $questionOpen = 1;

--- a/main/exercise/exercise.class.php
+++ b/main/exercise/exercise.class.php
@@ -10950,7 +10950,7 @@ class Exercise
             ORAL_EXPRESSION,
             ANNOTATION,
         ];
-        $userId = empty($userId) ? api_get_user_id() : (int)$userId;
+        $userId = empty($userId) ? api_get_user_id() : (int) $userId;
         $extraMessage = null;
         $bestAttempt = [];
         $exercise_stat_info = Event::getExerciseResultsByUser(

--- a/main/exercise/exercise_report.php
+++ b/main/exercise/exercise_report.php
@@ -266,8 +266,8 @@ if (isset($_REQUEST['comments']) &&
     Database::query($sql);
 
     // See BT#18165
-     $objExerciseTmp->remedialCourseList($student_id,true);
-     $objExerciseTmp->advanceCourseList($student_id);
+    $objExerciseTmp->remedialCourseList($student_id, true);
+    $objExerciseTmp->advanceCourseList($student_id);
 
     if (isset($_POST['send_notification'])) {
         //@todo move this somewhere else

--- a/main/exercise/exercise_report.php
+++ b/main/exercise/exercise_report.php
@@ -266,8 +266,8 @@ if (isset($_REQUEST['comments']) &&
     Database::query($sql);
 
     // See BT#18165
-    $objExerciseTmp->remedialCourseList($student_id, true);
-    $objExerciseTmp->advanceCourseList($student_id);
+    $objExerciseTmp->remedialCourseList($student_id, true, api_get_session_id());
+    $objExerciseTmp->advanceCourseList($student_id,api_get_session_id());
 
     if (isset($_POST['send_notification'])) {
         //@todo move this somewhere else

--- a/main/exercise/exercise_report.php
+++ b/main/exercise/exercise_report.php
@@ -267,7 +267,7 @@ if (isset($_REQUEST['comments']) &&
 
     // See BT#18165
     $objExerciseTmp->remedialCourseList($student_id, true, api_get_session_id());
-    $objExerciseTmp->advanceCourseList($student_id,api_get_session_id());
+    $objExerciseTmp->advanceCourseList($student_id, api_get_session_id());
 
     if (isset($_POST['send_notification'])) {
         //@todo move this somewhere else

--- a/main/exercise/exercise_report.php
+++ b/main/exercise/exercise_report.php
@@ -266,7 +266,7 @@ if (isset($_REQUEST['comments']) &&
     Database::query($sql);
 
     // See BT#18165
-    $remedialMessage = $objExerciseTmp->remedialCourseList($student_id, api_get_session_id(),[],true);
+    $remedialMessage = $objExerciseTmp->remedialCourseList($student_id, api_get_session_id(), [], true);
     if (null != $remedialMessage) {
         Display::addFlash(
             Display::return_message($remedialMessage, 'warning', false)

--- a/main/exercise/exercise_report.php
+++ b/main/exercise/exercise_report.php
@@ -266,9 +266,20 @@ if (isset($_REQUEST['comments']) &&
     Database::query($sql);
 
     // See BT#18165
-    $objExerciseTmp->remedialCourseList($student_id, true, api_get_session_id());
-    $objExerciseTmp->advanceCourseList($student_id, api_get_session_id());
-
+    $remedialMessage = $objExerciseTmp->remedialCourseList($student_id, api_get_session_id(),[],true);
+    if (null != $remedialMessage) {
+        Display::addFlash(
+            Display::return_message($remedialMessage, 'warning', false)
+        );
+    }
+    $advanceMessage = $objExerciseTmp->advanceCourseList($student_id, api_get_session_id());
+    if (!empty($advanceMessage)) {
+        $message = Display::return_message(
+            $advanceMessage,
+            'info',
+            false
+        );
+    }
     if (isset($_POST['send_notification'])) {
         //@todo move this somewhere else
         $subject = get_lang('ExamSheetVCC');

--- a/main/exercise/exercise_report.php
+++ b/main/exercise/exercise_report.php
@@ -265,6 +265,10 @@ if (isset($_REQUEST['comments']) &&
             WHERE exe_id = ".$id;
     Database::query($sql);
 
+    // See BT#18165
+     $objExerciseTmp->remedialCourseList($student_id,true);
+     $objExerciseTmp->advanceCourseList($student_id);
+
     if (isset($_POST['send_notification'])) {
         //@todo move this somewhere else
         $subject = get_lang('ExamSheetVCC');

--- a/main/exercise/exercise_result.php
+++ b/main/exercise/exercise_result.php
@@ -265,14 +265,14 @@ if ($exerciseAttempts > 0) {
     if ($attempt_count >= $exerciseAttempts) {
         $remedialMessage .= $objExercise->remedialCourseList(api_get_user_id(), false, api_get_session_id());
     }
-    if ($remedialMessage != null) {
+    if (null != $remedialMessage) {
         Display::addFlash(
             Display::return_message($remedialMessage, 'warning', false)
         );
     }
 }
 
-if ($advanceCourseMessage != null) {
+if (null != $advanceCourseMessage) {
     Display::addFlash(
         Display::return_message($advanceCourseMessage, 'info', false)
     );

--- a/main/exercise/exercise_result.php
+++ b/main/exercise/exercise_result.php
@@ -276,6 +276,10 @@ ExerciseLib::exercise_time_control_delete(
     $learnpath_id,
     $learnpath_item_id
 );
+
+// See BT#18165
+$objExercise->advanceCourseList();
+
 ExerciseLib::delete_chat_exercise_session($exeId);
 
 if (!in_array($origin, ['learnpath', 'embeddable', 'mobileapp'])) {

--- a/main/exercise/exercise_result.php
+++ b/main/exercise/exercise_result.php
@@ -115,7 +115,7 @@ $learnpath_id = isset($exercise_stat_info['orig_lp_id']) ? $exercise_stat_info['
 $learnpath_item_id = isset($exercise_stat_info['orig_lp_item_id']) ? $exercise_stat_info['orig_lp_item_id'] : 0;
 $learnpath_item_view_id = isset($exercise_stat_info['orig_lp_item_view_id'])
     ? $exercise_stat_info['orig_lp_item_view_id'] : 0;
-$exerciseId = isset($exercise_stat_info['exe_exo_id'])?$exercise_stat_info['exe_exo_id']:0;
+$exerciseId = isset($exercise_stat_info['exe_exo_id']) ? $exercise_stat_info['exe_exo_id'] : 0;
 
 $logInfo = [
     'tool' => TOOL_QUIZ,
@@ -276,13 +276,13 @@ $exerciseStatInfo = Event::getExerciseResultsByUser(
     api_get_course_int_id(),
     api_get_session_id()
 );
-$advanceCourseMessage = $objExercise->advanceCourseList(api_get_user_id(), api_get_session_id(),$exerciseStatInfo);
+$advanceCourseMessage = $objExercise->advanceCourseList(api_get_user_id(), api_get_session_id(), $exerciseStatInfo);
 if (null != $advanceCourseMessage) {
     Display::addFlash(
         Display::return_message($advanceCourseMessage, 'info', false)
     );
 }
-$remedialMessage = $objExercise->remedialCourseList(api_get_user_id(),api_get_session_id(),$exerciseStatInfo);
+$remedialMessage = $objExercise->remedialCourseList(api_get_user_id(), api_get_session_id(), $exerciseStatInfo);
 if (null != $remedialMessage) {
     Display::addFlash(
         Display::return_message($remedialMessage, 'warning', false)

--- a/main/exercise/exercise_result.php
+++ b/main/exercise/exercise_result.php
@@ -290,7 +290,7 @@ if (null != $advanceCourseMessage) {
     );
 }
 $remedialMessage = null;
-if ($attempt_count >= $objExercise->selectAttempts()) {
+if ($attempt_count >= $objExercise->selectAttempts() || $objExercise->isBlockedByPercentage($exercise_stat_info)) {
     $remedialMessage = $objExercise->remedialCourseList(api_get_user_id(), api_get_session_id(), $exerciseStatInfo);
 }
 if (null != $remedialMessage) {

--- a/main/exercise/exercise_result.php
+++ b/main/exercise/exercise_result.php
@@ -203,8 +203,6 @@ if (!empty($exercise_stat_info)) {
 }
 
 $max_score = $objExercise->get_max_score();
-// See BT#18165
-$advanceCourseMessage = $objExercise->advanceCourseList(api_get_user_id());
 
 if ('embeddable' === $origin) {
     $pageTop .= showEmbeddableFinishButton();
@@ -212,12 +210,6 @@ if ('embeddable' === $origin) {
     Display::addFlash(
         Display::return_message(get_lang('Saved'), 'normal', false)
     );
-
-    if($advanceCourseMessage != null){
-        Display::addFlash(
-            Display::return_message($advanceCourseMessage, 'info', false)
-        );
-    }
 }
 $saveResults = true;
 $feedbackType = $objExercise->getFeedbackType();
@@ -262,6 +254,28 @@ $objExercise->disableHideCorrectAnsweredQuestions = false;
 if (!empty($learnpath_id) && $saveResults) {
     // Save attempt in lp
     Exercise::saveExerciseInLp($learnpath_item_id, $exeId);
+}
+
+$exerciseAttempts = $objExercise->selectAttempts();
+$remedialMessage = null;
+// See BT#18165
+$advanceCourseMessage = $objExercise->advanceCourseList(api_get_user_id());
+
+if ($exerciseAttempts > 0) {
+    if ($attempt_count >= $exerciseAttempts) {
+        $remedialMessage .= $objExercise->remedialCourseList(api_get_user_id());
+    }
+    if($remedialMessage != null){
+        Display::addFlash(
+            Display::return_message($remedialMessage, 'warning', false)
+        );
+    }
+}
+
+if($advanceCourseMessage != null){
+    Display::addFlash(
+        Display::return_message($advanceCourseMessage, 'info', false)
+    );
 }
 
 ExerciseLib::sendNotification(

--- a/main/exercise/exercise_result.php
+++ b/main/exercise/exercise_result.php
@@ -203,6 +203,8 @@ if (!empty($exercise_stat_info)) {
 }
 
 $max_score = $objExercise->get_max_score();
+// See BT#18165
+$advanceCourseMessage = $objExercise->advanceCourseList(api_get_user_id());
 
 if ('embeddable' === $origin) {
     $pageTop .= showEmbeddableFinishButton();
@@ -210,6 +212,12 @@ if ('embeddable' === $origin) {
     Display::addFlash(
         Display::return_message(get_lang('Saved'), 'normal', false)
     );
+
+    if($advanceCourseMessage != null){
+        Display::addFlash(
+            Display::return_message($advanceCourseMessage, 'info', false)
+        );
+    }
 }
 $saveResults = true;
 $feedbackType = $objExercise->getFeedbackType();
@@ -277,8 +285,6 @@ ExerciseLib::exercise_time_control_delete(
     $learnpath_item_id
 );
 
-// See BT#18165
-$objExercise->advanceCourseList();
 
 ExerciseLib::delete_chat_exercise_session($exeId);
 

--- a/main/exercise/exercise_result.php
+++ b/main/exercise/exercise_result.php
@@ -265,14 +265,14 @@ if ($exerciseAttempts > 0) {
     if ($attempt_count >= $exerciseAttempts) {
         $remedialMessage .= $objExercise->remedialCourseList(api_get_user_id());
     }
-    if($remedialMessage != null){
+    if ($remedialMessage != null) {
         Display::addFlash(
             Display::return_message($remedialMessage, 'warning', false)
         );
     }
 }
 
-if($advanceCourseMessage != null){
+if ($advanceCourseMessage != null) {
     Display::addFlash(
         Display::return_message($advanceCourseMessage, 'info', false)
     );
@@ -298,7 +298,6 @@ ExerciseLib::exercise_time_control_delete(
     $learnpath_id,
     $learnpath_item_id
 );
-
 
 ExerciseLib::delete_chat_exercise_session($exeId);
 

--- a/main/exercise/exercise_result.php
+++ b/main/exercise/exercise_result.php
@@ -276,13 +276,23 @@ $exerciseStatInfo = Event::getExerciseResultsByUser(
     api_get_course_int_id(),
     api_get_session_id()
 );
+$attempt_count = Event::get_attempt_count(
+    $currentUserId,
+    $exerciseId,
+    $learnpath_id,
+    $learnpath_item_id,
+    $learnpath_item_view_id
+);
 $advanceCourseMessage = $objExercise->advanceCourseList(api_get_user_id(), api_get_session_id(), $exerciseStatInfo);
 if (null != $advanceCourseMessage) {
     Display::addFlash(
         Display::return_message($advanceCourseMessage, 'info', false)
     );
 }
-$remedialMessage = $objExercise->remedialCourseList(api_get_user_id(), api_get_session_id(), $exerciseStatInfo);
+$remedialMessage = null;
+if ($attempt_count >= $objExercise->selectAttempts()) {
+    $remedialMessage = $objExercise->remedialCourseList(api_get_user_id(), api_get_session_id(), $exerciseStatInfo);
+}
 if (null != $remedialMessage) {
     Display::addFlash(
         Display::return_message($remedialMessage, 'warning', false)

--- a/main/exercise/exercise_result.php
+++ b/main/exercise/exercise_result.php
@@ -259,11 +259,11 @@ if (!empty($learnpath_id) && $saveResults) {
 $exerciseAttempts = $objExercise->selectAttempts();
 $remedialMessage = null;
 // See BT#18165
-$advanceCourseMessage = $objExercise->advanceCourseList(api_get_user_id());
+$advanceCourseMessage = $objExercise->advanceCourseList(api_get_user_id(),api_get_session_id());
 
 if ($exerciseAttempts > 0) {
     if ($attempt_count >= $exerciseAttempts) {
-        $remedialMessage .= $objExercise->remedialCourseList(api_get_user_id());
+        $remedialMessage .= $objExercise->remedialCourseList(api_get_user_id(), false, api_get_session_id());
     }
     if ($remedialMessage != null) {
         Display::addFlash(

--- a/main/exercise/exercise_result.php
+++ b/main/exercise/exercise_result.php
@@ -259,7 +259,7 @@ if (!empty($learnpath_id) && $saveResults) {
 $exerciseAttempts = $objExercise->selectAttempts();
 $remedialMessage = null;
 // See BT#18165
-$advanceCourseMessage = $objExercise->advanceCourseList(api_get_user_id(),api_get_session_id());
+$advanceCourseMessage = $objExercise->advanceCourseList(api_get_user_id(), api_get_session_id());
 
 if ($exerciseAttempts > 0) {
     if ($attempt_count >= $exerciseAttempts) {

--- a/main/exercise/exercise_submit.php
+++ b/main/exercise/exercise_submit.php
@@ -1053,7 +1053,9 @@ if (api_is_course_admin() && !in_array($origin, ['learnpath', 'embeddable'])) {
 $is_visible_return = $objExercise->is_visible(
     $learnpath_id,
     $learnpath_item_id,
-    $learnpath_item_view_id
+    $learnpath_item_view_id,
+    true,
+    $sessionId
 );
 
 if ($is_visible_return['value'] == false) {

--- a/main/exercise/overview.php
+++ b/main/exercise/overview.php
@@ -196,7 +196,7 @@ if ($visible_return['value'] == false) {
         $exercise_url_button = null;
     }
 } else {
-    $text = $objExercise->advanceCourseList(api_get_user_id(),api_get_session_id());
+    $text = $objExercise->advanceCourseList(api_get_user_id(), api_get_session_id());
     if (!empty($text)) {
         $message = Display::return_message(
             $text,

--- a/main/exercise/overview.php
+++ b/main/exercise/overview.php
@@ -181,7 +181,8 @@ $visible_return = $objExercise->is_visible(
     $learnpath_id,
     $learnpath_item_id,
     null,
-    true
+    true,
+    $sessionId
 );
 
 // Exercise is not visible remove the button

--- a/main/exercise/overview.php
+++ b/main/exercise/overview.php
@@ -195,18 +195,16 @@ if ($visible_return['value'] == false) {
         $message = $visible_return['message'];
         $exercise_url_button = null;
     }
-}else{
+} else {
     $text = $objExercise->advanceCourseList(api_get_user_id());
-    if(!empty($text)){
+    if (!empty($text)) {
         $message = Display::return_message(
             $text,
             'info',
             false
         );
     }
-
 }
-
 
 if (!api_is_allowed_to_session_edit()) {
     $exercise_url_button = null;

--- a/main/exercise/overview.php
+++ b/main/exercise/overview.php
@@ -195,7 +195,18 @@ if ($visible_return['value'] == false) {
         $message = $visible_return['message'];
         $exercise_url_button = null;
     }
+}else{
+    $text = $objExercise->advanceCourseList(api_get_user_id());
+    if(!empty($text)){
+        $message = Display::return_message(
+            $text,
+            'info',
+            false
+        );
+    }
+
 }
+
 
 if (!api_is_allowed_to_session_edit()) {
     $exercise_url_button = null;

--- a/main/exercise/overview.php
+++ b/main/exercise/overview.php
@@ -215,8 +215,8 @@ $exercise_stat_info = Event::getExerciseResultsByUser(
 );
 $attempt_count = count($exercise_stat_info) + 1;
 if ($exerciseAttempts > 0) {
-    if ($attempt_count >= $exerciseAttempts) {
-        $remedialMessage .= $objExercise->remedialCourseList(api_get_user_id(), api_get_session_id());
+    if ($attempt_count > $exerciseAttempts) {
+        $remedialMessage .= $objExercise->remedialCourseList(api_get_user_id(), api_get_session_id(), $exercise_stat_info);
     }
     if (null != $remedialMessage) {
         Display::addFlash(

--- a/main/exercise/overview.php
+++ b/main/exercise/overview.php
@@ -195,13 +195,31 @@ if ($visible_return['value'] == false) {
         $message = $visible_return['message'];
         $exercise_url_button = null;
     }
-} else {
-    $text = $objExercise->advanceCourseList(api_get_user_id(), api_get_session_id());
-    if (!empty($text)) {
-        $message = Display::return_message(
-            $text,
-            'info',
-            false
+}
+$advanceMessage = $objExercise->advanceCourseList(api_get_user_id(), api_get_session_id());
+if (!empty($advanceMessage)) {
+    $message = Display::return_message(
+        $advanceMessage,
+        'info',
+        false
+    );
+}
+$exerciseAttempts = $objExercise->selectAttempts();
+$remedialMessage = null;
+$exercise_stat_info = Event::getExerciseResultsByUser(
+    api_get_user_id(),
+    $objExercise->iId,
+    $objExercise->course_id,
+    api_get_session_id()
+);
+$attempt_count= count($exercise_stat_info)+1;
+if ($exerciseAttempts > 0) {
+    if ($attempt_count >= $exerciseAttempts) {
+        $remedialMessage .= $objExercise->remedialCourseList(api_get_user_id(), api_get_session_id());
+    }
+    if (null != $remedialMessage) {
+        Display::addFlash(
+            Display::return_message($remedialMessage, 'warning', false)
         );
     }
 }

--- a/main/exercise/overview.php
+++ b/main/exercise/overview.php
@@ -196,7 +196,7 @@ if ($visible_return['value'] == false) {
         $exercise_url_button = null;
     }
 } else {
-    $text = $objExercise->advanceCourseList(api_get_user_id());
+    $text = $objExercise->advanceCourseList(api_get_user_id(),api_get_session_id());
     if (!empty($text)) {
         $message = Display::return_message(
             $text,

--- a/main/exercise/overview.php
+++ b/main/exercise/overview.php
@@ -212,7 +212,7 @@ $exercise_stat_info = Event::getExerciseResultsByUser(
     $objExercise->course_id,
     api_get_session_id()
 );
-$attempt_count= count($exercise_stat_info)+1;
+$attempt_count = count($exercise_stat_info) + 1;
 if ($exerciseAttempts > 0) {
     if ($attempt_count >= $exerciseAttempts) {
         $remedialMessage .= $objExercise->remedialCourseList(api_get_user_id(), api_get_session_id());

--- a/main/inc/lib/plugin.lib.php
+++ b/main/inc/lib/plugin.lib.php
@@ -259,6 +259,7 @@ class AppPlugin
             'positioning',
             'questionoptionsevaluation',
             'redirection',
+            'remedial_course',
             'reports',
             'resubscription',
             'rss',

--- a/main/inc/lib/usergroup.lib.php
+++ b/main/inc/lib/usergroup.lib.php
@@ -446,7 +446,7 @@ class UserGroup extends Model
      * Gets all users that are part of a group or class.
      *
      * @param array $options
-     * @param int   $type        0 = classes / 1 = social groups
+     * @param int   $type    0 = classes / 1 = social groups
      *
      * @return array
      */
@@ -520,7 +520,8 @@ class UserGroup extends Model
         if ($getCount) {
             if (Database::num_rows($result)) {
                 $row = Database::fetch_array($result);
-                return  $row['count'];
+
+                return $row['count'];
             }
 
             return 0;

--- a/plugin/remedial_course/README.md
+++ b/plugin/remedial_course/README.md
@@ -1,0 +1,17 @@
+Create a field to remedial course
+======
+
+The purpose of this plugin is the possibility of adding remedial courses or advanced courses so that, when a course is 
+approved or failed, you can opt for a set of remedial courses or advanced courses.
+
+* For remedial courses:
+  When activating the plugin, in the test settings, a remedialCourseList field is enabled, where the course (s) to be 
+  taken is established if the user fails all the course attempts.
+  For this to work, the number of attempts must be activated and also, have an exam success rate enabled.
+  After the user fails the last attempt, they automatically enroll in the selected courses.
+
+* For advanced courses:
+  When activating the plugin, in the test settings, the advanceCourseList field is enabled, which allows you to select 
+  one or more courses that will be added to the user when they have passed an exam.
+  This function is independent of the number of attempts, but the passing percentage must be established from the test 
+  configuration.

--- a/plugin/remedial_course/RemedialCoursePlugin.php
+++ b/plugin/remedial_course/RemedialCoursePlugin.php
@@ -9,19 +9,7 @@ require_once __DIR__.'/../../main/inc/global.inc.php';
 class RemedialCoursePlugin extends Plugin
 {
     const SETTING_ENABLED = 'enabled';
-    /**
-     * @var array
-     */
-    protected $remedialField;
-    /**
-     * @var array
-     */
-    protected $remedialAdvanceField;
-    //advancedCourseList
 
-    /**
-     * RemedialCoursePlugin constructor.
-     */
     public function __construct()
     {
         $settings = [
@@ -33,41 +21,6 @@ class RemedialCoursePlugin extends Plugin
             $settings
         );
         $this->setSettings();
-        $field = new ExtraField('exercise');
-        $remedialField = $field->get_handler_field_info_by_field_variable('remedialcourselist');
-
-        if (empty($remedialField)) {
-            $remedialField = [
-                'field_type' => ExtraField::FIELD_TYPE_SELECT_MULTIPLE,
-                'variable' => 'remedialcourselist',
-                'display_text' => 'remedialCourseList',
-                'default_value' => 1,
-                'field_order' => 0,
-                'visible_to_self' => 1,
-                'visible_to_others' => 0,
-                'changeable' => 1,
-                'filter' => 0,
-            ];
-        }
-        $this->remedialField = $remedialField;
-        //Advance
-        $field = new ExtraField('exercise');
-        $remedialAdvanceField = $field->get_handler_field_info_by_field_variable('advancedCourseList');
-
-        if (empty($remedialAdvanceField)) {
-            $remedialAdvanceField = [
-                'field_type' => ExtraField::FIELD_TYPE_SELECT_MULTIPLE,
-                'variable' => 'advancedcourselist',
-                'display_text' => 'advancedCourseList',
-                'default_value' => 1,
-                'field_order' => 0,
-                'visible_to_self' => 1,
-                'visible_to_others' => 0,
-                'changeable' => 1,
-                'filter' => 0,
-            ];
-        }
-        $this->remedialAdvanceField = $remedialAdvanceField;
     }
 
     /**
@@ -97,14 +50,20 @@ class RemedialCoursePlugin extends Plugin
      */
     public function SaveRemedialField()
     {
-        $schedule = new ExtraField('exercise');
-        $data = $this->getDataRemedialField();
-        $data['default_value'] = 1;
-        $data['visible_to_self'] = 1;
-        if (isset($data['id'])) {
-            $schedule->update($data);
-        } else {
-            $schedule->save($data);
+        $extraField = new ExtraField('exercise');
+        $remedialcourselist = $extraField->get_handler_field_info_by_field_variable('remedialcourselist');
+        if (false === $remedialcourselist) {
+            $extraField->save([
+                'field_type' => ExtraField::FIELD_TYPE_SELECT_MULTIPLE,
+                'variable' => 'remedialcourselist',
+                'display_text' => 'remedialCourseList',
+                'default_value' => 1,
+                'field_order' => 0,
+                'visible_to_self' => 1,
+                'visible_to_others' => 0,
+                'changeable' => 1,
+                'filter' => 0,
+            ]);
         }
     }
 
@@ -114,61 +73,21 @@ class RemedialCoursePlugin extends Plugin
      */
     public function SaveAdvanceRemedialField()
     {
-        $schedule = new ExtraField('exercise');
-        $data = $this->getDataAdvanceRemedialField();
-        $data['default_value'] = 1;
-        $data['visible_to_self'] = 1;
-        if (isset($data['id'])) {
-            $schedule->update($data);
-        } else {
-            $schedule->save($data);
+        $extraField = new ExtraField('exercise');
+        $advancedcourselist = $extraField->get_handler_field_info_by_field_variable('advancedcourselist');
+        if (false === $advancedcourselist) {
+            $extraField->save([
+                'field_type' => ExtraField::FIELD_TYPE_SELECT_MULTIPLE,
+                'variable' => 'advancedcourselist',
+                'display_text' => 'advancedCourseList',
+                'default_value' => 1,
+                'field_order' => 0,
+                'visible_to_self' => 1,
+                'visible_to_others' => 0,
+                'changeable' => 1,
+                'filter' => 0,
+            ]);
         }
-    }
-
-    /**
-     * Make a array clean of remedialcourselist.
-     *
-     * @return array|bool
-     */
-    public function getDataRemedialField($install = true)
-    {
-        $data = $this->remedialField;
-
-        $data['field_type'] = isset($data['field_type']) ? $data['field_type'] : ExtraField::FIELD_TYPE_SELECT_MULTIPLE;
-        $data['field_order'] = isset($data['field_order']) ? $data['field_order'] : $data['field_order']; // at
-        $data['variable'] = isset($data['variable']) ? $data['variable'] : 'remedialcourselist';
-        $data['display_text'] = isset($data['display_text']) ? $data['display_text'] : 'remedialCourseList';
-        $data['default_value'] = (int) $install;
-        $data['field_order'] = isset($data['field_order']) ? $data['field_order'] : 0;
-        $data['visible_to_self'] = isset($data['visible_to_self']) ? $data['visible_to_self'] : 1;
-        $data['visible_to_others'] = isset($data['visible_to_others']) ? $data['visible_to_others'] : 0;
-        $data['changeable'] = isset($data['changeable']) ? $data['changeable'] : 1;
-        $data['filter'] = isset($data['filter']) ? $data['filter'] : 0;
-
-        return $data;
-    }
-
-    /**
-     * Make a array clean of advancedcourselist.
-     *
-     * @return array|bool
-     */
-    public function getDataAdvanceRemedialField($install = true)
-    {
-        $data = $this->remedialAdvanceField;
-
-        $data['field_type'] = isset($data['field_type']) ? $data['field_type'] : ExtraField::FIELD_TYPE_SELECT_MULTIPLE;
-        $data['field_order'] = isset($data['field_order']) ? $data['field_order'] : $data['field_order']; // at
-        $data['variable'] = isset($data['variable']) ? $data['variable'] : 'advancedcourselist';
-        $data['display_text'] = isset($data['display_text']) ? $data['display_text'] : 'advancedCourseList';
-        $data['default_value'] = (int) $install;
-        $data['field_order'] = isset($data['field_order']) ? $data['field_order'] : 0;
-        $data['visible_to_self'] = isset($data['visible_to_self']) ? $data['visible_to_self'] : 1;
-        $data['visible_to_others'] = isset($data['visible_to_others']) ? $data['visible_to_others'] : 0;
-        $data['changeable'] = isset($data['changeable']) ? $data['changeable'] : 1;
-        $data['filter'] = isset($data['filter']) ? $data['filter'] : 0;
-
-        return $data;
     }
 
     /**

--- a/plugin/remedial_course/RemedialCoursePlugin.php
+++ b/plugin/remedial_course/RemedialCoursePlugin.php
@@ -1,0 +1,191 @@
+<?php
+
+/* For licensing terms, see /license.txt */
+
+/**
+ * Class RemedialCoursePlugin.
+ */
+class RemedialCoursePlugin extends Plugin
+{
+    /**
+     * @var array
+     */
+    protected $remedialField;
+    /**
+     * @var array
+     */
+    protected $remedialAdvanceField;
+//advancedCourseList
+
+    /**
+     * RemedialCoursePlugin constructor.
+     */
+    public function __construct()
+    {
+        parent::__construct(
+            '1.0',
+            'Carlos Alvarado'
+        );
+        $field = new ExtraField('exercise');
+        $remedialField = $field->get_handler_field_info_by_field_variable('remedialcourselist');
+
+        if (empty($remedialField)) {
+            $remedialField = [
+                'field_type' => ExtraField::FIELD_TYPE_SELECT_MULTIPLE,
+                'variable' => 'remedialcourselist',
+                'display_text' => 'remedialCourseList',
+                'default_value' => 1,
+                'field_order' => 0,
+                'visible_to_self' => 1,
+                'visible_to_others' => 0,
+                'changeable' => 1,
+                'filter' => 0,
+            ];
+        }
+        $this->remedialField = $remedialField;
+        //Advance
+        $field = new ExtraField('exercise');
+        $remedialAdvanceField = $field->get_handler_field_info_by_field_variable('advancedCourseList');
+
+        if (empty($remedialAdvanceField)) {
+            $remedialAdvanceField = [
+                'field_type' => ExtraField::FIELD_TYPE_SELECT_MULTIPLE,
+                'variable' => 'advancedcourselist',
+                'display_text' => 'advancedCourseList',
+                'default_value' => 1,
+                'field_order' => 0,
+                'visible_to_self' => 1,
+                'visible_to_others' => 0,
+                'changeable' => 1,
+                'filter' => 0,
+            ];
+        }
+        $this->remedialAdvanceField = $remedialAdvanceField;
+    }
+
+    /**
+     * Create a new instance of RemedialCoursePlugin.
+     *
+     * @return RemedialCoursePlugin
+     */
+    public static function create()
+    {
+        static $result = null;
+
+        return $result ? $result : $result = new self();
+    }
+
+    /**
+     * Perform the plugin installation.
+     */
+    public function install()
+    {
+        $this->SaveRemedialField();
+        $this->SaveAdvanceRemedialField();
+    }
+
+
+    /**
+     * Save the arrangement for remedialcourselist, it is adjusted internally so that the values
+     * match the necessary ones.
+     */
+    public function SaveRemedialField()
+    {
+
+        $schedule = new ExtraField('exercise');
+        $data = $this->getDataRemedialField();
+        $data['default_value'] = 1;
+        if (isset($data['id'])) {
+            $schedule->update($data);
+        } else {
+            $schedule->save($data);
+        }
+    }
+
+    /**
+     * Save the arrangement for remedialadvancecourselist, it is adjusted internally so that the values
+     * match the necessary ones.
+     */
+    public function SaveAdvanceRemedialField()
+    {
+
+        $schedule = new ExtraField('exercise');
+        $data = $this->getDataAdvanceRemedialField();
+        $data['default_value'] = 1;
+        if (isset($data['id'])) {
+            $schedule->update($data);
+        } else {
+            $schedule->save($data);
+        }
+    }
+
+    /**
+     * Make a array clean of remedialcourselist
+     *
+     * @return array|bool
+     */
+    public function getDataRemedialField($install = true)
+    {
+        $data = $this->remedialField;
+
+        $data['field_type'] = isset($data['field_type']) ? $data['field_type'] : ExtraField::FIELD_TYPE_SELECT_MULTIPLE;
+        $data['field_order'] = isset($data['field_order']) ? $data['field_order'] : $data['field_order']; // at
+        $data['variable'] = isset($data['variable']) ? $data['variable'] : 'remedialcourselist';
+        $data['display_text'] = isset($data['display_text']) ? $data['display_text'] : 'remedialCourseList';
+        $data['default_value'] = (int)$install;
+        $data['field_order'] = isset($data['field_order']) ? $data['field_order'] : 0;
+        $data['visible_to_self'] = isset($data['visible_to_self']) ? $data['visible_to_self'] : 1;
+        $data['visible_to_others'] = isset($data['visible_to_others']) ? $data['visible_to_others'] : 0;
+        $data['changeable'] = isset($data['changeable']) ? $data['changeable'] : 1;
+        $data['filter'] = isset($data['filter']) ? $data['filter'] : 0;
+        return $data;
+    }
+
+    /**
+     * Make a array clean of advancedcourselist
+     *
+     * @return array|bool
+     */
+    public function getDataAdvanceRemedialField($install = true)
+    {
+        $data = $this->remedialAdvanceField;
+
+        $data['field_type'] = isset($data['field_type']) ? $data['field_type'] : ExtraField::FIELD_TYPE_SELECT_MULTIPLE;
+        $data['field_order'] = isset($data['field_order']) ? $data['field_order'] : $data['field_order']; // at
+        $data['variable'] = isset($data['variable']) ? $data['variable'] : 'advancedcourselist';
+        $data['display_text'] = isset($data['display_text']) ? $data['display_text'] : 'advancedCourseList';
+        $data['default_value'] = (int)$install;
+        $data['field_order'] = isset($data['field_order']) ? $data['field_order'] : 0;
+        $data['visible_to_self'] = isset($data['visible_to_self']) ? $data['visible_to_self'] : 1;
+        $data['visible_to_others'] = isset($data['visible_to_others']) ? $data['visible_to_others'] : 0;
+        $data['changeable'] = isset($data['changeable']) ? $data['changeable'] : 1;
+        $data['filter'] = isset($data['filter']) ? $data['filter'] : 0;
+        return $data;
+    }
+
+    /**
+     * Set default_value to 0.
+     */
+    public function uninstall()
+    {
+        $schedule = new ExtraField('exercise');
+        $data = $this->getDataRemedialField(false);
+        $data['default_value'] = 0;
+        if (isset($data['id'])) {
+            $schedule->update($data);
+        } else {
+            $schedule->save($data);
+        }
+
+        //advance
+        $schedule = new ExtraField('exercise');
+        $data = $this->getDataAdvanceRemedialField(false);
+        $data['default_value'] = 0;
+        if (isset($data['id'])) {
+            $schedule->update($data);
+        } else {
+            $schedule->save($data);
+        }
+    }
+
+}

--- a/plugin/remedial_course/RemedialCoursePlugin.php
+++ b/plugin/remedial_course/RemedialCoursePlugin.php
@@ -40,15 +40,15 @@ class RemedialCoursePlugin extends Plugin
      */
     public function install()
     {
-        $this->SaveRemedialField();
-        $this->SaveAdvanceRemedialField();
+        $this->saveRemedialField();
+        $this->saveAdvanceRemedialField();
     }
 
     /**
      * Save the arrangement for remedialcourselist, it is adjusted internally so that the values
      * match the necessary ones.
      */
-    public function SaveRemedialField()
+    public function saveRemedialField()
     {
         $extraField = new ExtraField('exercise');
         $remedialcourselist = $extraField->get_handler_field_info_by_field_variable('remedialcourselist');
@@ -71,7 +71,7 @@ class RemedialCoursePlugin extends Plugin
      * Save the arrangement for remedialadvancecourselist, it is adjusted internally so that the values
      * match the necessary ones.
      */
-    public function SaveAdvanceRemedialField()
+    public function saveAdvanceRemedialField()
     {
         $extraField = new ExtraField('exercise');
         $advancedcourselist = $extraField->get_handler_field_info_by_field_variable('advancedcourselist');

--- a/plugin/remedial_course/RemedialCoursePlugin.php
+++ b/plugin/remedial_course/RemedialCoursePlugin.php
@@ -93,6 +93,7 @@ class RemedialCoursePlugin extends Plugin
         $schedule = new ExtraField('exercise');
         $data = $this->getDataRemedialField();
         $data['default_value'] = 1;
+        $data['visible_to_self'] = 1;
         if (isset($data['id'])) {
             $schedule->update($data);
         } else {
@@ -109,6 +110,7 @@ class RemedialCoursePlugin extends Plugin
         $schedule = new ExtraField('exercise');
         $data = $this->getDataAdvanceRemedialField();
         $data['default_value'] = 1;
+        $data['visible_to_self'] = 1;
         if (isset($data['id'])) {
             $schedule->update($data);
         } else {
@@ -170,6 +172,7 @@ class RemedialCoursePlugin extends Plugin
         $schedule = new ExtraField('exercise');
         $data = $this->getDataRemedialField(false);
         $data['default_value'] = 0;
+        $data['visible_to_self'] = 0;
         if (isset($data['id'])) {
             $schedule->update($data);
         } else {
@@ -180,6 +183,7 @@ class RemedialCoursePlugin extends Plugin
         $schedule = new ExtraField('exercise');
         $data = $this->getDataAdvanceRemedialField(false);
         $data['default_value'] = 0;
+        $data['visible_to_self'] = 0;
         if (isset($data['id'])) {
             $schedule->update($data);
         } else {

--- a/plugin/remedial_course/RemedialCoursePlugin.php
+++ b/plugin/remedial_course/RemedialCoursePlugin.php
@@ -4,7 +4,7 @@
 require_once __DIR__.'/../../main/inc/global.inc.php';
 
 /**
- * Class RemedialCoursePlugin
+ * Class RemedialCoursePlugin.
  */
 class RemedialCoursePlugin extends Plugin
 {

--- a/plugin/remedial_course/RemedialCoursePlugin.php
+++ b/plugin/remedial_course/RemedialCoursePlugin.php
@@ -1,12 +1,14 @@
 <?php
 
 /* For licensing terms, see /license.txt */
+require_once __DIR__.'/../../main/inc/global.inc.php';
 
 /**
- * Class RemedialCoursePlugin.
+ * Class RemedialCoursePlugin
  */
 class RemedialCoursePlugin extends Plugin
 {
+    const SETTING_ENABLED = 'enabled';
     /**
      * @var array
      */
@@ -22,10 +24,15 @@ class RemedialCoursePlugin extends Plugin
      */
     public function __construct()
     {
+        $settings = [
+            self::SETTING_ENABLED => 'boolean',
+        ];
         parent::__construct(
             '1.0',
-            'Carlos Alvarado'
+            'Carlos Alvarado',
+            $settings
         );
+        $this->setSettings();
         $field = new ExtraField('exercise');
         $remedialField = $field->get_handler_field_info_by_field_variable('remedialcourselist');
 
@@ -169,25 +176,15 @@ class RemedialCoursePlugin extends Plugin
      */
     public function uninstall()
     {
-        $schedule = new ExtraField('exercise');
-        $data = $this->getDataRemedialField(false);
-        $data['default_value'] = 0;
-        $data['visible_to_self'] = 0;
-        if (isset($data['id'])) {
-            $schedule->update($data);
-        } else {
-            $schedule->save($data);
-        }
+    }
 
-        //advance
-        $schedule = new ExtraField('exercise');
-        $data = $this->getDataAdvanceRemedialField(false);
-        $data['default_value'] = 0;
-        $data['visible_to_self'] = 0;
-        if (isset($data['id'])) {
-            $schedule->update($data);
-        } else {
-            $schedule->save($data);
+    /**
+     * Set the  settings.
+     */
+    private function setSettings()
+    {
+        if ('true' !== $this->get(self::SETTING_ENABLED)) {
+            return;
         }
     }
 }

--- a/plugin/remedial_course/RemedialCoursePlugin.php
+++ b/plugin/remedial_course/RemedialCoursePlugin.php
@@ -15,7 +15,7 @@ class RemedialCoursePlugin extends Plugin
      * @var array
      */
     protected $remedialAdvanceField;
-//advancedCourseList
+    //advancedCourseList
 
     /**
      * RemedialCoursePlugin constructor.
@@ -84,14 +84,12 @@ class RemedialCoursePlugin extends Plugin
         $this->SaveAdvanceRemedialField();
     }
 
-
     /**
      * Save the arrangement for remedialcourselist, it is adjusted internally so that the values
      * match the necessary ones.
      */
     public function SaveRemedialField()
     {
-
         $schedule = new ExtraField('exercise');
         $data = $this->getDataRemedialField();
         $data['default_value'] = 1;
@@ -108,7 +106,6 @@ class RemedialCoursePlugin extends Plugin
      */
     public function SaveAdvanceRemedialField()
     {
-
         $schedule = new ExtraField('exercise');
         $data = $this->getDataAdvanceRemedialField();
         $data['default_value'] = 1;
@@ -120,7 +117,7 @@ class RemedialCoursePlugin extends Plugin
     }
 
     /**
-     * Make a array clean of remedialcourselist
+     * Make a array clean of remedialcourselist.
      *
      * @return array|bool
      */
@@ -132,17 +129,18 @@ class RemedialCoursePlugin extends Plugin
         $data['field_order'] = isset($data['field_order']) ? $data['field_order'] : $data['field_order']; // at
         $data['variable'] = isset($data['variable']) ? $data['variable'] : 'remedialcourselist';
         $data['display_text'] = isset($data['display_text']) ? $data['display_text'] : 'remedialCourseList';
-        $data['default_value'] = (int)$install;
+        $data['default_value'] = (int) $install;
         $data['field_order'] = isset($data['field_order']) ? $data['field_order'] : 0;
         $data['visible_to_self'] = isset($data['visible_to_self']) ? $data['visible_to_self'] : 1;
         $data['visible_to_others'] = isset($data['visible_to_others']) ? $data['visible_to_others'] : 0;
         $data['changeable'] = isset($data['changeable']) ? $data['changeable'] : 1;
         $data['filter'] = isset($data['filter']) ? $data['filter'] : 0;
+
         return $data;
     }
 
     /**
-     * Make a array clean of advancedcourselist
+     * Make a array clean of advancedcourselist.
      *
      * @return array|bool
      */
@@ -154,12 +152,13 @@ class RemedialCoursePlugin extends Plugin
         $data['field_order'] = isset($data['field_order']) ? $data['field_order'] : $data['field_order']; // at
         $data['variable'] = isset($data['variable']) ? $data['variable'] : 'advancedcourselist';
         $data['display_text'] = isset($data['display_text']) ? $data['display_text'] : 'advancedCourseList';
-        $data['default_value'] = (int)$install;
+        $data['default_value'] = (int) $install;
         $data['field_order'] = isset($data['field_order']) ? $data['field_order'] : 0;
         $data['visible_to_self'] = isset($data['visible_to_self']) ? $data['visible_to_self'] : 1;
         $data['visible_to_others'] = isset($data['visible_to_others']) ? $data['visible_to_others'] : 0;
         $data['changeable'] = isset($data['changeable']) ? $data['changeable'] : 1;
         $data['filter'] = isset($data['filter']) ? $data['filter'] : 0;
+
         return $data;
     }
 
@@ -187,5 +186,4 @@ class RemedialCoursePlugin extends Plugin
             $schedule->save($data);
         }
     }
-
 }

--- a/plugin/remedial_course/config.php
+++ b/plugin/remedial_course/config.php
@@ -2,3 +2,4 @@
 /* For licensing terms, see /license.txt */
 
 require_once __DIR__.'/../../main/inc/global.inc.php';
+require_once 'RemedialCoursePlugin.php';

--- a/plugin/remedial_course/config.php
+++ b/plugin/remedial_course/config.php
@@ -1,0 +1,5 @@
+<?php
+/* For licensing terms, see /license.txt */
+
+require_once __DIR__.'/../../main/inc/global.inc.php';
+require_once __DIR__.'/RemedialCoursePlugin.php';

--- a/plugin/remedial_course/config.php
+++ b/plugin/remedial_course/config.php
@@ -2,4 +2,3 @@
 /* For licensing terms, see /license.txt */
 
 require_once __DIR__.'/../../main/inc/global.inc.php';
-require_once __DIR__.'/RemedialCoursePlugin.php';

--- a/plugin/remedial_course/index.php
+++ b/plugin/remedial_course/index.php
@@ -3,7 +3,7 @@
 /* For licensing terms, see /license.txt */
 
 // Check extra_field remedialcourselist and advancedCourseList
-require_once __DIR__.'/../../main/inc/global.inc.php';
+require_once __DIR__.'/config.php';
 
 if (api_is_anonymous()) {
 }

--- a/plugin/remedial_course/index.php
+++ b/plugin/remedial_course/index.php
@@ -4,4 +4,3 @@
 
 // Check extra_field remedialcourselist and advancedCourseList
 require_once __DIR__.'/config.php';
-

--- a/plugin/remedial_course/index.php
+++ b/plugin/remedial_course/index.php
@@ -1,0 +1,9 @@
+<?php
+
+/* For licensing terms, see /license.txt */
+
+// Check extra_field remedialcourselist and advancedCourseList
+require_once __DIR__.'/../../main/inc/global.inc.php';
+
+if (api_is_anonymous()) {
+}

--- a/plugin/remedial_course/index.php
+++ b/plugin/remedial_course/index.php
@@ -5,5 +5,3 @@
 // Check extra_field remedialcourselist and advancedCourseList
 require_once __DIR__.'/config.php';
 
-if (api_is_anonymous()) {
-}

--- a/plugin/remedial_course/install.php
+++ b/plugin/remedial_course/install.php
@@ -3,7 +3,7 @@
 /* For licensing terms, see /license.txt */
 
 // Check extra_field remedialcourselist and advancedCourseList
-require_once 'RemedialCoursePlugin.php';
+require_once __DIR__.'/config.php';
 
 if (!api_is_platform_admin()) {
     exit('You must have admin permissions to install plugins');

--- a/plugin/remedial_course/install.php
+++ b/plugin/remedial_course/install.php
@@ -1,0 +1,11 @@
+<?php
+
+/* For licensing terms, see /license.txt */
+
+// Check extra_field remedialcourselist and advancedCourseList
+require_once 'RemedialCoursePlugin.php';
+
+if (!api_is_platform_admin()) {
+    exit('You must have admin permissions to install plugins');
+}
+RemedialCoursePlugin::create()->install();

--- a/plugin/remedial_course/plugin.php
+++ b/plugin/remedial_course/plugin.php
@@ -1,4 +1,5 @@
 <?php
+require_once __DIR__.'/config.php';
 
 /* For licensing terms, see /license.txt */
 
@@ -14,9 +15,17 @@
 /**
  * Plugin details (must be present).
  */
+$plugin_info = RemedialCoursePlugin::create()->get_info();
 $plugin_info['title'] = 'Remedial and Advance Courses';
 $plugin_info['comment'] = 'It adds the possibility of enrolling the user in a remedial course when the last '.
     'attempt of an exercise fails or an advanced course when they pass an exercise. The success rate of '.
     'the exercise must be established';
 $plugin_info['version'] = '1.0'; // o la versión que corresponda
 $plugin_info['author'] = 'Carlos Alvarado';
+
+$strings['plugin_title'] = 'Remedial and Advance Courses';
+$strings['title'] = 'Remedial and Advance Courses';
+$strings['enabled'] = 'Enabled';
+$strings['plugin_comment'] = 'It adds the possibility of enrolling the user in a remedial course when the last '.
+    'attempt of an exercise fails or an advanced course when they pass an exercise. The success rate of '.
+    'the exercise must be established';

--- a/plugin/remedial_course/plugin.php
+++ b/plugin/remedial_course/plugin.php
@@ -8,8 +8,6 @@ require_once __DIR__.'/config.php';
  * (course plugins are slightly different).
  * These settings will be used in the administration interface for plugins (Chamilo configuration settings->Plugins).
  *
- * @package chamilo.plugin
- *
  * @author Carlos Alvarado <alvaradocarlo@gmail.com>
  */
 /**

--- a/plugin/remedial_course/plugin.php
+++ b/plugin/remedial_course/plugin.php
@@ -22,10 +22,3 @@ $plugin_info['comment'] = 'It adds the possibility of enrolling the user in a re
     'the exercise must be established';
 $plugin_info['version'] = '1.0'; // o la versión que corresponda
 $plugin_info['author'] = 'Carlos Alvarado';
-
-$strings['plugin_title'] = 'Remedial and Advance Courses';
-$strings['title'] = 'Remedial and Advance Courses';
-$strings['enabled'] = 'Enabled';
-$strings['plugin_comment'] = 'It adds the possibility of enrolling the user in a remedial course when the last '.
-    'attempt of an exercise fails or an advanced course when they pass an exercise. The success rate of '.
-    'the exercise must be established';

--- a/plugin/remedial_course/plugin.php
+++ b/plugin/remedial_course/plugin.php
@@ -1,0 +1,22 @@
+<?php
+
+/* For licensing terms, see /license.txt */
+
+/**
+ * This script is a configuration file for the date plugin. You can use it as a master for other platform plugins
+ * (course plugins are slightly different).
+ * These settings will be used in the administration interface for plugins (Chamilo configuration settings->Plugins).
+ *
+ * @package chamilo.plugin
+ *
+ * @author Carlos Alvarado <alvaradocarlo@gmail.com>
+ */
+/**
+ * Plugin details (must be present).
+ */
+$plugin_info['title'] = 'Remedial and Advance Courses';
+$plugin_info['comment'] = 'It adds the possibility of enrolling the user in a remedial course when the last '.
+    'attempt of an exercise fails or an advanced course when they pass an exercise. The success rate of '.
+    'the exercise must be established';
+$plugin_info['version'] = '1.0'; // o la versión que corresponda
+$plugin_info['author'] = 'Carlos Alvarado';

--- a/plugin/remedial_course/uninstall.php
+++ b/plugin/remedial_course/uninstall.php
@@ -1,0 +1,10 @@
+<?php
+
+/* For license terms, see /license.txt */
+
+require_once 'RemedialCoursePlugin.php';
+
+if (!api_is_platform_admin()) {
+    exit('You must have admin permissions to uninstall plugins');
+}
+RemedialCoursePlugin::create()->uninstall();

--- a/plugin/remedial_course/uninstall.php
+++ b/plugin/remedial_course/uninstall.php
@@ -2,7 +2,7 @@
 
 /* For license terms, see /license.txt */
 
-require_once 'RemedialCoursePlugin.php';
+require_once __DIR__.'/config.php';
 
 if (!api_is_platform_admin()) {
     exit('You must have admin permissions to uninstall plugins');


### PR DESCRIPTION
Se requiere crear un plugin que permita la inscripcion de los alumnos en cursos remediales cuando estos fallan el ultimo intento de una prueba, como tambien, si pasan la prueba pueden ser inscritos en cursos mas avanzados (ejeplo subir de nivel de español basico a español intermedio).

Este plugin debe crear dos campos:
remedialcourselist -> Variable de lenguaje remedialCourseList
advancedcourselist-> Variable de lenguaje advancedCoursList

![imagen](https://user-images.githubusercontent.com/18097392/102821541-43bc2280-43a5-11eb-84ae-243f406d48a1.png)

Por los momentos, para desactivar el plugin se debe establecer default_value en 0 y para que este activo, default_value debe ser 1. Posteriormente tambien se limitará la visibilidad.

Estos campos habilitaran parametros avanzados dentro de la configuracion de un ejercicio, y estableceran los cursos que se tomaran cuando el usuario falla o pasa el ejercicio.
![imagen](https://user-images.githubusercontent.com/18097392/102821866-e1afed00-43a5-11eb-99a7-7b79af29cba6.png)


Sin embargo, es requerido evaluar la cantidad de ejercicios por corregir para cuado las preguntas son de desarrollo, y asi prevenir que se le inscriba en un curso remedial cuando aun exista la posiblidad de que llegue a pasar el examen luego que el docente evalue la respuesta.
![imagen](https://user-images.githubusercontent.com/18097392/102822009-250a5b80-43a6-11eb-8503-1541b073df47.png)
