### PR TITLE
Agenda: Fixed date rfc5545 from ics when importing 

### DIFF
--- a/main/inc/lib/agenda.lib.php
+++ b/main/inc/lib/agenda.lib.php
@@ -3116,7 +3116,16 @@ class Agenda
         $calendar = Sabre\VObject\Reader::read($data);
         $currentTimeZone = api_get_timezone();
         if (!empty($calendar->VEVENT)) {
+            /** @var Sabre\VObject\Component\VEvent $event */
             foreach ($calendar->VEVENT as $event) {
+                $tempDate = $event->DTSTART->getValue();
+                if ('Z' == substr($tempDate, -1) && 'UTC' != date('e', strtotime($tempDate))) {
+                    $event->DTSTART->setValue(gmdate('Ymd\THis\Z', strtotime($tempDate)));
+                }
+                $tempDate = $event->DTEND->getValue();
+                if ('Z' == substr($tempDate, -1) && 'UTC' != date('e', strtotime($tempDate))) {
+                    $event->DTEND->setValue(gmdate('Ymd\THis\Z', strtotime($tempDate)));
+                }
                 $start = $event->DTSTART->getDateTime();
                 $end = $event->DTEND->getDateTime();
                 //Sabre\VObject\DateTimeParser::parseDateTime(string $dt, \Sabre\VObject\DateTimeZone $tz)


### PR DESCRIPTION
Al momento de importar un archivo ics, puede presentar fallos al momento de generar la hora del evento, para esto se ajusta la hora al formato correcto y evitar de ese modo, cualquier posible futuro fallo. 
> ![image](https://user-images.githubusercontent.com/18097392/108273108-20151e80-7141-11eb-8daa-806008a0a267.png)
Se ha utilizado el archivo tarjeta.txt al cual se le debe cambiar la extensión a ics para que pueda funcionar
> [tarjeta.txt](https://github.com/chamilo/chamilo-lms/files/5998865/tarjeta.txt)

Se mostrara en la lista de eventos de la siguiente forma 
> ![image](https://user-images.githubusercontent.com/18097392/108276101-49d04480-7145-11eb-80e1-77f9bea4828b.png)

#3735  