### PR TITLE
WIP: Mostrar u Ocultar el numero de la pregunta de un ejercicio - 18450

### DIFF
--- a/main/exercise/exercise.class.php
+++ b/main/exercise/exercise.class.php
@@ -2232,7 +2232,7 @@ class Exercise
                 ];
                 $form->addGroup($group, null, get_lang('ResultsConfigurationPage'));
             }
-            $showHide = api_get_configuration_value('hide_question_number');
+            $showHideConfiguration = api_get_configuration_value('hide_question_number');
             if ( $showHideConfiguration ) {
                 $group = [
                     $form->createElement('radio', 'hide_question_number', null, get_lang('Yes'), '1'),

--- a/main/exercise/exercise.class.php
+++ b/main/exercise/exercise.class.php
@@ -2793,7 +2793,10 @@ class Exercise
         $this->setNotifications($form->getSubmitValue('notifications'));
         $this->setExerciseCategoryId($form->getSubmitValue('exercise_category_id'));
         $this->setPageResultConfiguration($form->getSubmitValues());
-        $this->setHideShowQuestionNumber($form->getSubmitValue('hide_question_number'));
+        $showHideConfiguration = api_get_configuration_value('hide_question_number');
+        if ($showHideConfiguration) {
+            $this->setHideShowQuestionNumber($form->getSubmitValue('hide_question_number'));
+        }
         $this->preventBackwards = (int) $form->getSubmitValue('prevent_backwards');
 
         $this->start_time = null;

--- a/main/exercise/exercise.class.php
+++ b/main/exercise/exercise.class.php
@@ -1683,7 +1683,7 @@ class Exercise
             }
 
             $showHideConfiguration = api_get_configuration_value('hide_question_number');
-            if ($showHideConfiguration ) {
+            if ($showHideConfiguration) {
                 $paramsExtra['hide_question_number'] = $this->hideQuestionNumber;
             }
 
@@ -1781,7 +1781,7 @@ class Exercise
                 $params['page_result_configuration'] = $this->pageResultConfiguration;
             }
             $showHideConfiguration = api_get_configuration_value('hide_question_number');
-            if ( $showHideConfiguration ) {
+            if ($showHideConfiguration) {
                 $params['hide_question_number'] = $this->hideQuestionNumber;
             }
 
@@ -2233,7 +2233,7 @@ class Exercise
                 $form->addGroup($group, null, get_lang('ResultsConfigurationPage'));
             }
             $showHideConfiguration = api_get_configuration_value('hide_question_number');
-            if ( $showHideConfiguration ) {
+            if ($showHideConfiguration) {
                 $group = [
                     $form->createElement('radio', 'hide_question_number', null, get_lang('Yes'), '1'),
                     $form->createElement('radio', 'hide_question_number', null, get_lang('No'), '0'),
@@ -8365,27 +8365,30 @@ class Exercise
     }
 
     /**
-     * Set the value to hide or show the question number
+     * Set the value to hide or show the question number.
      *
      * @param int $value
      */
-    public function setHideShowQuestionNumber($value = 0){
+    public function setHideShowQuestionNumber($value = 0)
+    {
         $showHideConfiguration = api_get_configuration_value('hide_question_number');
         if ($showHideConfiguration) {
-            $this->hideQuestionNumber = (int) $value ;
+            $this->hideQuestionNumber = (int) $value;
         }
     }
 
     /**
-     * Gets the value to hide or show the question number. If it does not exist, it is set to 0
+     * Gets the value to hide or show the question number. If it does not exist, it is set to 0.
      *
      * @return int
      */
-    public function getHideShowQuestionNumber(){
+    public function getHideShowQuestionNumber()
+    {
         $showHideConfiguration = api_get_configuration_value('hide_question_number');
         if ($showHideConfiguration) {
             return (int) $this->hideQuestionNumber;
         }
+
         return 0;
     }
 
@@ -8421,7 +8424,7 @@ class Exercise
     }
 
     /**
-     * Sets the value to show or hide the question number in the default settings of the forms
+     * Sets the value to show or hide the question number in the default settings of the forms.
      *
      * @param array $defaults
      */
@@ -8450,7 +8453,7 @@ class Exercise
     }
 
     /**
-     * Get the value to show or hide the question number in the default settings of the forms
+     * Get the value to show or hide the question number in the default settings of the forms.
      *
      * @return array
      */
@@ -8458,7 +8461,7 @@ class Exercise
     {
         $pageConfig = api_get_configuration_value('hide_question_number');
         if ($pageConfig) {
-            return  ['hide_question_number'=>$this->hideQuestionNumber];
+            return ['hide_question_number' => $this->hideQuestionNumber];
         }
 
         return [];

--- a/main/exercise/question.class.php
+++ b/main/exercise/question.class.php
@@ -278,7 +278,9 @@ abstract class Question
         $tblQuiz = Database::get_course_table(TABLE_QUIZ_TEST);
         $tblQuizRelQuestion = Database::get_course_table(TABLE_QUIZ_TEST_QUESTION);
         $showHideConfiguration = api_get_configuration_value('hide_question_number');
-        if (!$showHideConfiguration) return 0;
+        if (!$showHideConfiguration) {
+            return 0;
+        }
         // Check if the field exist
         $checkFieldSql = "SHOW COLUMNS FROM $tblQuiz WHERE Field = 'hide_question_number'";
         $res = Database::query($checkFieldSql);
@@ -297,7 +299,7 @@ abstract class Question
                 isset($result[0]) &&
                 isset($result[0]['active'])
             ) {
-                return (int)$result[0]['active'];
+                return (int) $result[0]['active'];
             }
         }
 

--- a/main/exercise/question.class.php
+++ b/main/exercise/question.class.php
@@ -253,13 +253,55 @@ abstract class Question
         }
 
         $title .= $showQuestionTitleHtml ? '' : '<strong>';
-        $title .= $itemNumber.'. '.$this->selectTitle();
+        $checkIfShowNumberQuestion = $this->getShowHideConfiguration();
+        if ($checkIfShowNumberQuestion != 1) {
+            $title .= $itemNumber.'. ';
+        }
+        $title .= $this->selectTitle();
+
         $title .= $showQuestionTitleHtml ? '' : '</strong>';
 
         return Display::div(
             $title,
             ['class' => 'question_title']
         );
+    }
+
+    /**
+     * Gets the respective value to show or hide the number of a question in the exam.
+     * If the field does not exist in the database, it will return 0.
+     *
+     * @return int
+     */
+    public function getShowHideConfiguration()
+    {
+        $tblQuiz = Database::get_course_table(TABLE_QUIZ_TEST);
+        $tblQuizRelQuestion = Database::get_course_table(TABLE_QUIZ_TEST_QUESTION);
+        $showHideConfiguration = api_get_configuration_value('hide_question_number');
+        if (!$showHideConfiguration) return 0;
+        // Check if the field exist
+        $checkFieldSql = "SHOW COLUMNS FROM $tblQuiz WHERE Field = 'hide_question_number'";
+        $res = Database::query($checkFieldSql);
+        $result = Database::store_result($res);
+        if (count($result) != 0) {
+            $sql = "
+                SELECT
+                    q.hide_question_number AS `active`
+                FROM
+                      $tblQuiz as q
+                INNER JOIN  $tblQuizRelQuestion AS qrq ON qrq.exercice_id = q.id
+                WHERE qrq.question_id = ".$this->id;
+            $res = Database::query($sql);
+            $result = Database::store_result($res);
+            if (is_array($result) &&
+                isset($result[0]) &&
+                isset($result[0]['active'])
+            ) {
+                return (int)$result[0]['active'];
+            }
+        }
+
+        return 0;
     }
 
     /**

--- a/main/install/configuration.dist.php
+++ b/main/install/configuration.dist.php
@@ -1304,6 +1304,10 @@ $_configuration['required_extra_fields_in_profile'] = [
 // ALTER TABLE c_quiz ADD page_result_configuration LONGTEXT DEFAULT NULL COMMENT '(DC2Type:array)';
 //$_configuration['allow_quiz_results_page_config'] = false;
 
+// Allows you to show or hide the number of the question in the exercises
+// ALTER TABLE `c_quiz` ADD COLUMN `hide_question_number` int(0) NULL DEFAULT 0 COMMENT 'Show/Hide question number in quiz' ;
+//$_configuration['hide_question_number'] = false;
+
 // Allow multiple options for the exercise "save answer" option
 // ALTER TABLE c_quiz MODIFY COLUMN save_correct_answers INT NULL DEFAULT NULL;
 //$_configuration['allow_quiz_save_correct_options'] = false;


### PR DESCRIPTION
Cuando esta habilitado. Se activa la posibilidad de ocultar el numero de la pregunta durante el ejercicio. Para esto se debe ir a la configuración del ejercicio
![image](https://user-images.githubusercontent.com/18097392/111526057-4328f300-872c-11eb-8883-e21a8315ede2.png)
y seleccionar Si.

Realizada la configuración, se puede validar presentando el ejercicio, donde en condiciones normales estará el numero de la pregunta 
![image](https://user-images.githubusercontent.com/18097392/111526225-78354580-872c-11eb-8cad-9972722b2178.png)
No aparecerá ningún numero 
![image](https://user-images.githubusercontent.com/18097392/111526469-c9ddd000-872c-11eb-8f13-2e62686f509b.png)



