### PR TITLE
Fix possible injection using HTTP_X_FORWARDED_FOR

### DIFF
--- a/main/webservices/testip.php
+++ b/main/webservices/testip.php
@@ -3,9 +3,16 @@
 /**
  *  @package chamilo.webservices
  */
-$ip = trim($_SERVER['REMOTE_ADDR']);
-if (!empty($_SERVER['HTTP_X_FORWARDED_FOR'])) {
-    list($ip1, $ip2) = preg_split('/,/', $_SERVER['HTTP_X_FORWARDED_FOR']);
-    $ip = trim($ip1);
+$ip = '';
+if (!empty($_SERVER['REMOTE_ADDR'])) {
+    $ip = trim($_SERVER['REMOTE_ADDR']);
 }
-echo htmlentities($ip);
+if (!empty($_SERVER['HTTP_X_FORWARDED_FOR'])) {
+    if (filter_var($_SERVER['HTTP_X_FORWARDED_FOR'], FILTER_FLAG_IPV4 | FILTER_FLAG_IPV6) == $_SERVER['HTTP_X_FORWARDED_FOR']) {
+        list($ip1, $ip2) = preg_split('/,/', $_SERVER['HTTP_X_FORWARDED_FOR']);
+        $ip = trim($ip1);
+    }
+}
+if (!empty($ip) && filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4 | FILTER_FLAG_IPV6)) {
+    echo htmlentities($ip);
+}


### PR DESCRIPTION
Not really dangerous but it is possible to inject content in HTTP_X_FORWARDED_FOR and it displays.
* check existance of REMOTE_ADDR in $_SERVER 
* display ip only if valid ip