### PR TITLE
Show current question number of total.

### DIFF
--- a/main/exercise/exercise.class.php
+++ b/main/exercise/exercise.class.php
@@ -3282,7 +3282,8 @@ class Exercise
         $questions_in_media = [],
         $currentAnswer = '',
         $myRemindList = [],
-        $showPreviousButton = true
+        $showPreviousButton = true,
+        $totalQuestions = 0
     ) {
         global $safe_lp_id, $safe_lp_item_id, $safe_lp_item_view_id;
         $nbrQuestions = $this->countQuestionsInExercise();
@@ -3424,6 +3425,19 @@ class Exercise
             }
             $buttonList[] = '<span id="save_for_now_'.$question_id.'" class="exercise_save_mini_message"></span>';
 
+            $extraFieldValue = new ExtraFieldValue('exercise');
+            $showHideQuestionNumber = $extraFieldValue->get_values_by_handler_and_field_variable(
+                $this->iId,
+                'hidequestionnumber'
+            );
+            if($totalQuestions != 0 && is_array($showHideQuestionNumber) && $showHideQuestionNumber['value'] == 1)  {
+                $showQuestion = sprintf(
+                    get_lang('ShowQuestionNumber'),
+                    $questionNum,
+                    $totalQuestions
+                );
+                $buttonList[] = "<span>$showQuestion</span>";
+            }
             $html .= implode(PHP_EOL, $buttonList).PHP_EOL;
 
             return $html;

--- a/main/exercise/exercise.class.php
+++ b/main/exercise/exercise.class.php
@@ -3430,7 +3430,7 @@ class Exercise
                 $this->iId,
                 'hidequestionnumber'
             );
-            if($totalQuestions != 0 && is_array($showHideQuestionNumber) && $showHideQuestionNumber['value'] == 1)  {
+            if ($totalQuestions != 0 && is_array($showHideQuestionNumber) && $showHideQuestionNumber['value'] == 1) {
                 $showQuestion = sprintf(
                     get_lang('ShowQuestionNumber'),
                     $questionNum,

--- a/main/exercise/exercise_submit.php
+++ b/main/exercise/exercise_submit.php
@@ -368,6 +368,7 @@ $exercise_stat_info = $objExercise->get_stat_track_exercise_info(
 
 // Fix in order to get the correct question list.
 $questionListUncompressed = $objExercise->getQuestionListWithMediasUncompressed();
+$totalQuestions = count($questionListUncompressed);
 Session::write('question_list_uncompressed', $questionListUncompressed);
 $clock_expired_time = null;
 if (empty($exercise_stat_info)) {
@@ -1756,7 +1757,8 @@ foreach ($questionList as $questionId) {
                 [],
                 [],
                 $myRemindList,
-                $showPreviousButton
+                $showPreviousButton,
+                $totalQuestions
             );
             break;
         case ALL_ON_ONE_PAGE:


### PR DESCRIPTION
En este caso seria conveniente realziar el cambio por extrafield, ya que pueden ajustar la visibilidad de la herramienta correctamente, para este caso se deberá realizar lo siguiente:

Dirigirse a Administracion y encontrar la seccion de campos extra en el apartado de Plataforma.
> ![adm_1](https://user-images.githubusercontent.com/18097392/108762823-8f628800-751e-11eb-8649-8b35bc33ed72.JPG)
Para el tipo de campo, debemeos seleccionar exercise. Tener en cuenta que la variable debe ser en minuscula "hidequestionnumber" del tipo radio.
> ![adm_2](https://user-images.githubusercontent.com/18097392/108762829-912c4b80-751e-11eb-9480-4fc0ad66fb53.JPG)
>![adm_3](https://user-images.githubusercontent.com/18097392/108762831-91c4e200-751e-11eb-925d-32b278d4f025.JPG)

En los valores de campo extra, debemos tener en cuenta que el valor para No es 0, y para si es 1.
> ![adm_4](https://user-images.githubusercontent.com/18097392/108762786-8671b680-751e-11eb-9587-d5c6fd716c6a.JPG)

Luego de haber realizado este proceso, en las configuraciones del ejercicio, podemos encontrar la seleccion para mostrar el numero de la pregunta.
> ![exercise_1](https://user-images.githubusercontent.com/18097392/108762797-8a9dd400-751e-11eb-9b11-f1e2cf2b4332.JPG)

De este modo, al momento de realizar el ejercicio, podemos ver la pregunta actual junto con la cantidad de preguntas restantes. En este caso se requeriria una variable de idioma de modo:






$ShowQuestionNumber = "Question %s of %s";
>![exercise_2](https://user-images.githubusercontent.com/18097392/108762822-8ec9f180-751e-11eb-8092-fd7a27ff0b2e.JPG) 

