### PR TITLE
Gradebook display certificate - Prevent that the generate and delete certificate buttons are overwriten 

### DIFF
--- a/main/gradebook/gradebook_display_certificate.php
+++ b/main/gradebook/gradebook_display_certificate.php
@@ -256,7 +256,7 @@ $hideCertificateExport = api_get_setting('hide_certificate_export_link');
 
 if (count($certificate_list) > 0 && $hideCertificateExport !== 'true') {
     if ($allowCustomCertificate) {
-        $actions = Display::url(
+        $actions .= Display::url(
             Display::return_icon('pdf.png', get_lang('ExportAllCertificatesToPDF'), [], ICON_SIZE_MEDIUM),
             api_get_path(WEB_PLUGIN_PATH)
                 .'customcertificate/src/print_certificate.php?'.api_get_cidreq().'&'


### PR DESCRIPTION
Concatenates variable $actions to prevent that the generate and delete certificate buttons are overwriten if the custom certificates are allowed

![imagen](https://user-images.githubusercontent.com/48205899/116693147-c8572700-a9bd-11eb-98fa-2f645871fcac.png)
