### PR TITLE
getWorkListTeacherQuery Fix

### DIFF
--- a/main/work/work.lib.php
+++ b/main/work/work.lib.php
@@ -1573,7 +1573,7 @@ function getWorkListTeacherQuery(
     $workTable = Database::get_course_table(TABLE_STUDENT_PUBLICATION);
     $workTableAssignment = Database::get_course_table(TABLE_STUDENT_PUBLICATION_ASSIGNMENT);
 
-    $condition_session = api_get_session_condition($sessionId);
+    $condition_session = " AND ( session_id = $sessionId OR session_id is null ) ";
     $groupIid = 0;
     if ($groupId) {
         $groupInfo = GroupManager::get_group_properties($groupId);


### PR DESCRIPTION
Cas : 
1 - Un travail (outil travaux) est déclaré dans un cours et intégré dans une session
2 - Le cours est intégré dans une session
3 - Le travail est rendu par un eleve dans la session
4 - les travaux existent mais n'apparaissent jamais coté enseignant

Solution proposée line 1584:
function getWorkListTeacherQuery
$condition_session = "AND ( session_id = $sessionId OR session_id is null ) ";