### PR TITLE
param == "cmi.exit"

### DIFF
--- a/main/lp/scorm_api.php
+++ b/main/lp/scorm_api.php
@@ -701,6 +701,7 @@ function LMSSetValue(param, val) {
         save_suspend_data_in_local(); // save to local storage if available
         return_value='true';
     } else if ( param == "cmi.core.exit" || param == "cmi.exit" ) {
+        //cmi.exit for SCORM 1.3
         olms.lms_item_core_exit = val;
         olms.updatable_vars_list['cmi.core.exit']=true;
         return_value='true';


### PR DESCRIPTION
Ajout du verbe cmi.exit en plus de cmi.core.exit
Meilleure compatibilité avec le logiciel auteur RISE 360
SCORM 2004