### PR TITLE
Sending notifications to a specific group from the system announcements - 18151

### DIFF
--- a/main/admin/system_announcements.php
+++ b/main/admin/system_announcements.php
@@ -351,7 +351,7 @@ if ($action_todo) {
                     isset($values['promotion_id']) ? $values['promotion_id'] : 0,
                     $groupToSend
                 )) {
-                    if (isset($groupToSend)) {
+                    if (0 != $groupToSend) {
                         SystemAnnouncementManager::announcement_for_groups(
                             $values['id'],
                             [$groupToSend]

--- a/main/admin/system_announcements.php
+++ b/main/admin/system_announcements.php
@@ -301,6 +301,7 @@ if ($action_todo) {
         }
 
         $sendMail = isset($values['send_mail']) ? $values['send_mail'] : null;
+        $groupToSend = isset($values['group']) ? $values['group'] : 0;
 
         switch ($values['action']) {
             case 'add':
@@ -315,14 +316,15 @@ if ($action_todo) {
                     empty($values['add_to_calendar']) ? false : true,
                     empty($values['send_email_test']) ? false : true,
                     isset($values['career_id']) ? $values['career_id'] : 0,
-                    isset($values['promotion_id']) ? $values['promotion_id'] : 0
+                    isset($values['promotion_id']) ? $values['promotion_id'] : 0,
+                    $groupToSend
                 );
 
                 if ($announcement_id !== false) {
-                    if (isset($values['group'])) {
+                    if ($groupToSend != 0) {
                         SystemAnnouncementManager::announcement_for_groups(
                             $announcement_id,
-                            [$values['group']]
+                            [$groupToSend]
                         );
                     }
 
@@ -346,12 +348,13 @@ if ($action_todo) {
                     $sendMail,
                     $sendMailTest,
                     isset($values['career_id']) ? $values['career_id'] : 0,
-                    isset($values['promotion_id']) ? $values['promotion_id'] : 0
+                    isset($values['promotion_id']) ? $values['promotion_id'] : 0,
+                    $groupToSend
                 )) {
-                    if (isset($values['group'])) {
+                    if (isset($groupToSend)) {
                         SystemAnnouncementManager::announcement_for_groups(
                             $values['id'],
-                            [$values['group']]
+                            [$groupToSend]
                         );
                         echo Display::return_message(
                             get_lang('AnnouncementUpdated'),

--- a/main/inc/lib/system_announcements.lib.php
+++ b/main/inc/lib/system_announcements.lib.php
@@ -825,7 +825,7 @@ class SystemAnnouncementManager
      *
      * @param int $userId
      */
-    public static function getAnnouncementsForGroups($userId = 0, $visible)
+    public static function getAnnouncementsForGroups($userId , $visible)
     {
         $user_selected_language = Database::escape_string(api_get_interface_language());
         $tblSysAnnouncements = Database::get_main_table(TABLE_MAIN_SYSTEM_ANNOUNCEMENTS);

--- a/main/inc/lib/system_announcements.lib.php
+++ b/main/inc/lib/system_announcements.lib.php
@@ -825,7 +825,7 @@ class SystemAnnouncementManager
      *
      * @param int $userId
      */
-    public static function getAnnouncementsForGroups($userId , $visible)
+    public static function getAnnouncementsForGroups($userId, $visible)
     {
         $user_selected_language = Database::escape_string(api_get_interface_language());
         $tblSysAnnouncements = Database::get_main_table(TABLE_MAIN_SYSTEM_ANNOUNCEMENTS);

--- a/main/inc/lib/system_announcements.lib.php
+++ b/main/inc/lib/system_announcements.lib.php
@@ -991,7 +991,6 @@ class SystemAnnouncementManager
         if (count($announcements) === 0) {
             return null;
         }
-        echo "/*".__LINE__."**/<pre>".var_export($announcementToGroup,true)."</pre><br>";
         $template = new Template(null, false, false);
         $template->assign('announcements', $announcements);
         $layout = $template->get_template('announcement/slider.tpl');

--- a/main/inc/lib/system_announcements.lib.php
+++ b/main/inc/lib/system_announcements.lib.php
@@ -708,9 +708,8 @@ class SystemAnnouncementManager
             $sql = "select user_id from $tblGroupRelUser where usergroup_id = $groupId";
             $result = Database::query($sql);
             $data = Database::store_result($result);
-            Database::free_result($result);
             $usersId = [];
-            foreach($data as $userArray){
+            foreach ($data as $userArray) {
                 $usersId[] = $userArray['user_id'];
             }
             $usersId = implode(',', $usersId);

--- a/main/inc/lib/system_announcements.lib.php
+++ b/main/inc/lib/system_announcements.lib.php
@@ -710,9 +710,8 @@ class SystemAnnouncementManager
             $data = Database::store_result($result);
             Database::free_result($result);
             $usersId = [];
-            $totalUsers = count($data);
-            for ($i = 0; $i < $totalUsers; $i++) {
-                $usersId[] = $data[$i]['user_id'];
+            foreach($data as $userArray){
+                $usersId[] = $userArray['user_id'];
             }
             $usersId = implode(',', $usersId);
             $whereUsersInGroup = " AND u.user_id in ($usersId) ";

--- a/main/inc/lib/system_announcements.lib.php
+++ b/main/inc/lib/system_announcements.lib.php
@@ -971,9 +971,6 @@ class SystemAnnouncementManager
             }
         }
 
-        if (count($announcements) === 0) {
-            return null;
-        }
         /** Show announcement of group */
         $announcementToGroup = self::getAnnouncementsForGroups($userId);
         $totalAnnouncementToGroup = count($announcementToGroup);
@@ -992,6 +989,10 @@ class SystemAnnouncementManager
             $announcements[] = $announcementData;
         }
 
+        if (count($announcements) === 0) {
+            return null;
+        }
+        echo "/*".__LINE__."**/<pre>".var_export($announcementToGroup,true)."</pre><br>";
         $template = new Template(null, false, false);
         $template->assign('announcements', $announcements);
         $layout = $template->get_template('announcement/slider.tpl');

--- a/main/inc/lib/system_announcements.lib.php
+++ b/main/inc/lib/system_announcements.lib.php
@@ -980,7 +980,7 @@ class SystemAnnouncementManager
                 'content' => $announcement['content'],
                 'readMore' => null,
             ];
-            $content = (is_array($announcement)) ? $announcement['content'] : $announcement->content;
+            $content = $announcement['content'];
             if (api_strlen(strip_tags($content)) > $cut_size) {
                 $announcementData['content'] = cut($content, $cut_size);
                 $announcementData['readMore'] = true;

--- a/main/inc/lib/system_announcements.lib.php
+++ b/main/inc/lib/system_announcements.lib.php
@@ -826,7 +826,6 @@ class SystemAnnouncementManager
      * Returns the group announcements where the user is subscribed.
      *
      * @param int $userId
-     *
      */
     public static function getAnnouncementsForGroups($userId = 0)
     {
@@ -888,7 +887,7 @@ class SystemAnnouncementManager
         $sql .= self::getVisibilityCondition($visible);
 
         if (isset($id) && !empty($id)) {
-            $id = (int)$id;
+            $id = (int) $id;
             $sql .= " AND id = $id ";
         }
 
@@ -1013,7 +1012,7 @@ class SystemAnnouncementManager
         $selectedUserLanguage = Database::escape_string(api_get_interface_language());
         $announcementTable = Database::get_main_table(TABLE_MAIN_SYSTEM_ANNOUNCEMENTS);
         $now = api_get_utc_datetime();
-        $announcementId = (int)$announcementId;
+        $announcementId = (int) $announcementId;
 
         $whereConditions = [
             "(lang = ? OR lang IS NULL OR lang = '') " => $selectedUserLanguage,

--- a/main/inc/lib/system_announcements.lib.php
+++ b/main/inc/lib/system_announcements.lib.php
@@ -827,7 +827,7 @@ class SystemAnnouncementManager
      */
     public static function getAnnouncementsForGroups($userId, $visible)
     {
-        $user_selected_language = Database::escape_string(api_get_interface_language());
+        $userSelectedLanguage = Database::escape_string(api_get_interface_language());
         $tblSysAnnouncements = Database::get_main_table(TABLE_MAIN_SYSTEM_ANNOUNCEMENTS);
         $tblGrpAnnouncements = Database::get_main_table(TABLE_MAIN_SYSTEM_ANNOUNCEMENTS_GROUPS);
         $tblUsrGrp = Database::get_main_table(TABLE_USERGROUP_REL_USER);
@@ -843,7 +843,7 @@ class SystemAnnouncementManager
             usergroup_rel_user.usergroup_id = announcement_rel_group.group_id
         WHERE
               usergroup_rel_user.user_id = $userId AND
-              (sys_announcement.lang = '$user_selected_language' OR sys_announcement.lang = '') AND
+              (sys_announcement.lang = '$userSelectedLanguage' OR sys_announcement.lang = '') AND
               ('$now' >= sys_announcement.date_start AND '$now' <= sys_announcement.date_end)
         ";
         $sql .= self::getVisibilityCondition($visible);

--- a/main/inc/lib/system_announcements.lib.php
+++ b/main/inc/lib/system_announcements.lib.php
@@ -703,7 +703,7 @@ class SystemAnnouncementManager
             return true;
         }
         $whereUsersInGroup = '';
-        if($groupId != 0){
+        if (0 != $groupId) {
             $tblGroupRelUser = Database::get_main_table(TABLE_USERGROUP_REL_USER);
             $sql = "select user_id from $tblGroupRelUser where usergroup_id = $groupId";
             $result = Database::query($sql);

--- a/main/inc/lib/system_announcements.lib.php
+++ b/main/inc/lib/system_announcements.lib.php
@@ -825,7 +825,7 @@ class SystemAnnouncementManager
      *
      * @param int $userId
      */
-    public static function getAnnouncementsForGroups($userId = 0,$visible)
+    public static function getAnnouncementsForGroups($userId = 0, $visible)
     {
         $user_selected_language = Database::escape_string(api_get_interface_language());
         $tblSysAnnouncements = Database::get_main_table(TABLE_MAIN_SYSTEM_ANNOUNCEMENTS);
@@ -970,7 +970,7 @@ class SystemAnnouncementManager
         }
 
         /** Show announcement of group */
-        $announcementToGroup = self::getAnnouncementsForGroups($userId,$visible);
+        $announcementToGroup = self::getAnnouncementsForGroups($userId, $visible);
         $totalAnnouncementToGroup = count($announcementToGroup);
         for ($i = 0; $i < $totalAnnouncementToGroup; $i++) {
             $announcement = $announcementToGroup[$i];

--- a/main/inc/lib/system_announcements.lib.php
+++ b/main/inc/lib/system_announcements.lib.php
@@ -825,7 +825,7 @@ class SystemAnnouncementManager
      *
      * @param int $userId
      */
-    public static function getAnnouncementsForGroups($userId = 0)
+    public static function getAnnouncementsForGroups($userId = 0,$visible)
     {
         $user_selected_language = Database::escape_string(api_get_interface_language());
         $tblSysAnnouncements = Database::get_main_table(TABLE_MAIN_SYSTEM_ANNOUNCEMENTS);
@@ -846,6 +846,7 @@ class SystemAnnouncementManager
               (sys_announcement.lang = '$user_selected_language' OR sys_announcement.lang = '') AND
               ('$now' >= sys_announcement.date_start AND '$now' <= sys_announcement.date_end)
         ";
+        $sql .= self::getVisibilityCondition($visible);
         $result = Database::query($sql);
         $data = Database::store_result($result, 'ASSOC');
         Database::free_result($result);
@@ -969,7 +970,7 @@ class SystemAnnouncementManager
         }
 
         /** Show announcement of group */
-        $announcementToGroup = self::getAnnouncementsForGroups($userId);
+        $announcementToGroup = self::getAnnouncementsForGroups($userId,$visible);
         $totalAnnouncementToGroup = count($announcementToGroup);
         for ($i = 0; $i < $totalAnnouncementToGroup; $i++) {
             $announcement = $announcementToGroup[$i];
@@ -979,8 +980,9 @@ class SystemAnnouncementManager
                 'content' => $announcement['content'],
                 'readMore' => null,
             ];
-            if (api_strlen(strip_tags($announcement->content)) > $cut_size) {
-                $announcementData['content'] = cut($announcement->content, $cut_size);
+            $content = (is_array($announcement)) ? $announcement['content'] : $announcement->content;
+            if (api_strlen(strip_tags($content)) > $cut_size) {
+                $announcementData['content'] = cut($content, $cut_size);
                 $announcementData['readMore'] = true;
             }
             $announcements[] = $announcementData;


### PR DESCRIPTION

An adjustment is made to take groups into account when making an announcement, then, when creating or editing a system announcement and selecting a specific group, it will be sent only to the members of the group and not to the entire platform as it currently does
![image](https://user-images.githubusercontent.com/18097392/107693948-c615e400-6c7c-11eb-84e5-6116a8ab3760.png)


#3541 BT#18151