### PR TITLE
Add badge_assignation_notification conf setting - refs BT#19402

### DIFF
--- a/main/inc/lib/skill.lib.php
+++ b/main/inc/lib/skill.lib.php
@@ -3087,6 +3087,7 @@ class Skill extends Model
     public function addSkillToUserBadge($user, $skill, $levelId, $argumentation, $authorId)
     {
         $showLevels = false === api_get_configuration_value('hide_skill_levels');
+        $badgeAssignationNotification = api_get_configuration_value('badge_assignation_notification');
 
         $entityManager = Database::getManager();
 
@@ -3116,6 +3117,23 @@ class Skill extends Model
 
         $entityManager->persist($skillUser);
         $entityManager->flush();
+
+        if ($badgeAssignationNotification) {
+            $url = SkillRelUser::getIssueUrlAll($skillUser);
+
+            $message = sprintf(
+                get_lang('YouXHaveAchievedTheSkillYToSeeFollowLinkZ'),
+                $user->getFirstname(),
+                $skill->getName(),
+                Display::url($url, $url, ['target' => '_blank'])
+            );
+
+            MessageManager::send_message(
+                $user->getId(),
+                get_lang('YouHaveAchievedANewSkill'),
+                $message
+            );
+        }
 
         return $skillUser;
     }

--- a/main/install/configuration.dist.php
+++ b/main/install/configuration.dist.php
@@ -934,6 +934,9 @@ ALTER TABLE skill_rel_course ADD CONSTRAINT FK_E7CEC7FA613FECDF FOREIGN KEY (ses
 // 4. Set "allow_skill_rel_items" to true
 //$_configuration['allow_skill_rel_items'] = false;
 
+// Allows to send a notification when a user has achieved a skill
+//$_configuration['badge_assignation_notification'] = false;
+
 // Generate random login when importing users
 //$_configuration['generate_random_login'] = false;
 


### PR DESCRIPTION
Allows to send a notification when a user has achieved a skill.

Language variables
`$YouHaveAchievedANewSkill = 'You have achieved a new skill.';`
`$YouXHaveAchievedTheSkillYToSeeFollowLinkZ = 'Hi, %s. You have achieved the skill "%s". To see the details go here: %s.';`