### PR TITLE
Assign courses to urls - add title parameter to options elements to show coursename & code

### DIFF
--- a/main/admin/access_url_edit_courses_to_url.php
+++ b/main/admin/access_url_edit_courses_to_url.php
@@ -197,7 +197,7 @@ $url_list = UrlManager::get_url_data();
                             <?php
                             foreach ($no_course_list as $no_course) {
                                 ?>
-                                <option value="<?php echo $no_course['id']; ?>"><?php echo $no_course['title'].' ('.$no_course['code'].')'; ?></option>
+                                <option value="<?php echo $no_course['id']; ?>" title="<?php echo $no_course['title'].' ('.$no_course['code'].')'; ?>"><?php echo $no_course['title'].' ('.$no_course['code'].')'; ?></option>
                             <?php
                             }
                         unset($no_course_list); ?>
@@ -234,7 +234,7 @@ $url_list = UrlManager::get_url_data();
                     <?php
                     foreach ($course_list as $course) {
                         $courseInfo = api_get_course_info_by_id($course['id']); ?>
-                        <option value="<?php echo $course['id']; ?>">
+                        <option value="<?php echo $course['id']; ?>" title="<?php echo $course['title'].' ('.$courseInfo['code'].')'; ?>">
                             <?php echo $course['title'].' ('.$courseInfo['code'].')'; ?>
                         </option>
                     <?php

--- a/main/admin/access_url_edit_courses_to_url.php
+++ b/main/admin/access_url_edit_courses_to_url.php
@@ -197,7 +197,7 @@ $url_list = UrlManager::get_url_data();
                             <?php
                             foreach ($no_course_list as $no_course) {
                                 ?>
-                                <option value="<?php echo $no_course['id']; ?>" title="<?php echo $no_course['title'].' ('.$no_course['code'].')'; ?>"><?php echo $no_course['title'].' ('.$no_course['code'].')'; ?></option>
+                                <option value="<?php echo $no_course['id']; ?>" title="<?php echo htmlentities($no_course['title'], ENT_QUOTES).' ('.$no_course['code'].')'; ?>"><?php echo $no_course['title'].' ('.$no_course['code'].')'; ?></option>
                             <?php
                             }
                         unset($no_course_list); ?>
@@ -234,7 +234,7 @@ $url_list = UrlManager::get_url_data();
                     <?php
                     foreach ($course_list as $course) {
                         $courseInfo = api_get_course_info_by_id($course['id']); ?>
-                        <option value="<?php echo $course['id']; ?>" title="<?php echo $course['title'].' ('.$courseInfo['code'].')'; ?>">
+                        <option value="<?php echo $course['id']; ?>" title="<?php echo htmlentities($course['title'], ENT_QUOTES).' ('.$courseInfo['code'].')'; ?>">
                             <?php echo $course['title'].' ('.$courseInfo['code'].')'; ?>
                         </option>
                     <?php


### PR DESCRIPTION
Sometimes the course names are too long, this can be a problem in the tool to assign courses to urls; in case of long-named courses, the administrator will not be able to see the full name or course code.

This hack adds a title parameter to the option elements, using the course name and code as the value.

Hovering over the select elements will show course names and codes in a tooltip.

![imagen](https://user-images.githubusercontent.com/48205899/144446907-3a1843f7-9029-441e-baff-525ae5227607.png)
