### PR TITLE
Corrección al aplicar un tema a un curso específico

### DIFF
--- a/main/inc/lib/api.lib.php
+++ b/main/inc/lib/api.lib.php
@@ -5278,7 +5278,7 @@ function api_get_visual_theme()
         $course_id = api_get_course_id();
         if (!empty($course_id)) {
             if ($courseThemeAvailable) {
-                $course_theme = api_get_course_setting('course_theme', api_get_course_info());
+                $course_theme = api_get_course_setting('course_theme', api_get_course_info($course_id));
 
                 if (!empty($course_theme) && $course_theme != -1) {
                     if (!empty($course_theme)) {


### PR DESCRIPTION
Actualmente al indicar un determinado tema a un curso específico no funciona y muestra el tema de la plataforma.
Con esta corrección se corrige el problema