### PR TITLE
WIP: Admin: Show/hide password when creating user - refs BT#18449

### DIFF
--- a/main/admin/user_add.php
+++ b/main/admin/user_add.php
@@ -214,6 +214,19 @@ $group[] = $form->createElement(
 );
 
 $form->addGroup($group, 'password', get_lang('Password'));
+$form->addElement(
+    'checkbox',
+    'showPassword',
+    '<label for="showPassword" style="cursor: pointer;">'.
+    get_lang('ShowOrHide')." ".get_lang('Password')." ".
+    Display::returnFontAwesomeIcon('eye', null, true, 'showPasswordEye')
+    .'</label> ',
+    '',
+    [
+        'id' => 'showPassword',
+        'onchange' => 'javascript: ShowHidePassword();',
+    ]
+);
 $form->addPasswordRule('password', 'password');
 $form->addGroupRule('password', get_lang('EnterPassword'), 'required', null, 1);
 
@@ -303,10 +316,25 @@ if ($allowEmailTemplate) {
 $jquery_ready_content = $returnParams['jquery_ready_content'];
 
 // the $jquery_ready_content variable collects all functions that will be load in the $(document).ready javascript function
-$htmlHeadXtra[] = '<script>
+$htmlHeadXtra[] = '<script type="text/javascript">
 $(function () {
     '.$jquery_ready_content.'
+    if($(\'#showPassword\').prop(\'checked\')){
+        $(\'.showPasswordEye\').removeClass(\'fa-eye\').addClass(\'fa-eye-slash\');
+    }else{
+        $(\'.showPasswordEye\').addClass(\'fa-eye\').removeClass(\'fa-eye-slash\');
+    }
 });
+function ShowHidePassword(){
+
+        if($(\'#showPassword\').prop(\'checked\')){
+            $(\'#password\').attr(\'type\',\'text\');
+            $(\'.showPasswordEye\').removeClass(\'fa-eye\').addClass(\'fa-eye-slash\');
+        }else{
+            $(\'#password\').attr(\'type\',\'password\');
+            $(\'.showPasswordEye\').addClass(\'fa-eye\').removeClass(\'fa-eye-slash\');
+        }
+}
 </script>';
 
 // Set default values


### PR DESCRIPTION
When you navigate to /main/admin/user_add.php for the creation of a user, the possibility is given to show or hide the password for the administrator.

>![image](https://user-images.githubusercontent.com/18097392/108392851-17742500-71e1-11eb-9227-996ca6876113.png)

>![image](https://user-images.githubusercontent.com/18097392/108392886-20fd8d00-71e1-11eb-9343-7c77c18f3be6.png)
