### PR TITLE
Add ability to filter the message tracking to the coaches access dates

### DIFF
--- a/main/inc/lib/message.lib.php
+++ b/main/inc/lib/message.lib.php
@@ -2881,8 +2881,8 @@ class MessageManager
 
     /**
      * @param int      $userId
-     * @param datetime $dateStart
-     * @param datetime $dateFinish
+     * @param datetime $startDate
+     * @param datetime $endDate
      *
      * @return array
      */
@@ -2890,8 +2890,6 @@ class MessageManager
     {
         $messagesTable = Database::get_main_table(TABLE_MESSAGE);
         $userId = (int) $userId;
-        $startDate = Database::escape_string($startDate);
-        $endDate = Database::escape_string($endDate);
 
         $sql = "SELECT DISTINCT
                     user_sender_id
@@ -2900,10 +2898,12 @@ class MessageManager
                     user_receiver_id = ".$userId;
 
         if ($startDate != null) {
+            $startDate = Database::escape_string($startDate);
             $sql .= " AND send_date >= '".$startDate."'";
         }
 
         if ($endDate != null) {
+            $endDate = Database::escape_string($endDate);
             $sql .= " AND send_date <= '".$endDate."'";
         }
 
@@ -2927,8 +2927,8 @@ class MessageManager
     /**
      * @param int      $userId
      * @param int      $otherUserId
-     * @param datetime $dateStart
-     * @param datetime $dateFinish
+     * @param datetime $startDate
+     * @param datetime $endDate
      *
      * @return array
      */
@@ -2937,8 +2937,6 @@ class MessageManager
         $messagesTable = Database::get_main_table(TABLE_MESSAGE);
         $userId = (int) $userId;
         $otherUserId = (int) $otherUserId;
-        $startDate = Database::escape_string($startDate);
-        $endDate = Database::escape_string($endDate);
 
         if (empty($otherUserId) || empty($userId)) {
             return [];
@@ -2951,12 +2949,12 @@ class MessageManager
                     (user_receiver_id = $otherUserId AND user_sender_id = $userId))
             ";
         if ($startDate != null) {
-            $dateStart = Database::escape_string($startDate);
-            $sql .= " AND send_date >= '".$dateStart."'";
+            $startDate = Database::escape_string($startDate);
+            $sql .= " AND send_date >= '".$startDate."'";
         }
         if ($endDate != null) {
-            $dateFinish = Database::escape_string($endDate);
-            $sql .= " AND send_date <= '".$dateFinish."'";
+            $endDate = Database::escape_string($endDate);
+            $sql .= " AND send_date <= '".$endDate."'";
         }
         $sql .= " ORDER BY send_date DESC";
         $result = Database::query($sql);

--- a/main/inc/lib/message.lib.php
+++ b/main/inc/lib/message.lib.php
@@ -2886,10 +2886,12 @@ class MessageManager
      *
      * @return array
      */
-    public static function getUsersThatHadConversationWithUser($userId, $dateStart = null, $dateFinish = null)
+    public static function getUsersThatHadConversationWithUser($userId, $startDate = null, $endDate = null)
     {
         $messagesTable = Database::get_main_table(TABLE_MESSAGE);
         $userId = (int) $userId;
+        $startDate = Database::escape_string($startDate);
+        $endDate = Database::escape_string($endDate);
 
         $sql = "SELECT DISTINCT
                     user_sender_id
@@ -2897,12 +2899,12 @@ class MessageManager
                 WHERE
                     user_receiver_id = ".$userId;
 
-        if ($dateStart != null) {
-            $sql .= " AND send_date >= '".$dateStart."'";
+        if ($startDate != null) {
+            $sql .= " AND send_date >= '".$startDate."'";
         }
 
-        if ($dateFinish != null) {
-            $sql .= " AND send_date <= '".$dateFinish."'";
+        if ($endDate != null) {
+            $sql .= " AND send_date <= '".$endDate."'";
         }
 
         $result = Database::query($sql);
@@ -2930,11 +2932,13 @@ class MessageManager
      *
      * @return array
      */
-    public static function getAllMessagesBetweenStudents($userId, $otherUserId, $dateStart = null, $dateFinish = null)
+    public static function getAllMessagesBetweenStudents($userId, $otherUserId, $startDate = null, $endDate = null)
     {
         $messagesTable = Database::get_main_table(TABLE_MESSAGE);
         $userId = (int) $userId;
         $otherUserId = (int) $otherUserId;
+        $startDate = Database::escape_string($startDate);
+        $endDate = Database::escape_string($endDate);
 
         if (empty($otherUserId) || empty($userId)) {
             return [];
@@ -2946,12 +2950,12 @@ class MessageManager
                     ((user_receiver_id = $userId AND user_sender_id = $otherUserId) OR
                     (user_receiver_id = $otherUserId AND user_sender_id = $userId))
             ";
-        if ($dateStart != null) {
-            $dateStart = Database::escape_string($dateStart);
+        if ($startDate != null) {
+            $dateStart = Database::escape_string($startDate);
             $sql .= " AND send_date >= '".$dateStart."'";
         }
-        if ($dateFinish != null) {
-            $dateFinish = Database::escape_string($dateFinish);
+        if ($endDate != null) {
+            $dateFinish = Database::escape_string($endDate);
             $sql .= " AND send_date <= '".$dateFinish."'";
         }
         $sql .= " ORDER BY send_date DESC";

--- a/main/inc/lib/message.lib.php
+++ b/main/inc/lib/message.lib.php
@@ -2880,11 +2880,13 @@ class MessageManager
     }
 
     /**
-     * @param int $userId
+     * @param int      $userId
+     * @param datetime $dateStart
+     * @param datetime $dateFinish
      *
      * @return array
      */
-    public static function getUsersThatHadConversationWithUser($userId)
+    public static function getUsersThatHadConversationWithUser($userId, $dateStart = null, $dateFinish = null)
     {
         $messagesTable = Database::get_main_table(TABLE_MESSAGE);
         $userId = (int) $userId;
@@ -2894,6 +2896,15 @@ class MessageManager
                 FROM $messagesTable
                 WHERE
                     user_receiver_id = ".$userId;
+
+        if ($dateStart != null) {
+            $sql .= " AND send_date >= '".$dateStart."'";
+        }
+
+        if ($dateFinish != null) {
+            $sql .= " AND send_date <= '".$dateFinish."'";
+        }
+
         $result = Database::query($sql);
         $users = Database::store_result($result);
         $userList = [];
@@ -2912,12 +2923,14 @@ class MessageManager
     }
 
     /**
-     * @param int $userId
-     * @param int $otherUserId
+     * @param int      $userId
+     * @param int      $otherUserId
+     * @param datetime $dateStart
+     * @param datetime $dateFinish
      *
      * @return array
      */
-    public static function getAllMessagesBetweenStudents($userId, $otherUserId)
+    public static function getAllMessagesBetweenStudents($userId, $otherUserId, $dateStart = null, $dateFinish = null)
     {
         $messagesTable = Database::get_main_table(TABLE_MESSAGE);
         $userId = (int) $userId;
@@ -2930,10 +2943,18 @@ class MessageManager
         $sql = "SELECT DISTINCT *
                 FROM $messagesTable
                 WHERE
-                    (user_receiver_id = $userId AND user_sender_id = $otherUserId) OR
-                    (user_receiver_id = $otherUserId AND user_sender_id = $userId)
-                ORDER BY send_date DESC
+                    ((user_receiver_id = $userId AND user_sender_id = $otherUserId) OR
+                    (user_receiver_id = $otherUserId AND user_sender_id = $userId))
             ";
+        if ($dateStart != null) {
+            $dateStart = Database::escape_string($dateStart);
+            $sql .= " AND send_date >= '".$dateStart."'";
+        }
+        if ($dateFinish != null) {
+            $dateFinish = Database::escape_string($dateFinish);
+            $sql .= " AND send_date <= '".$dateFinish."'";
+        }
+        $sql .= " ORDER BY send_date DESC";
         $result = Database::query($sql);
         $messages = Database::store_result($result);
         $list = [];

--- a/main/install/configuration.dist.php
+++ b/main/install/configuration.dist.php
@@ -940,6 +940,10 @@ ALTER TABLE skill_rel_course ADD CONSTRAINT FK_E7CEC7FA613FECDF FOREIGN KEY (ses
 // affect privacy protection.
 //$_configuration['allow_user_message_tracking'] = false;
 
+// Filter messages between a teacher and a student between the session start end dates
+// Need $_configuration['allow_user_message_tracking'] = true;
+$_configuration['filter_interactivity_messages'] = false;
+
 // Add a portfolio tool (duplicating the Notebook tool). Requires DB changes:
 /*
 CREATE TABLE portfolio (id INT AUTO_INCREMENT NOT NULL, user_id INT NOT NULL, c_id INT DEFAULT NULL, session_id INT DEFAULT NULL, category_id INT DEFAULT NULL, title VARCHAR(255) NOT NULL, content LONGTEXT NOT NULL, creation_date DATETIME NOT NULL, update_date DATETIME NOT NULL, is_visible TINYINT(1) DEFAULT '1' NOT NULL, INDEX user (user_id), INDEX course (c_id), INDEX session (session_id), INDEX category (category_id), PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8 COLLATE utf8_unicode_ci ENGINE = InnoDB;

--- a/main/install/configuration.dist.php
+++ b/main/install/configuration.dist.php
@@ -942,7 +942,7 @@ ALTER TABLE skill_rel_course ADD CONSTRAINT FK_E7CEC7FA613FECDF FOREIGN KEY (ses
 
 // Filter messages between a teacher and a student between the session start end dates
 // Need $_configuration['allow_user_message_tracking'] = true;
-$_configuration['filter_interactivity_messages'] = false;
+//$_configuration['filter_interactivity_messages'] = false;
 
 // Add a portfolio tool (duplicating the Notebook tool). Requires DB changes:
 /*

--- a/main/mySpace/myStudents.php
+++ b/main/mySpace/myStudents.php
@@ -2060,9 +2060,9 @@ if ($allowMessages === true) {
 $filter_messages = api_get_configuration_value('filter_interactivity_messages') && !empty($sessionId);
 
 if ($filter_messages) {
-	$session_info = api_get_session_info($sessionId);
-	$coach_access_start_date = $session_info['coach_access_start_date'];
-	$coach_access_end_date = $session_info['coach_access_end_date'];
+    $session_info = api_get_session_info($sessionId);
+    $coach_access_start_date = $session_info['coach_access_start_date'];
+    $coach_access_end_date = $session_info['coach_access_end_date'];
 }
 
 $allow = api_get_configuration_value('allow_user_message_tracking');

--- a/main/mySpace/myStudents.php
+++ b/main/mySpace/myStudents.php
@@ -2065,8 +2065,10 @@ if (!empty($sessionId)) {
 
     if ($filterMessages) {
         $sessionInfo = api_get_session_info($sessionId);
-        $coachAccessStartDate = $sessionInfo['coach_access_start_date'];
-        $coachAccessEndDate = $sessionInfo['coach_access_end_date'];
+        if (!empty($sessionInfo)) {
+            $coachAccessStartDate = $sessionInfo['coach_access_start_date'];
+            $coachAccessEndDate = $sessionInfo['coach_access_end_date'];
+        }
     }
 }
 

--- a/main/mySpace/myStudents.php
+++ b/main/mySpace/myStudents.php
@@ -2057,8 +2057,21 @@ if ($allowMessages === true) {
     $form->display();
 }
 
+$filter_messages = api_get_configuration_value('filter_interactivity_messages') && !empty($sessionId);
+
+if ($filter_messages) {
+	$session_info = api_get_session_info($sessionId);
+	$coach_access_start_date = $session_info['coach_access_start_date'];
+	$coach_access_end_date = $session_info['coach_access_end_date'];
+}
+
 $allow = api_get_configuration_value('allow_user_message_tracking');
 if ($allow && (api_is_drh() || api_is_platform_admin())) {
+    if ($filter_messages) {
+        $users = MessageManager::getUsersThatHadConversationWithUser($student_id, $coach_access_start_date, $coach_access_end_date);
+    } else {
+        $users = MessageManager::getUsersThatHadConversationWithUser($student_id);
+    }
     $users = MessageManager::getUsersThatHadConversationWithUser($student_id);
     echo Display::page_subheader2(get_lang('MessageTracking'));
 
@@ -2076,7 +2089,13 @@ if ($allow && (api_is_drh() || api_is_platform_admin())) {
     $row++;
     foreach ($users as $userFollowed) {
         $followedUserId = $userFollowed['user_id'];
-        $url = api_get_path(WEB_CODE_PATH).'tracking/messages.php?from_user='.$student_id.'&to_user='.$followedUserId;
+
+        if ($filter_messages) {
+            $url = api_get_path(WEB_CODE_PATH).'tracking/messages.php?from_user='.$student_id.'&to_user='.$followedUserId.'&date_from='.$coach_access_start_date.'&date_to='.$coach_access_end_date;
+        } else {
+            $url = api_get_path(WEB_CODE_PATH).'tracking/messages.php?from_user='.$student_id.'&to_user='.$followedUserId;
+        }
+
         $link = Display::url(
             $userFollowed['complete_name'],
             $url

--- a/main/mySpace/myStudents.php
+++ b/main/mySpace/myStudents.php
@@ -2057,18 +2057,23 @@ if ($allowMessages === true) {
     $form->display();
 }
 
-$filter_messages = api_get_configuration_value('filter_interactivity_messages') && !empty($sessionId);
+$coachAccessStartDate = null;
+$coachAccessEndDate = null;
 
-if ($filter_messages) {
-    $session_info = api_get_session_info($sessionId);
-    $coach_access_start_date = $session_info['coach_access_start_date'];
-    $coach_access_end_date = $session_info['coach_access_end_date'];
+if (!empty($sessionId)) {
+    $filterMessages = api_get_configuration_value('filter_interactivity_messages');
+
+    if ($filterMessages) {
+        $sessionInfo = api_get_session_info($sessionId);
+        $coachAccessStartDate = $sessionInfo['coach_access_start_date'];
+        $coachAccessEndDate = $sessionInfo['coach_access_end_date'];
+    }
 }
 
 $allow = api_get_configuration_value('allow_user_message_tracking');
 if ($allow && (api_is_drh() || api_is_platform_admin())) {
-    if ($filter_messages) {
-        $users = MessageManager::getUsersThatHadConversationWithUser($student_id, $coach_access_start_date, $coach_access_end_date);
+    if ($filterMessages) {
+        $users = MessageManager::getUsersThatHadConversationWithUser($student_id, $coachAccessStartDate, $coachAccessEndDate);
     } else {
         $users = MessageManager::getUsersThatHadConversationWithUser($student_id);
     }
@@ -2090,8 +2095,8 @@ if ($allow && (api_is_drh() || api_is_platform_admin())) {
     foreach ($users as $userFollowed) {
         $followedUserId = $userFollowed['user_id'];
 
-        if ($filter_messages) {
-            $url = api_get_path(WEB_CODE_PATH).'tracking/messages.php?from_user='.$student_id.'&to_user='.$followedUserId.'&date_from='.$coach_access_start_date.'&date_to='.$coach_access_end_date;
+        if ($filterMessages) {
+            $url = api_get_path(WEB_CODE_PATH).'tracking/messages.php?from_user='.$student_id.'&to_user='.$followedUserId.'&start_date='.$coachAccessStartDate.'&end_date='.$coachAccessEndDate;
         } else {
             $url = api_get_path(WEB_CODE_PATH).'tracking/messages.php?from_user='.$student_id.'&to_user='.$followedUserId;
         }

--- a/main/tracking/messages.php
+++ b/main/tracking/messages.php
@@ -18,8 +18,8 @@ if (!$allowUser) {
 $fromUserId = isset($_GET['from_user']) ? (int) $_GET['from_user'] : 0;
 $toUserId = isset($_GET['to_user']) ? (int) $_GET['to_user'] : 0;
 
-$coach_access_start_date = isset($_GET['date_from']) ? $_GET['date_from'] : null;
-$coach_access_end_date = isset($_GET['date_to']) ? $_GET['date_to'] : null;
+$coachAccessStartDate = isset($_GET['start_date']) ? $_GET['start_date'] : null;
+$coachAccessEndDate = isset($_GET['end_date']) ? $_GET['end_date'] : null;
 
 if (empty($fromUserId) || empty($toUserId)) {
     api_not_allowed(true);
@@ -65,9 +65,9 @@ if (api_is_drh()) {
 $usersData[$toUserId] = api_get_user_info($toUserId);
 $usersData[$fromUserId] = api_get_user_info($fromUserId);
 
-$filter_messages = api_get_configuration_value('filter_interactivity_messages');
-if ($filter_messages) {
-    $messages = MessageManager::getAllMessagesBetweenStudents($toUserId, $fromUserId, $coach_access_start_date, $coach_access_end_date);
+$filterMessages = api_get_configuration_value('filter_interactivity_messages');
+if ($filterMessages) {
+    $messages = MessageManager::getAllMessagesBetweenStudents($toUserId, $fromUserId, $coachAccessStartDate, $coachAccessEndDate);
 } else {
     $messages = MessageManager::getAllMessagesBetweenStudents($toUserId, $fromUserId);
 }

--- a/main/tracking/messages.php
+++ b/main/tracking/messages.php
@@ -18,6 +18,9 @@ if (!$allowUser) {
 $fromUserId = isset($_GET['from_user']) ? (int) $_GET['from_user'] : 0;
 $toUserId = isset($_GET['to_user']) ? (int) $_GET['to_user'] : 0;
 
+$coach_access_start_date = isset($_GET['date_from']) ? $_GET['date_from'] : null;
+$coach_access_end_date = isset($_GET['date_to']) ? $_GET['date_to'] : null;
+
 if (empty($fromUserId) || empty($toUserId)) {
     api_not_allowed(true);
 }
@@ -61,7 +64,13 @@ if (api_is_drh()) {
 
 $usersData[$toUserId] = api_get_user_info($toUserId);
 $usersData[$fromUserId] = api_get_user_info($fromUserId);
-$messages = MessageManager::getAllMessagesBetweenStudents($toUserId, $fromUserId);
+
+$filter_messages = api_get_configuration_value('filter_interactivity_messages');
+if ($filter_messages) {
+    $messages = MessageManager::getAllMessagesBetweenStudents($toUserId, $fromUserId, $coach_access_start_date, $coach_access_end_date);
+} else {
+    $messages = MessageManager::getAllMessagesBetweenStudents($toUserId, $fromUserId);
+}
 
 $content = Display::page_subheader2(sprintf(
     get_lang('MessagesExchangeBetweenXAndY'),


### PR DESCRIPTION
On /main/mySpace/myStudents.php if the configuration.php value 'allow_user_message_tracking' is set to true we can track the messages between teachers & students, independely of the session access dates, ... but in some cases we want to only track messages between the session access dates.

So this pullrequest add the option to do so.

It needs a new configuration.php parameter: 

**`$_configuration['filter_interactivity_messages'] = false;`**

... also **$_configuration['allow_user_message_tracking']** must be true or we can not track any messages of all

So the changes on  main/inc/lib/message.lib.php

1. Changed getUsersThatHadConversationWithUser($userId) to getUsersThatHadConversationWithUser($userId, $dateStart = null, $dateFinish = null) and filter the query with the two dates
2. Changed getAllMessagesBetweenStudents($userId) to getAllMessagesBetweenStudents($userId, $dateStart = null, $dateFinish = null) and filter the query with the two dates

The changes on main/mySpace/myStudents.php are:

1. Get the coach_access_start_date and coach_access_end_date from the session info
2. If allow_user_message_tracking and filter_interactivity_messages are true, filter the messages between the two dates
3. Add to the query string of the link of main/tracking/messages.php the two dates

And finally the changes on  main/tracking/messages.php are:
1. Get from the query string the dates to filter
2. If filter_interactivity_messages is set true filter the messages between the two dates
