### PR TITLE
[BUG] USERMANAGER::get_user_id_of_course_admin_or_session_admin does not filter by session id

### DIFF
--- a/main/inc/lib/usermanager.lib.php
+++ b/main/inc/lib/usermanager.lib.php
@@ -5788,6 +5788,7 @@ class UserManager
                     ON sru.user_id=u.id
                     WHERE
                         sru.c_id="'.$courseId.'" AND
+                        sru.session_id="'.$session.'" AND
                         sru.status = '.SessionEntity::COACH;
         }
 


### PR DESCRIPTION
USERMANAGER::get_user_id_of_course_admin_or_session_admin does not filter for the current session so the returned value could be wrong if a course has more than one session