### PR TITLE
Couse log - Option to set default extra fields as columns

### DIFF
--- a/main/inc/lib/tracking.lib.php
+++ b/main/inc/lib/tracking.lib.php
@@ -8137,7 +8137,7 @@ class TrackingCourseLog
         $extra_fields_to_show = 0;
         foreach ($extra_fields as $key => $field) {
             // exclude extra profile fields by id
-            if (in_array($field[0], $exclude)) {
+            if (in_array($field[3], $exclude)) {
                 continue;
             }
             // show only extra fields that are visible + and can be filtered, added by J.Montoya

--- a/main/inc/lib/tracking.lib.php
+++ b/main/inc/lib/tracking.lib.php
@@ -8701,18 +8701,18 @@ class TrackingCourseLog
             $data = Session::read('default_additional_user_profile_info');
             $defaultExtraFieldInfo = Session::read('default_extra_field_info');
             if (isset($defaultExtraFieldInfo) && isset($data)) {
-                foreach ($data as $clave => $val) {
+                foreach ($data as $key => $val) {
                     if (isset($val[$user['user_id']])) {
                         if (is_array($val[$user['user_id']])) {
-                            $user_row[$defaultExtraFieldInfo[$clave]['variable']] = implode(
+                            $user_row[$defaultExtraFieldInfo[$key]['variable']] = implode(
                                 ', ',
                                 $val[$user['user_id']]
                             );
                         } else {
-                            $user_row[$defaultExtraFieldInfo[$clave]['variable']] = $val[$user['user_id']];
+                            $user_row[$defaultExtraFieldInfo[$key]['variable']] = $val[$user['user_id']];
                         }
                     } else {
-                        $user_row[$defaultExtraFieldInfo[$clave]['variable']] = '';
+                        $user_row[$defaultExtraFieldInfo[$key]['variable']] = '';
                     }
                 }
             }

--- a/main/inc/lib/tracking.lib.php
+++ b/main/inc/lib/tracking.lib.php
@@ -8118,7 +8118,7 @@ class TrackingCourseLog
     }
 
     /**
-     * @param array    $exclude    Extra fields to be skipped, by ID
+     * @param array $exclude Extra fields to be skipped, by ID
      *
      * @return string
      */

--- a/main/inc/lib/tracking.lib.php
+++ b/main/inc/lib/tracking.lib.php
@@ -8118,9 +8118,11 @@ class TrackingCourseLog
     }
 
     /**
+     * @param array    $exclude    Extra fields to be skipped, by ID
+     *
      * @return string
      */
-    public static function display_additional_profile_fields()
+    public static function display_additional_profile_fields($exclude = [])
     {
         // getting all the extra profile fields that are defined by the platform administrator
         $extra_fields = UserManager::get_extra_fields(0, 50, 5, 'ASC');
@@ -8134,6 +8136,10 @@ class TrackingCourseLog
         $return .= '<option value="-">'.get_lang('SelectFieldToAdd').'</option>';
         $extra_fields_to_show = 0;
         foreach ($extra_fields as $key => $field) {
+            // exclude extra profile fields by id
+            if (in_array($field[0], $exclude)) {
+                continue;
+            }
             // show only extra fields that are visible + and can be filtered, added by J.Montoya
             if ($field[6] == 1 && $field[8] == 1) {
                 if (isset($_GET['additional_profile_field']) && $field[0] == $_GET['additional_profile_field']) {
@@ -8692,6 +8698,25 @@ class TrackingCourseLog
                 }
             }
 
+            $data = Session::read('default_additional_user_profile_info');
+            $defaultExtraFieldInfo = Session::read('default_extra_field_info');
+            if (isset($defaultExtraFieldInfo) && isset($data)) {
+                foreach ($data as $clave => $val) {
+                    if (isset($val[$user['user_id']])) {
+                        if (is_array($val[$user['user_id']])) {
+                            $user_row[$defaultExtraFieldInfo[$clave]['variable']] = implode(
+                                ', ',
+                                $val[$user['user_id']]
+                            );
+                        } else {
+                            $user_row[$defaultExtraFieldInfo[$clave]['variable']] = $val[$user['user_id']];
+                        }
+                    } else {
+                        $user_row[$defaultExtraFieldInfo[$clave]['variable']] = '';
+                    }
+                }
+            }
+
             if (api_get_setting('show_email_addresses') === 'true') {
                 $user_row['email'] = $user['col4'];
             }
@@ -8717,6 +8742,8 @@ class TrackingCourseLog
 
         Session::erase('additional_user_profile_info');
         Session::erase('extra_field_info');
+        Session::erase('default_additional_user_profile_info');
+        Session::erase('default_extra_field_info');
         Session::write('user_id_list', $userIdList);
 
         return $users;

--- a/main/install/configuration.dist.php
+++ b/main/install/configuration.dist.php
@@ -221,6 +221,12 @@ $_configuration['system_stable'] = NEW_VERSION_STABLE;
 //);
 // Course log - Default columns to hide
 //$_configuration['course_log_hide_columns'] = ['columns' => [1, 9]];
+// Course log - User extra fields to show as columns for default
+// For example, to show as a default column the user extra field with id 15 and 37 on site 1:
+// [1 => [15, 37]];
+// Same config plus site 3 and extra fields with id 53 and 55:
+// [1 => [15, 37], 2 => [53, 55]];
+//$_configuration['course_log_default_extra_fields'] = [1 => []];
 // Unoconv binary file
 //$_configuration['unoconv.binaries'] = '/usr/bin/unoconv';
 // Proxy settings for access external services

--- a/main/install/configuration.dist.php
+++ b/main/install/configuration.dist.php
@@ -222,11 +222,7 @@ $_configuration['system_stable'] = NEW_VERSION_STABLE;
 // Course log - Default columns to hide
 //$_configuration['course_log_hide_columns'] = ['columns' => [1, 9]];
 // Course log - User extra fields to show as columns for default
-// For example, to show as a default column the user extra field with id 15 and 37 on site 1:
-// [1 => [15, 37]];
-// Same config plus site 3 and extra fields with id 53 and 55:
-// [1 => [15, 37], 3 => [53, 55]];
-//$_configuration['course_log_default_extra_fields'] = [1 => []];
+//$_configuration['course_log_default_extra_fields'] = ['extra_fields' => [66, 67]];
 // Unoconv binary file
 //$_configuration['unoconv.binaries'] = '/usr/bin/unoconv';
 // Proxy settings for access external services

--- a/main/install/configuration.dist.php
+++ b/main/install/configuration.dist.php
@@ -225,7 +225,7 @@ $_configuration['system_stable'] = NEW_VERSION_STABLE;
 // For example, to show as a default column the user extra field with id 15 and 37 on site 1:
 // [1 => [15, 37]];
 // Same config plus site 3 and extra fields with id 53 and 55:
-// [1 => [15, 37], 2 => [53, 55]];
+// [1 => [15, 37], 3 => [53, 55]];
 //$_configuration['course_log_default_extra_fields'] = [1 => []];
 // Unoconv binary file
 //$_configuration['unoconv.binaries'] = '/usr/bin/unoconv';

--- a/main/install/configuration.dist.php
+++ b/main/install/configuration.dist.php
@@ -222,7 +222,7 @@ $_configuration['system_stable'] = NEW_VERSION_STABLE;
 // Course log - Default columns to hide
 //$_configuration['course_log_hide_columns'] = ['columns' => [1, 9]];
 // Course log - User extra fields to show as columns for default
-//$_configuration['course_log_default_extra_fields'] = ['extra_fields' => [66, 67]];
+//$_configuration['course_log_default_extra_fields'] = ['extra_fields' => ['office_address', 'office_phone_extension']];
 // Unoconv binary file
 //$_configuration['unoconv.binaries'] = '/usr/bin/unoconv';
 // Proxy settings for access external services

--- a/main/tracking/courseLog.php
+++ b/main/tracking/courseLog.php
@@ -219,13 +219,17 @@ if (!empty($defaultExtraFieldsFromSettings) && isset($defaultExtraFieldsFromSett
         $userArray[] = $key;
     }
 
-    foreach ($defaultExtraFields as $fieldId) {
-        // Fetching only the user that are loaded NOT ALL user in the portal.
-        $defaultUserProfileInfo[$fieldId] = TrackingCourseLog::getAdditionalProfileInformationOfFieldByUser(
-            $fieldId,
-            $userArray
-        );
-        $defaultExtraInfo[$fieldId] = UserManager::get_extra_field_information($fieldId);
+    foreach ($defaultExtraFields as $fieldName) {
+        $extraFieldInfo = UserManager::get_extra_field_information_by_name($fieldName);
+
+        if (!empty($extraFieldInfo)) {
+            // Fetching only the user that are loaded NOT ALL user in the portal.
+            $defaultUserProfileInfo[$extraFieldInfo['id']] = TrackingCourseLog::getAdditionalProfileInformationOfFieldByUser(
+                $extraFieldInfo['id'],
+                $userArray
+            );
+            $defaultExtraInfo[$extraFieldInfo['id']] = $extraFieldInfo;
+        }
     }
 
     Session::write('default_additional_user_profile_info', $defaultUserProfileInfo);

--- a/main/tracking/courseLog.php
+++ b/main/tracking/courseLog.php
@@ -206,6 +206,32 @@ if (isset($_GET['additional_profile_field'])) {
 Session::write('additional_user_profile_info', $userProfileInfo);
 Session::write('extra_field_info', $extra_info);
 
+$defaultExtraFields = [];
+$defaultExtraFieldsFromSettings = [];
+$defaultExtraFieldsFromSettings = api_get_configuration_value('course_log_default_extra_fields');
+if (isset($defaultExtraFieldsFromSettings)) {
+    $default_extra_fields = $defaultExtraFieldsFromSettings;
+    $defaultExtraInfo = [];
+    $defaultUserProfileInfo = [];
+
+    $user_array = [];
+    foreach ($studentList as $key => $item) {
+        $user_array[] = $key;
+    }
+
+    foreach ($default_extra_fields as $fieldId) {
+        // Fetching only the user that are loaded NOT ALL user in the portal.
+        $defaultUserProfileInfo[$fieldId] = TrackingCourseLog::getAdditionalProfileInformationOfFieldByUser(
+            $fieldId,
+            $user_array
+        );
+        $defaultExtraInfo[$fieldId] = UserManager::get_extra_field_information($fieldId);
+    }
+
+    Session::write('default_additional_user_profile_info', $defaultUserProfileInfo);
+    Session::write('default_extra_field_info', $defaultExtraInfo);
+}
+
 Display::display_header($nameTools, 'Tracking');
 
 $actionsLeft = TrackingCourseLog::actionsLeft('users', $sessionId);
@@ -589,7 +615,7 @@ if ($nbStudents > 0) {
         Display::return_icon('export_csv.png', get_lang('ExportAsCSV'), '', ICON_SIZE_SMALL).
         get_lang('ExportAsCSV')
     .' </a>');
-    $extraFieldSelect = TrackingCourseLog::display_additional_profile_fields();
+    $extraFieldSelect = TrackingCourseLog::display_additional_profile_fields($default_extra_fields);
     if (!empty($extraFieldSelect)) {
         $html .= $extraFieldSelect;
     }
@@ -743,6 +769,13 @@ if ($nbStudents > 0) {
             $headers[$extra_info[$fieldId]['variable']] = $extra_info[$fieldId]['display_text'];
             $counter++;
             $parameters['additional_profile_field'] = $fieldId;
+        }
+    }
+    if (isset($default_extra_fields)) {
+        foreach ($defaultExtraInfo as $field) {
+            $table->set_header($counter, $field['display_text'], false);
+            $headers[$field['variable']] = $field['display_text'];
+            $counter++;
         }
     }
     $table->set_header($counter, get_lang('Details'), false);

--- a/main/tracking/courseLog.php
+++ b/main/tracking/courseLog.php
@@ -210,20 +210,20 @@ $defaultExtraFields = [];
 $defaultExtraFieldsFromSettings = [];
 $defaultExtraFieldsFromSettings = api_get_configuration_value('course_log_default_extra_fields');
 if (isset($defaultExtraFieldsFromSettings)) {
-    $default_extra_fields = $defaultExtraFieldsFromSettings;
+    $defaultExtraFields = $defaultExtraFieldsFromSettings;
     $defaultExtraInfo = [];
     $defaultUserProfileInfo = [];
 
-    $user_array = [];
+    $userArray = [];
     foreach ($studentList as $key => $item) {
-        $user_array[] = $key;
+        $userArray[] = $key;
     }
 
-    foreach ($default_extra_fields as $fieldId) {
+    foreach ($defaultExtraFields as $fieldId) {
         // Fetching only the user that are loaded NOT ALL user in the portal.
         $defaultUserProfileInfo[$fieldId] = TrackingCourseLog::getAdditionalProfileInformationOfFieldByUser(
             $fieldId,
-            $user_array
+            $userArray
         );
         $defaultExtraInfo[$fieldId] = UserManager::get_extra_field_information($fieldId);
     }
@@ -615,7 +615,7 @@ if ($nbStudents > 0) {
         Display::return_icon('export_csv.png', get_lang('ExportAsCSV'), '', ICON_SIZE_SMALL).
         get_lang('ExportAsCSV')
     .' </a>');
-    $extraFieldSelect = TrackingCourseLog::display_additional_profile_fields($default_extra_fields);
+    $extraFieldSelect = TrackingCourseLog::display_additional_profile_fields($defaultExtraFields);
     if (!empty($extraFieldSelect)) {
         $html .= $extraFieldSelect;
     }
@@ -771,7 +771,7 @@ if ($nbStudents > 0) {
             $parameters['additional_profile_field'] = $fieldId;
         }
     }
-    if (isset($default_extra_fields)) {
+    if (isset($defaultExtraFields)) {
         foreach ($defaultExtraInfo as $field) {
             $table->set_header($counter, $field['display_text'], false);
             $headers[$field['variable']] = $field['display_text'];

--- a/main/tracking/courseLog.php
+++ b/main/tracking/courseLog.php
@@ -209,8 +209,8 @@ Session::write('extra_field_info', $extra_info);
 $defaultExtraFields = [];
 $defaultExtraFieldsFromSettings = [];
 $defaultExtraFieldsFromSettings = api_get_configuration_value('course_log_default_extra_fields');
-if (isset($defaultExtraFieldsFromSettings)) {
-    $defaultExtraFields = $defaultExtraFieldsFromSettings;
+if (!empty($defaultExtraFieldsFromSettings) && isset($defaultExtraFieldsFromSettings['extra_fields'])) {
+    $defaultExtraFields = $defaultExtraFieldsFromSettings['extra_fields'];
     $defaultExtraInfo = [];
     $defaultUserProfileInfo = [];
 


### PR DESCRIPTION
With this PR we can set some user extra fields to show automatically as columns on main/tracking/courseLog.php.


![imagen](https://user-images.githubusercontent.com/48205899/121557199-d8c6dc80-ca14-11eb-8e7f-36799a0233c9.png)


To achive it we need a new configuration.php parameter:

`$_configuration['course_log_default_extra_fields'] = [1 => []];`

For example, to show as a default column the user extra field with id 15 and 37 on site 1

`$_configuration['course_log_default_extra_fields'] = [1 => [15, 37]];`

Same config plus site 3 and extra fields with id 53 and 55:

`$_configuration['course_log_default_extra_fields'] = [1 => [15, 37], 3 => [53, 55]];`

Changes on main/inc/lib/tracking.lib.php:

1. Changed display_additional_profile_fields() to display_additional_profile_fields($exclude = []) to pass some extra fields to filter
2. Get on get_user_data($from, $number_of_items, $column, $direction, $conditions = []) the value for the the extra fields configuered as columns  at $_configuration['course_log_default_extra_fields']

Changes on main/install/configuration.dist.php:

1. Manage the $_configuration['course_log_default_extra_fields'] to show them as columns




