### PR TITLE
Preventing DDoS (false positive) in Ajax Calls

### DIFF
--- a/main/template/default/admin/settings_index.tpl
+++ b/main/template/default/admin/settings_index.tpl
@@ -2,12 +2,15 @@
 
 <script>
     $(document).ready(function () {
-        $.ajax({
-            url: '{{ web_admin_ajax_url }}?a=version',
-            success: function (version) {
-                $(".admin-block-version").html(version);
-            }
-        });
+    
+        setTimeout(function(){
+            $.ajax({
+                url: '{{ web_admin_ajax_url }}?a=version',
+                success: function (version) {
+                    $(".admin-block-version").html(version);
+                }
+            });
+        }, 3000);
 
         {% if _u.is_admin %}
             (function (CKEDITOR) {


### PR DESCRIPTION
Preventing DDoS (false positive) in Ajax Calls - hosting recommandations
Add setTimeout(function(){
        ajax
}, 3000);