### PR TITLE
Buycourses plugin - Missing plugin_buycourses_services table parameter

### DIFF
--- a/plugin/buycourses/database.php
+++ b/plugin/buycourses/database.php
@@ -297,6 +297,7 @@ if (false === $sm->tablesExist(BuyCoursesPlugin::TABLE_SERVICES)) {
     $servicesTable->addColumn('video_url', Types::STRING);
     $servicesTable->addColumn('image', Types::STRING);
     $servicesTable->addColumn('service_information', Types::TEXT);
+    $servicesTable->addColumn('tax_perc', Types::INTEGER);
     $servicesTable->setPrimaryKey(['id']);
 }
 


### PR DESCRIPTION
Buycourses install is missing the tax_perc parameter for the plugin_buycourses_services table.

This commit fix it.

