### PR TITLE
ReportByAuthor: Recuperando $ en selector de tabla

### DIFF
--- a/main/inc/lib/myspace.lib.php
+++ b/main/inc/lib/myspace.lib.php
@@ -1954,7 +1954,7 @@ class MySpace
             lp.id = lpi.lp_id AND
             lpi.c_id = lp.c_id
         )
-        INNER JOIN tblUser AS u
+        INNER JOIN $tblUser AS u
         ON (u.id = srcu.user_id)
         $accessUrlFilter
         WHERE


### PR DESCRIPTION
el commit fec0f45e27501d983a022f4ce09b5f536d5426e8 removio los ` backtip pero tambien removio el dolar en el query de la selección.