### PR TITLE
fix ajax user manager

### DIFF
--- a/main/inc/ajax/user_manager.ajax.php
+++ b/main/inc/ajax/user_manager.ajax.php
@@ -69,6 +69,10 @@ switch ($action) {
 
         $isAnonymous = api_is_anonymous();
 
+        if ($isAnonymous && empty($courseId)) {
+            break;
+        }
+
         if ($isAnonymous && $courseId) {
             if ('false' === api_get_setting('course_catalog_published')) {
                 break;


### PR DESCRIPTION
Fix case in get_user_popup when courseid is empty and user is anonymous.

Avoid to return user information when not logged in. Before that it was possible to get user information with such a curl :

curl -H 'X-Requested-With: XMLHttpRequest' "https://platform_url/main/inc/ajax/user_manager.ajax.php?a=get_user_popup&user_id=23"