### PR TITLE
Plugin BuyCourses install fix: DBAL Types do not have TINYINT.

### DIFF
--- a/plugin/buycourses/database.php
+++ b/plugin/buycourses/database.php
@@ -447,7 +447,7 @@ if (false === $sm->tablesExist(BuyCoursesPlugin::TABLE_COUPON)) {
     $couponTable->addColumn('valid_start', Types::DATETIME_MUTABLE);
     $couponTable->addColumn('valid_end', Types::DATETIME_MUTABLE);
     $couponTable->addColumn('delivered', Types::INTEGER);
-    $couponTable->addColumn('active', Types::TINYINT);
+    $couponTable->addColumn('active', Types::BOOLEAN);
     $couponTable->setPrimaryKey(['id']);
 }
 


### PR DESCRIPTION
Installing BuyCourses plugin on a fresh Chamilo 1.11.16 I got an error:

```
Fatal error: Uncaught Error: Undefined class constant 'TINYINT' in /Users/me/Projects/chamilo-lms/plugin/buycourses/database.php:450 Stack trace:
#0 /Users/me/Projects/chamilo-lms/plugin/buycourses/src/buy_course_plugin.class.php(168): require_once()
#1 /Users/me/Projects/chamilo-lms/plugin/buycourses/install.php(16): BuyCoursesPlugin->install()
#2 /Users/me/Projects/chamilo-lms/main/inc/lib/plugin.lib.php(321): require('/Users/neurotoo...')
#3 /Users/me/Projects/chamilo-lms/main/admin/settings.lib.php(943): AppPlugin->install('buycourses')
#4 /Users/me/Projects/chamilo-lms/main/admin/settings.lib.php(226): storePlugins()
#5 /Users/me/Projects/chamilo-lms/main/admin/settings.php(472): handlePlugins()
#6 {main} thrown in /Users/me/Projects/chamilo-lms/plugin/buycourses/database.php on line 450
```
It's because Chamilo tries to create the database tables using DBAL and a field type is defined using the DBAL Types constant Types::TINYINT, but that constant is undefined in DBAL Types.

As stated by DBAL mantainers, you should use Types::BOOLEAN instead.

