### PR TITLE
Course about page: add option to hide teachers name

### DIFF
--- a/main/install/configuration.dist.php
+++ b/main/install/configuration.dist.php
@@ -2015,7 +2015,7 @@ VALUES (21, 13, 'send_notification_at_a_specific_date', 'Send notification at a 
 //$_configuration['extldap_config'] = ['host' => '', 'port' => ''];
 
 // Option to hide the teachers info on courses about info page.
-//$_configuration['course_about_teacher_name_hiden'] = false;
+//$_configuration['course_about_teacher_name_hide'] = false;
 
 // KEEP THIS AT THE END
 // -------- Custom DB changes

--- a/main/install/configuration.dist.php
+++ b/main/install/configuration.dist.php
@@ -2015,7 +2015,7 @@ VALUES (21, 13, 'send_notification_at_a_specific_date', 'Send notification at a 
 //$_configuration['extldap_config'] = ['host' => '', 'port' => ''];
 
 // Option to hide the teachers info on courses about info page.
-//$_configuration['hide_teachers_name_from_course_about_info'] = false;
+//$_configuration['course_about_teacher_name_hiden'] = false;
 
 // KEEP THIS AT THE END
 // -------- Custom DB changes

--- a/main/install/configuration.dist.php
+++ b/main/install/configuration.dist.php
@@ -2010,6 +2010,9 @@ VALUES (21, 13, 'send_notification_at_a_specific_date', 'Send notification at a 
 // Overwrites the app/config/auth.conf.php settings
 //$_configuration['extldap_config'] = ['host' => '', 'port' => ''];
 
+// Option to hide the teachers info on courses about info page.
+//$_configuration['hide_teachers_name_from_course_about_info'] = false;
+
 // KEEP THIS AT THE END
 // -------- Custom DB changes
 // Add user activation by confirmation email

--- a/main/template/default/course_home/about.tpl
+++ b/main/template/default/course_home/about.tpl
@@ -1,7 +1,7 @@
 <div id="about-course">
     <div id="course-info-top">
         <h2 class="session-title">{{ course.title }}</h2>
-        {% if not 'course_about_teacher_name_hiden'|api_get_configuration_value %}
+        {% if not 'course_about_teacher_name_hide'|api_get_configuration_value %}
             <div class="course-short">
                 <ul>
                     <li class="author">{{ "Professors"|get_lang }}</li>
@@ -178,7 +178,7 @@
                     </div>
                 </div>
                 {% endif %}
-                {% if course.teachers and not 'course_about_teacher_name_hiden'|api_get_configuration_value %}
+                {% if course.teachers and not 'course_about_teacher_name_hide'|api_get_configuration_value %}
                     <div class="panel panel-default">
                         <div class="panel-body">
                             <div class="panel-teachers">

--- a/main/template/default/course_home/about.tpl
+++ b/main/template/default/course_home/about.tpl
@@ -1,7 +1,7 @@
 <div id="about-course">
     <div id="course-info-top">
         <h2 class="session-title">{{ course.title }}</h2>
-        {% if not 'hide_teachers_name_from_course_about_info'|api_get_configuration_value %}
+        {% if not 'course_about_teacher_name_hiden'|api_get_configuration_value %}
             <div class="course-short">
                 <ul>
                     <li class="author">{{ "Professors"|get_lang }}</li>
@@ -178,7 +178,7 @@
                     </div>
                 </div>
                 {% endif %}
-                {% if course.teachers and not 'hide_teachers_name_from_course_about_info'|api_get_configuration_value %}
+                {% if course.teachers and not 'course_about_teacher_name_hiden'|api_get_configuration_value %}
                     <div class="panel panel-default">
                         <div class="panel-body">
                             <div class="panel-teachers">

--- a/main/template/default/course_home/about.tpl
+++ b/main/template/default/course_home/about.tpl
@@ -1,14 +1,16 @@
 <div id="about-course">
     <div id="course-info-top">
         <h2 class="session-title">{{ course.title }}</h2>
-        <div class="course-short">
-            <ul>
-                <li class="author">{{ "Professors"|get_lang }}</li>
-                {%  for teacher in course.teachers %}
-                    <li>{{ teacher.complete_name }} | </li>
-                {% endfor %}
-            </ul>
-        </div>
+        {% if not 'hide_teachers_name_from_course_about_info'|api_get_configuration_value %}
+            <div class="course-short">
+                <ul>
+                    <li class="author">{{ "Professors"|get_lang }}</li>
+                    {%  for teacher in course.teachers %}
+                        <li>{{ teacher.complete_name }} | </li>
+                    {% endfor %}
+                </ul>
+            </div>
+        {% endif %}
     </div>
 
     {% set course_video = '' %}
@@ -176,7 +178,7 @@
                     </div>
                 </div>
                 {% endif %}
-                {% if course.teachers %}
+                {% if course.teachers and not 'hide_teachers_name_from_course_about_info'|api_get_configuration_value %}
                     <div class="panel panel-default">
                         <div class="panel-body">
                             <div class="panel-teachers">


### PR DESCRIPTION
This pull add a new configuration.php option, hide_teachers_name_from_course_about_info, to hide the teachers info on courses about pages:

**hide_teachers_name_from_course_about_info -> no value or false:**

![imagen](https://user-images.githubusercontent.com/48205899/141352593-cfbebadf-35dc-4435-8857-31ff7f37a5fe.png)

**hide_teachers_name_from_course_about_info -> true:**

![imagen](https://user-images.githubusercontent.com/48205899/141352644-6f42d7c2-09b7-4093-8126-fa433fb79bb4.png)

