### PR TITLE
Add agenda_reminders configuration setting - refs BT#19392

### DIFF
--- a/main/calendar/agenda.php
+++ b/main/calendar/agenda.php
@@ -276,6 +276,10 @@ if ($allowToEdit) {
                 $attachmentList = $sendAttachment ? $_FILES : null;
                 $attachmentCommentList = $values['legend'] ?? '';
                 $comment = $values['comment'] ?? '';
+                $notificationCount = $_REQUEST['notification_count'] ?? [];
+                $notificationPeriod = $_REQUEST['notification_period'] ?? [];
+
+                $reminders = $notificationCount ? array_map(null, $notificationCount, $notificationPeriod) : [];
 
                 // This is a sub event. Delete the current and create another BT#7803
                 if (!empty($event['parent_event_id'])) {
@@ -295,7 +299,8 @@ if ($allowToEdit) {
                         $comment,
                         '',
                         $values['invitees'] ?? [],
-                        $values['collective'] ?? false
+                        $values['collective'] ?? false,
+                        $reminders
                     );
 
                     $message = Display::return_message(get_lang('Updated'), 'confirmation');
@@ -323,7 +328,8 @@ if ($allowToEdit) {
                     true,
                     0,
                     $values['invitees'] ?? [],
-                    $values['collective'] ?? false
+                    $values['collective'] ?? false,
+                    $reminders
                 );
 
                 if (!empty($values['repeat']) && !empty($eventId)) {

--- a/main/calendar/agenda.php
+++ b/main/calendar/agenda.php
@@ -92,6 +92,45 @@ function add_image_form() {
 }
 </script>';
 
+$agendaRemindersEnabled = api_get_configuration_value('agenda_reminders');
+
+if ($agendaRemindersEnabled) {
+    $htmlHeadXtra[] = '<script>
+    $(function () {
+        var template = \'<div class="form-group">\' +
+            \'<div class="col-sm-offset-2 col-sm-3">\' +
+            \'<input min="0" step="1" id="notification_count[]" type="number" class=" form-control" name="notification_count[]">\' +
+            \'</div>\' +
+            \'<div class="col-sm-3">\' +
+            \'<select class="form-control" name="notification_period[]" id="form_notification_period[]">\' +
+            \'<option value="i">'.get_lang('Minutes').'</option>\' +
+            \'<option value="h">'.get_lang('Hours').'</option>\' +
+            \'<option value="d">'.get_lang('Days').'</option>\' +
+            \'<option value="w">'.get_lang('Weeks').'</option>\' +
+            \'</select>\' +
+            \'</div>\' +
+            \'<div class="col-sm-2"><p class="form-control-static">'.get_lang('Before').'</p></div>\' +
+            \'<div class="text-right col-sm-2">\' +
+            \'<button class="btn btn-default delete-notification" type="button" aria-label="'.get_lang('Delete').'"><em class="fa fa-times"></em></button>\' +
+            \'</div>\' +
+            \'</div>\';
+
+        $("#add_event_add_notification").on("click", function (e) {
+            e.preventDefault();
+
+            $(template).appendTo("#notification_list");
+            $("#notification_list select").selectpicker("refresh");
+        });
+
+        $("#notification_list").on("click", ".delete-notification", function (e) {
+            e.preventDefault();
+
+            $(this).parents(".form-group").remove();
+        });
+    });
+    </script>';
+}
+
 // setting the name of the tool
 $nameTools = get_lang('Agenda');
 
@@ -161,6 +200,10 @@ if ($allowToEdit) {
                 $usersToSend = $values['users_to_send'] ?? '';
                 $startDate = $values['date_range_start'];
                 $endDate = $values['date_range_end'];
+                $notificationCount = $_REQUEST['notification_count'] ?? [];
+                $notificationPeriod = $_REQUEST['notification_period'] ?? [];
+
+                $reminders = $notificationCount ? array_map(null, $notificationCount, $notificationPeriod) : [];
 
                 $eventId = $agenda->addEvent(
                     $startDate,
@@ -176,7 +219,8 @@ if ($allowToEdit) {
                     $comment,
                     '',
                     $values['invitees'] ?? [],
-                    $values['collective'] ?? false
+                    $values['collective'] ?? false,
+                    $reminders
                 );
 
                 if (!empty($values['repeat']) && !empty($eventId)) {

--- a/main/calendar/agenda.php
+++ b/main/calendar/agenda.php
@@ -106,7 +106,6 @@ if ($agendaRemindersEnabled) {
             \'<option value="i">'.get_lang('Minutes').'</option>\' +
             \'<option value="h">'.get_lang('Hours').'</option>\' +
             \'<option value="d">'.get_lang('Days').'</option>\' +
-            \'<option value="w">'.get_lang('Weeks').'</option>\' +
             \'</select>\' +
             \'</div>\' +
             \'<div class="col-sm-2"><p class="form-control-static">'.get_lang('Before').'</p></div>\' +

--- a/main/calendar/agenda_js.php
+++ b/main/calendar/agenda_js.php
@@ -294,6 +294,11 @@ if (api_get_configuration_value('agenda_collective_invitations') && 'personal' =
     $form->addCheckBox('collective', '', get_lang('IsItEditableByTheInvitees'));
 }
 
+if (api_get_configuration_value('agenda_reminders')) {
+    $form->addHtml('<hr><div id="notification_list"></div>');
+    $form->addButton('add_notification', get_lang('AddNotification'), 'bell-o')->setType('button');
+}
+
 $form->addHtml('<div id="attachment_block" style="display: none">');
 $form->addLabel(get_lang('Attachment'), '<div id="attachment_text" style="display: none"></div>');
 $form->addHtml('</div>');

--- a/main/calendar/agenda_js.php
+++ b/main/calendar/agenda_js.php
@@ -297,6 +297,7 @@ if (api_get_configuration_value('agenda_collective_invitations') && 'personal' =
 if (api_get_configuration_value('agenda_reminders')) {
     $form->addHtml('<hr><div id="notification_list"></div>');
     $form->addButton('add_notification', get_lang('AddNotification'), 'bell-o')->setType('button');
+    $form->addHtml('<hr>');
 }
 
 $form->addHtml('<div id="attachment_block" style="display: none">');

--- a/main/cron/agenda_reminders.php
+++ b/main/cron/agenda_reminders.php
@@ -5,7 +5,6 @@
 /**
  * This script send notification messages to users that have reminders from an event in their agenda.
  */
-
 require_once __DIR__.'/../../main/inc/global.inc.php';
 
 exit;
@@ -161,7 +160,7 @@ foreach ($reminders as $reminder) {
 
     $em->persist($reminder);
 
-    ++$batchCounter;
+    $batchCounter++;
 
     if (($batchCounter % $batchSize) === 0) {
         $em->flush();

--- a/main/cron/agenda_reminders.php
+++ b/main/cron/agenda_reminders.php
@@ -1,0 +1,172 @@
+<?php
+
+/* For licensing terms, see /license.txt */
+
+/**
+ * This script send notification messages to users that have reminders from an event in their agenda.
+ */
+
+require_once __DIR__.'/../../main/inc/global.inc.php';
+
+exit;
+
+if (false === api_get_configuration_value('agenda_reminders')) {
+    exit;
+}
+
+$batchCounter = 0;
+$batchSize = 100;
+
+$agendaCollectiveInvitations = api_get_configuration_value('agenda_collective_invitations');
+
+$now = new DateTime('now', new DateTimeZone('UTC'));
+
+$em = Database::getManager();
+$remindersRepo = $em->getRepository('ChamiloCoreBundle:AgendaReminder');
+
+$reminders = $remindersRepo->findBySent(false);
+
+foreach ($reminders as $reminder) {
+    if ('personal' === $reminder->getType()) {
+        $event = $em->find('ChamiloCoreBundle:PersonalAgenda', $reminder->getEventId());
+
+        $notificationDate = clone $event->getDate();
+        $notificationDate->sub($reminder->getDateInterval());
+
+        if ($notificationDate > $now) {
+            continue;
+        }
+
+        $eventDetails = [];
+        $eventDetails[] = '<strong>'.$event->getTitle().'</strong>';
+
+        if ($event->getAllDay()) {
+            $eventDetails[] = get_lang('AllDay');
+        } else {
+            $eventDetails[] = sprintf(
+                get_lang('FromDateX'),
+                api_get_local_time($event->getDate(), null, null, false, true, true)
+            );
+
+            if (!empty($event->getEnddate())) {
+                $eventDetails[] = sprintf(
+                    get_lang('UntilDateX'),
+                    api_get_local_time($event->getEnddate(), null, null, false, true, true)
+                );
+            }
+        }
+
+        if (!empty($event->getText())) {
+            $eventDetails[] = $event->getText();
+        }
+
+        $messageSubject = sprintf(get_lang('ReminderXEvent'), $event->getTitle());
+        $messageContent = implode('<br />', $eventDetails);
+
+        MessageManager::send_message_simple(
+            $event->getUser(),
+            $messageSubject,
+            $messageContent,
+            $event->getUser()
+        );
+
+        if ($agendaCollectiveInvitations) {
+            $invitees = Agenda::getInviteesForPersonalEvent($reminder->getEventId());
+            $inviteesIdList = array_column($invitees, 'id');
+
+            foreach ($inviteesIdList as $userId) {
+                MessageManager::send_message_simple(
+                    $userId,
+                    $messageSubject,
+                    $messageContent,
+                    $event->getUser()
+                );
+            }
+        }
+    }
+
+    if ('course' === $reminder->getType()) {
+        $event = $em->find('ChamiloCourseBundle:CCalendarEvent', $reminder->getEventId());
+        $agenda = new Agenda('course');
+
+        $notificationDate = clone $event->getStartDate();
+        $notificationDate->sub($reminder->getDateInterval());
+
+        if ($notificationDate > $now) {
+            continue;
+        }
+
+        $eventDetails = [];
+        $eventDetails[] = '<strong>'.$event->getTitle().'</strong>';
+
+        if ($event->getAllDay()) {
+            $eventDetails[] = get_lang('AllDay');
+        } else {
+            $eventDetails[] = sprintf(
+                get_lang('FromDateX'),
+                api_get_local_time($event->getStartDate(), null, null, false, true, true)
+            );
+
+            if (!empty($event->getEndDate())) {
+                $eventDetails[] = sprintf(
+                    get_lang('UntilDateX'),
+                    api_get_local_time($event->getEndDate(), null, null, false, true, true)
+                );
+            }
+        }
+
+        if (!empty($event->getContent())) {
+            $eventDetails[] = $event->getContent();
+        }
+
+        $messageSubject = sprintf(get_lang('ReminderXEvent'), $event->getTitle());
+        $messageContent = implode('<br />', $eventDetails);
+
+        $courseInfo = api_get_course_info_by_id($event->getCId());
+
+        $sendTo = $agenda->getUsersAndGroupSubscribedToEvent(
+            $event->getIid(),
+            $event->getCId(),
+            $event->getSessionId()
+        );
+
+        if ($sendTo['everyone']) {
+            $users = CourseManager::get_user_list_from_course_code($courseInfo['code'], $event->getSessionId());
+            $userIdList = array_keys($users);
+
+            if ($event->getSessionId()) {
+                $coaches = SessionManager::getCoachesByCourseSession($event->getSessionId(), $event->getCId());
+                $userIdList += $coaches;
+            }
+
+            foreach ($userIdList as $userId) {
+                MessageManager::send_message_simple($userId, $messageSubject, $messageContent);
+            }
+        } else {
+            foreach ($sendTo['groups'] as $groupId) {
+                $groupUserList = GroupManager::get_users($groupId, false, null, null, false, $event->getSessionId());
+
+                foreach ($groupUserList as $groupUserId) {
+                    MessageManager::send_message_simple($groupUserId, $messageSubject, $messageContent);
+                }
+            }
+
+            foreach ($sendTo['users'] as $userId) {
+                MessageManager::send_message_simple($userId, $messageSubject, $messageContent);
+            }
+        }
+    }
+
+    $reminder->setSent(true);
+
+    $em->persist($reminder);
+
+    ++$batchCounter;
+
+    if (($batchCounter % $batchSize) === 0) {
+        $em->flush();
+    }
+}
+
+$em->flush();
+$em->clear();

--- a/main/inc/ajax/agenda.ajax.php
+++ b/main/inc/ajax/agenda.ajax.php
@@ -47,6 +47,10 @@ switch ($action) {
         $userToSend = isset($_REQUEST['users_to_send']) ? $_REQUEST['users_to_send'] : [];
         $inviteesList = $_REQUEST['invitees'] ?? [];
         $isCollective = isset($_REQUEST['collective']);
+        $notificationCount = $_REQUEST['notification_count'] ?? [];
+        $notificationPeriod = $_REQUEST['notification_period'] ?? [];
+
+        $reminders = $notificationCount ? array_map(null, $notificationCount, $notificationPeriod) : [];
 
         $eventId = $agenda->addEvent(
             $_REQUEST['start'],
@@ -62,7 +66,8 @@ switch ($action) {
             $comment,
             '',
             $inviteesList,
-            $isCollective
+            $isCollective,
+            $reminders
         );
 
         echo $eventId;

--- a/main/inc/lib/agenda.lib.php
+++ b/main/inc/lib/agenda.lib.php
@@ -4,6 +4,7 @@
 
 use Chamilo\CoreBundle\Entity\AgendaEventInvitation;
 use Chamilo\CoreBundle\Entity\AgendaEventInvitee;
+use Chamilo\CoreBundle\Entity\AgendaReminder;
 use Chamilo\UserBundle\Entity\User;
 
 /**
@@ -250,7 +251,8 @@ class Agenda
         $eventComment = null,
         $color = '',
         array $inviteesList = [],
-        bool $isCollective = false
+        bool $isCollective = false,
+        array $reminders = []
     ) {
         $start = api_get_utc_datetime($start);
         $end = api_get_utc_datetime($end);
@@ -452,7 +454,47 @@ class Agenda
                 break;
         }
 
+        if (api_get_configuration_value('agenda_reminders')) {
+            foreach ($reminders as $reminder) {
+                $this->addReminder($id, $reminder[0], $reminder[1]);
+            }
+        }
+
         return $id;
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function addReminder($eventId, $count, $period)
+    {
+        switch ($period) {
+            case 'i':
+                $dateInterval = DateInterval::createFromDateString("$count minutes");
+                break;
+            case 'h':
+                $dateInterval = DateInterval::createFromDateString("$count hours");
+                break;
+            case 'd':
+                $dateInterval = DateInterval::createFromDateString("$count days");
+                break;
+            case 'w':
+                $dateInterval = DateInterval::createFromDateString("$count weeks");
+                break;
+            default:
+                return null;
+        }
+
+        $agendaReminder = new AgendaReminder();
+        $agendaReminder
+            ->setType($this->type)
+            ->setEventId($eventId)
+            ->setDateInterval($dateInterval)
+        ;
+
+        $em = Database::getManager();
+        $em->persist($agendaReminder);
+        $em->flush();
     }
 
     /**
@@ -2697,6 +2739,11 @@ class Agenda
 
             $params['invitees'] = array_keys($invitees);
             $params['collective'] = $isCollective;
+        }
+
+        if (api_get_configuration_value('agenda_reminders') && 'add' === $params['action']) {
+            $form->addHtml('<hr><div id="notification_list"></div>');
+            $form->addButton('add_notification', get_lang('AddNotification'), 'bell-o')->setType('button');
         }
 
         if ($id) {

--- a/main/inc/lib/agenda.lib.php
+++ b/main/inc/lib/agenda.lib.php
@@ -2520,7 +2520,7 @@ class Agenda
         return $remindersRepo->findBy(
             [
                 'eventId' => $eventId,
-                'type' => $type ?: $this->type
+                'type' => $type ?: $this->type,
             ]
         );
     }

--- a/main/inc/lib/agenda.lib.php
+++ b/main/inc/lib/agenda.lib.php
@@ -1670,18 +1670,7 @@ class Agenda
 
                 if ($agendaCollectiveInvitations) {
                     $event['collective'] = (bool) $row['collective'];
-                    $event['invitees'] = [];
-
-                    $invitees = $inviteeRepo->findBy(['invitation' => $row['agenda_event_invitation_id']]);
-
-                    foreach ($invitees as $invitee) {
-                        $inviteeUser = $invitee->getUser();
-
-                        $event['invitees'][] = [
-                            'id' => $inviteeUser->getId(),
-                            'name' => $inviteeUser->getCompleteNameWithUsername(),
-                        ];
-                    }
+                    $event['invitees'] = self::getInviteesForPersonalEvent($row['id']);
                 }
 
                 $my_events[] = $event;
@@ -1713,6 +1702,28 @@ class Agenda
         }
 
         return $my_events;
+    }
+
+    public static function getInviteesForPersonalEvent($eventId): array
+    {
+        $em = Database::getManager();
+        $event = $em->find('ChamiloCoreBundle:PersonalAgenda', $eventId);
+
+        $inviteeRepo = $em->getRepository('ChamiloCoreBundle:AgendaEventInvitee');
+        $invitees = $inviteeRepo->findByInvitation($event->getInvitation());
+
+        $inviteeList = [];
+
+        foreach ($invitees as $invitee) {
+            $inviteeUser = $invitee->getUser();
+
+            $inviteeList[] = [
+                'id' => $inviteeUser->getId(),
+                'name' => $inviteeUser->getCompleteNameWithUsername(),
+            ];
+        }
+
+        return $inviteeList;
     }
 
     /**

--- a/main/install/configuration.dist.php
+++ b/main/install/configuration.dist.php
@@ -452,6 +452,12 @@ CREATE UNIQUE INDEX UNIQ_D8612460AF68C6B ON personal_agenda (agenda_event_invita
 // Then add the "@" symbol to AgendaEventInvitation and AgendaEventInvitee classes in the ORM\Entity() line.
 // Then uncomment the "use EventCollectiveTrait;" line in the PersonalAgenda class.
 //$_configuration['agenda_collective_invitations'] = false;
+// Enable reminders for agenda events. Requires database changes:
+/*
+ CREATE TABLE agenda_reminder (id BIGINT AUTO_INCREMENT NOT NULL, type VARCHAR(255) NOT NULL, event_id INT NOT NULL, date_interval VARCHAR(255) NOT NULL COMMENT '(DC2Type:dateinterval)', sent TINYINT(1) NOT NULL, created_at DATETIME NOT NULL, updated_at DATETIME NOT NULL, PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8 COLLATE `utf8_unicode_ci` ENGINE = InnoDB;
+*/
+// Then add the "@" symbol to AgendaReminder class in the ORM\Entity() line.
+//$_configuration['agenda_reminders'] = false;
 // ------
 //
 // Save some tool titles with HTML editor. Require DB changes:

--- a/main/template/default/agenda/month.tpl
+++ b/main/template/default/agenda/month.tpl
@@ -1,4 +1,5 @@
 {% set agenda_collective_invitations = 'agenda_collective_invitations'|api_get_configuration_value %}
+{% set agenda_reminders = 'agenda_reminders'|api_get_configuration_value %}
 
 <style>
 .fc-day-grid-event > .fc-content {
@@ -571,6 +572,33 @@ $(function() {
                     }
                 {% endif %}
 
+                {% if agenda_reminders %}
+                    $('#notification_list').html('').next('.form-group').hide();
+
+                    $('#notification_list').append("<strong>{{ 'NotifyBeforeTheEventStarts'|get_lang }}</strong><br>");
+
+                    calEvent.reminders.forEach(function (reminder) {
+                        var reminderText = '<span class="fa fa-bell-o" aria-hidden="true"></span> ' + reminder.date_interval[0] + ' ';
+
+                        switch (reminder.date_interval[1]) {
+                            case 'i':
+                                reminderText += "{{ 'Minutes'|get_lang }}";
+                                break;
+                            case 'h':
+                                reminderText += "{{ 'Hours'|get_lang }}";
+                                break;
+                            case 'd':
+                            default:
+                                reminderText += "{{ 'Days'|get_lang }}";
+                                break;
+                        }
+
+                        reminderText += '<br>';
+
+                        $('#notification_list').append(reminderText);
+                    });
+                {% endif %}
+
                 $("#title_edit").show();
                 $("#content_edit").show();
                 {% if agenda_collective_invitations and 'personal' == type %}
@@ -742,6 +770,8 @@ $(function() {
                             $("#form_invitees").val(null).trigger('change');
                             $('#collective').prop('checked', false);
                         {% endif %}
+
+                        $('#notification_list').html('').next('.form-group').show();
 					}
 				});
 			} else {
@@ -781,6 +811,32 @@ $(function() {
                 $("#simple_content").html(calEvent.description);
                 $("#simple_comment").html(calEvent.comment);
                 $("#simple_attachment").html(calEvent.attachment);
+
+                {% if agenda_reminders %}
+                $('#simple_notification_list').html('').append("<strong>{{ 'NotifyBeforeTheEventStarts'|get_lang }}</strong><br>");
+
+                calEvent.reminders.forEach(function (reminder) {
+                    var reminderText = '<span class="fa fa-bell-o" aria-hidden="true"></span> ' + reminder.date_interval[0] + ' ';
+
+                    switch (reminder.date_interval[1]) {
+                        case 'i':
+                            reminderText += "{{ 'Minutes'|get_lang }}";
+                            break;
+                        case 'h':
+                            reminderText += "{{ 'Hours'|get_lang }}";
+                            break;
+                        case 'd':
+                        default:
+                            reminderText += "{{ 'Days'|get_lang }}";
+                            break;
+                    }
+
+                    reminderText += '<br>';
+
+                    $('#simple_notification_list').append(reminderText);
+                });
+                {% endif %}
+
                 {% if agenda_collective_invitations and 'personal' == type %}
                     $('#simple_invitees').html(function () {
                         if (!calEvent.invitees) {
@@ -960,6 +1016,12 @@ $(function() {
                 <div class="form-group">
                     <label class="col-sm-3 control-label">{{ 'Invitees' }}</label>
                     <div class="col-sm-9" id="simple_invitees"></div>
+                </div>
+            {% endif %}
+
+            {% if agenda_reminders %}
+                <div class="form-group">
+                    <div class="col-sm-offset-3 col-sm-9" id="simple_notification_list"></div>
                 </div>
             {% endif %}
         </form>

--- a/main/template/default/agenda/month.tpl
+++ b/main/template/default/agenda/month.tpl
@@ -870,6 +870,39 @@ $(function() {
 			else $('#loading').hide();
 		}
 	});
+
+    {% if 'agenda_reminders'|api_get_configuration_value %}
+        var template = '<div class="form-group">' +
+            '<div class="col-sm-offset-2 col-sm-3">' +
+            '<input min="0" step="1" id="notification_count[]" type="number" class=" form-control" name="notification_count[]">' +
+            '</div>' +
+            '<div class="col-sm-3">' +
+            '<select class="form-control" name="notification_period[]" id="form_notification_period[]">' +
+            '<option value="i">{{ 'Minutes'|get_lang }}</option>' +
+            '<option value="h">{{ 'Hours'|get_lang }}</option>' +
+            '<option value="d">{{ 'Days'|get_lang }}</option>' +
+            '<option value="w">{{ 'Weeks'|get_lang }}</option>' +
+            '</select>' +
+            '</div>' +
+            '<div class="col-sm-2"><p class="form-control-static">{{ 'Before'|get_lang }}</p></div>' +
+            '<div class="text-right col-sm-2">' +
+            '<button class="btn btn-default delete-notification" type="button" aria-label="{{ 'Delete'|get_lang }}"><em class="fa fa-times"></em></button>' +
+            '</div>' +
+            '</div>';
+
+        $('#form_add_notification').on('click', function (e) {
+            e.preventDefault();
+
+            $(template).appendTo('#notification_list');
+            $('#notification_list select').selectpicker('refresh');
+        });
+
+        $('#notification_list').on('click', '.delete-notification', function (e) {
+            e.preventDefault();
+
+            $(this).parents('.form-group').remove();
+        });
+    {% endif %}
 });
 </script>
 {{ actions_div }}

--- a/main/template/default/agenda/month.tpl
+++ b/main/template/default/agenda/month.tpl
@@ -937,7 +937,6 @@ $(function() {
             '<option value="i">{{ 'Minutes'|get_lang }}</option>' +
             '<option value="h">{{ 'Hours'|get_lang }}</option>' +
             '<option value="d">{{ 'Days'|get_lang }}</option>' +
-            '<option value="w">{{ 'Weeks'|get_lang }}</option>' +
             '</select>' +
             '</div>' +
             '<div class="col-sm-2"><p class="form-control-static">{{ 'Before'|get_lang }}</p></div>' +

--- a/src/Chamilo/CoreBundle/Entity/AgendaReminder.php
+++ b/src/Chamilo/CoreBundle/Entity/AgendaReminder.php
@@ -1,0 +1,113 @@
+<?php
+
+/* For licensing terms, see /license.txt */
+
+namespace Chamilo\CoreBundle\Entity;
+
+use Chamilo\CoreBundle\Traits\TimestampableTypedEntity;
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\Table(name="agenda_reminder")
+ * Add @ to the next line when activatiing the agenda_reminders configuration setting
+ * ORM\Entity()
+ */
+class AgendaReminder
+{
+    use TimestampableTypedEntity;
+
+    /**
+     * @var int
+     *
+     * @ORM\Id()
+     * @ORM\Column(type="bigint")
+     * @ORM\GeneratedValue(strategy="AUTO")
+     */
+    protected $id;
+
+    /**
+     * @var string
+     *
+     * @ORM\Column(name="type", type="string")
+     */
+    protected $type;
+
+    /**
+     * @var int
+     *
+     * @ORM\Column(name="event_id", type="integer")
+     */
+    protected $eventId;
+
+    /**
+     * @var \DateInterval
+     *
+     * @ORM\Column(name="date_interval", type="dateinterval")
+     */
+    protected $dateInterval;
+
+    /**
+     * @var bool
+     *
+     * @ORM\Column(name="sent", type="boolean")
+     */
+    protected $sent;
+
+    public function __construct()
+    {
+        $this->sent = false;
+    }
+
+    public function getId(): int
+    {
+        return $this->id;
+    }
+
+    public function getType(): string
+    {
+        return $this->type;
+    }
+
+    public function setType(string $type): AgendaReminder
+    {
+        $this->type = $type;
+
+        return $this;
+    }
+
+    public function getEventId(): int
+    {
+        return $this->eventId;
+    }
+
+    public function setEventId(int $eventId): AgendaReminder
+    {
+        $this->eventId = $eventId;
+
+        return $this;
+    }
+
+    public function getDateInterval(): \DateInterval
+    {
+        return $this->dateInterval;
+    }
+
+    public function setDateInterval(\DateInterval $dateInterval): AgendaReminder
+    {
+        $this->dateInterval = $dateInterval;
+
+        return $this;
+    }
+
+    public function isSent(): bool
+    {
+        return $this->sent;
+    }
+
+    public function setSent(bool $sent): AgendaReminder
+    {
+        $this->sent = $sent;
+
+        return $this;
+    }
+}


### PR DESCRIPTION
Enable reminders for agenda events. Requires database changes:

```sql
CREATE TABLE agenda_reminder (id BIGINT AUTO_INCREMENT NOT NULL, type VARCHAR(255) NOT NULL, event_id INT NOT NULL, date_interval VARCHAR(255) NOT NULL COMMENT '(DC2Type:dateinterval)', sent TINYINT(1) NOT NULL, created_at DATETIME NOT NULL, updated_at DATETIME NOT NULL, PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8 COLLATE `utf8_unicode_ci` ENGINE = InnoDB;
```
Language variable:
$ReminderXEvent = 'Reminder: %s';
$AddNotification = 'Add notification';
$NotifyBeforeTheEventStarts = 'Notify before the event stars';