### PR TITLE
protect ajax.php after install

### DIFF
--- a/main/install/ajax.php
+++ b/main/install/ajax.php
@@ -27,6 +27,13 @@ session_start();
 require_once api_get_path(LIBRARY_PATH).'database.constants.inc.php';
 require_once 'install.lib.php';
 
+// A protection measure for already installed systems.
+if (isAlreadyInstalledSystem()) {
+    // The system has already been installed, so block re-installation.
+    echo "Chamilo has already been installed";
+    exit;
+}
+
 $action = isset($_POST['a']) ? $_POST['a'] : null;
 
 $dbHost = isset($_POST['db_host']) ? $_POST['db_host'] : 'localhost';


### PR DESCRIPTION
ajax.php has to be protected to avoid displaying database connection error.
I only add  a text because it is in ajax context.