### PR TITLE
ReportAuthor: Ajuste para mostrar correctamente autores en el reporte y edicion de item de lp

### DIFF
--- a/main/inc/lib/myspace.lib.php
+++ b/main/inc/lib/myspace.lib.php
@@ -1401,7 +1401,8 @@ class MySpace
                     FROM $tblExtraFieldValue
                     WHERE
                         field_id IN ( $queryExtraFieldPrice ) AND
-                        item_id in ($cLpItems)";
+                        item_id in ($cLpItems)
+                        AND value != 0";
             $queryResult = Database::query($sql);
             $lpItemPrice = [];
             while ($row = Database::fetch_array($queryResult, 'ASSOC')) {
@@ -4067,18 +4068,9 @@ class MySpace
             FROM
                 $tblItemProperty
             WHERE
-                c_id IN (
-                    SELECT
-                        c_id
-                    FROM
-                        ".TABLE_MAIN_COURSE_USER."
-                    WHERE
-                        STATUS = 5
-                )
-                AND lastedit_type = 'LearnpathSubscription'
+                lastedit_type = 'LearnpathSubscription'
 
                 ";
-            // -- AND $selectToCompany IS NOT NULL
             if (strlen($whereCondition) > 2) {
                 $query .= $whereCondition;
             }

--- a/main/lp/learnpath.class.php
+++ b/main/lp/learnpath.class.php
@@ -7335,7 +7335,7 @@ class learnpath
             case 'dir':
             case 'asset':
             case 'sco':
-                if (isset($_GET['view']) && $_GET['view'] == 'build') {
+            if (isset($_GET['view']) && $_GET['view'] == 'build') {
                     $return .= $this->display_manipulate($item_id, $row['item_type']);
                     $return .= $this->display_item_form(
                         $row['item_type'],
@@ -7749,6 +7749,7 @@ class learnpath
 
         $form->addHidden('type', TOOL_QUIZ);
         $form->addHidden('post_time', time());
+        $form = $this->getAutorLpItem($form);
         $form->setDefaults($defaults);
 
         return '<div class="sectioncomment">'.$form->returnForm().'</div>';
@@ -8110,6 +8111,7 @@ class learnpath
         }
         $form->addHidden('type', TOOL_FORUM);
         $form->addHidden('post_time', time());
+        $form = $this->getAutorLpItem($form);
         $form->setDefaults($defaults);
 
         return '<div class="sectioncomment">'.$form->returnForm().'</div>';
@@ -8314,6 +8316,7 @@ class learnpath
 
         $form->addHidden('type', TOOL_THREAD);
         $form->addHidden('post_time', time());
+        $form = $this->getAutorLpItem($form);
         $form->setDefaults($defaults);
 
         return $form->returnForm();
@@ -8963,6 +8966,7 @@ class learnpath
         }
         $form->addElement('hidden', 'type', TOOL_DOCUMENT);
         $form->addElement('hidden', 'post_time', time());
+        $form = $this->getAutorLpItem($form);
         $form->setDefaults($defaults);
 
         return $form->returnForm();
@@ -9254,6 +9258,7 @@ class learnpath
 
         $form->addElement('hidden', 'type', TOOL_READOUT_TEXT);
         $form->addElement('hidden', 'post_time', time());
+        $form = $this->getAutorLpItem($form);
         $form->setDefaults($defaults);
 
         return $form->returnForm();
@@ -9602,6 +9607,7 @@ class learnpath
         }
         $form->addHidden('type', TOOL_LINK);
         $form->addHidden('post_time', time());
+        $form = $this->getAutorLpItem($form);
         $form->setDefaults($defaults);
 
         return '<div class="sectioncomment">'.$form->returnForm().'</div>';
@@ -9774,6 +9780,7 @@ class learnpath
 
         $form->addHidden('type', TOOL_STUDENTPUBLICATION);
         $form->addHidden('post_time', time());
+        $form = $this->getAutorLpItem($form);
         $form->setDefaults(['title' => $item_title]);
 
         $return = '<div class="sectioncomment">';
@@ -14164,5 +14171,40 @@ EOD;
         }
 
         return '';
+    }
+
+    /**
+     * Gets the form to evaluate if it exists contains the extra field extra_authorlpitem to establish authors when
+     * editing an item of an LP. Returns the form with the authors' setting. It must be set before the setDefault.
+     *
+     * @param FormValidator $form
+     * @return FormValidator
+     */
+    private function getAutorLpItem($form ){
+        /** @var FormValidator $form */
+        if ($form->hasElement('extra_authorlpitem')) {
+            /** @var HTML_QuickForm_select $author */
+            $author = $form->getElement('extra_authorlpitem');
+            $options = [];
+            $field = new ExtraField('user');
+            $authorLp = $field->get_handler_field_info_by_field_variable('authorlp');
+            $idExtraField = (int) (isset($authorLp['id']) ? $authorLp['id'] : 0);
+            if ($idExtraField != 0) {
+                $extraFieldValueUser = new ExtraFieldValue('user');
+                $arrayExtraFieldValueUser = $extraFieldValueUser->get_item_id_from_field_variable_and_field_value(
+                    $authorLp['variable'],
+                    1,
+                    true,
+                    false,
+                    true
+                );
+                foreach ($arrayExtraFieldValueUser as $item) {
+                    $teacher = api_get_user_info($item['item_id']);
+                    $options[$teacher['id']] = $teacher['complete_name'];
+                }
+            }
+            $author->setOptions($options);
+        }
+        return $form;
     }
 }


### PR DESCRIPTION
Se corrige un bug donde en la edicion de un item de lp, no aparece los autores, aunque el plugin este habilitado.
Esto se debe a que, aunque se evaluaba que los autores existieran, no tomaba en consideracion los autores del item de lp.

![imagen](https://user-images.githubusercontent.com/18097392/103681995-40ed3000-4f56-11eb-9371-41cf40eb328e.png)


Tambien en el reporte general, se omite la consideracion cuando la relacion existen en course_rel_user con status 5, esto era para definir a los estudiantes solamente. 

![imagen](https://user-images.githubusercontent.com/18097392/103680629-6f6a0b80-4f54-11eb-8f6c-3123d221d6a4.png)
