### PR TITLE
Session cookie: Option to set samesite:None parameter

### DIFF
--- a/main/inc/lib/chamilo_session.class.php
+++ b/main/inc/lib/chamilo_session.class.php
@@ -87,7 +87,7 @@ class ChamiloSession extends System\Session
         //session ID in the cookie is only readable by the server
         ini_set('session.cookie_httponly', 1);
 
-        if (api_get_configuration_value('allow_session_samesite_none_cookie_parameter')) {
+        if (api_get_configuration_value('security_session_cookie_samesite_none')) {
             if (PHP_VERSION_ID < 70300) {
                 $sessionCookieParams = session_get_cookie_params();
                 session_set_cookie_params($sessionCookieParams['lifetime'], '/; samesite=None',

--- a/main/inc/lib/chamilo_session.class.php
+++ b/main/inc/lib/chamilo_session.class.php
@@ -87,6 +87,17 @@ class ChamiloSession extends System\Session
         //session ID in the cookie is only readable by the server
         ini_set('session.cookie_httponly', 1);
 
+        if (api_get_configuration_value('allow_session_samesite_none_cookie_parameter')) {
+            if (PHP_VERSION_ID < 70300) {
+                $sessionCookieParams = session_get_cookie_params();
+                session_set_cookie_params($sessionCookieParams['lifetime'], '/; samesite=None',
+                $sessionCookieParams['domain'], true, $sessionCookieParams['httponly']);
+            } else {
+                ini_set('session.cookie_secure', 1);
+                ini_set('session.cookie_samesite', 'None');
+            }
+        }
+
         //Use entropy file
         //session.entropy_file
         //ini_set('session.entropy_length', 128);

--- a/main/install/configuration.dist.php
+++ b/main/install/configuration.dist.php
@@ -2006,6 +2006,11 @@ VALUES (21, 13, 'send_notification_at_a_specific_date', 'Send notification at a 
 // Overwrites the app/config/auth.conf.php settings
 //$_configuration['extldap_config'] = ['host' => '', 'port' => ''];
 
+// Enable samesite:None parameter for session cookie.
+// More info: https://www.chromium.org/updates/same-site
+// Also: https://developers.google.com/search/blog/2020/01/get-ready-for-new-samesitenone-secure
+//$_configuration['allow_session_samesite_none_cookie_parameter'] = false;
+
 // KEEP THIS AT THE END
 // -------- Custom DB changes
 // Add user activation by confirmation email

--- a/main/install/configuration.dist.php
+++ b/main/install/configuration.dist.php
@@ -558,6 +558,11 @@ ALTER TABLE sys_announcement ADD COLUMN visible_boss INT DEFAULT 0;
 // information the browser includes with navigation away from a document
 // and should be set by all sites.
 //$_configuration['security_referrer_policy'] = 'origin-when-cross-origin';
+//
+// Enable samesite:None parameter for session cookie.
+// More info: https://www.chromium.org/updates/same-site
+// Also: https://developers.google.com/search/blog/2020/01/get-ready-for-new-samesitenone-secure
+//$_configuration['security_session_cookie_samesite_none'] = false;
 // ------ HTTP headers security section ends here
 //
 // ------ Survey configuration settings
@@ -2008,11 +2013,6 @@ VALUES (21, 13, 'send_notification_at_a_specific_date', 'Send notification at a 
 
 // Overwrites the app/config/auth.conf.php settings
 //$_configuration['extldap_config'] = ['host' => '', 'port' => ''];
-
-// Enable samesite:None parameter for session cookie.
-// More info: https://www.chromium.org/updates/same-site
-// Also: https://developers.google.com/search/blog/2020/01/get-ready-for-new-samesitenone-secure
-//$_configuration['allow_session_samesite_none_cookie_parameter'] = false;
 
 // KEEP THIS AT THE END
 // -------- Custom DB changes


### PR DESCRIPTION
Users using browsers with the Chromium engine (Chrome, Edge, ...) with chamilo campuses embedded in third-party sites via iframes (e.g., proctorized exam platforms) fail to login in.

This is due to changes in behavior for cross-site cookies introduced by Google in 2020 that require session cookies to be specified with the samesite parameter to None and secure to true.

https://www.chromium.org/updates/same-site
https://developers.google.com/search/blog/2020/01/get-ready-for-new-samesitenone-secure

To check this behavior create an html file with an iframe indicating in the src a Chamilo campus and open it with a browser with Chromium engine.

This pull add a new configuration parameter called "allow_session_samesite_none_cookie_parameter" (I really don´t like this name, any suggestions?), if its true adds to the session cookie the samesite:None and secure:True parameters
