### PR TITLE
Message: Allow set extra fields - refs BT#19287

### DIFF
--- a/app/Resources/public/css/base.css
+++ b/app/Resources/public/css/base.css
@@ -5258,6 +5258,15 @@ i.size-32.icon-new-work {
     width: 300px;
 }
 
+.actions .form-inline  .bootstrap-select.inbox-search-tags .dropdown-toggle .filter-option-inner-inner {
+    margin-right: 15px;
+    overflow: hidden;
+    min-width: 150px;
+    text-overflow: ellipsis;
+    width: 300px;
+}
+
+
 ul.holder {
     list-style: none;
     margin: 0;

--- a/app/Resources/public/css/base.css
+++ b/app/Resources/public/css/base.css
@@ -5958,7 +5958,7 @@ div#chat-remote-video video {
 }
 
 .form-search {
-    padding-bottom: 50px;
+    margin-bottom: 15px;
 }
 
 /* INSTALL CHAMILO */

--- a/main/inc/ajax/message.ajax.php
+++ b/main/inc/ajax/message.ajax.php
@@ -122,6 +122,46 @@ switch ($action) {
         header('Content-type:application/json');
         echo json_encode($return);
         break;
+    case 'add_tags':
+        $idList = $_POST['id'] ?? [];
+        $tagList = $_POST['tags'] ?? [];
+
+        if (false === api_get_configuration_value('enable_message_tags')
+            || api_is_anonymous()
+            || api_get_setting('allow_message_tool') !== 'true'
+            || empty($idList) || empty($tagList)
+        ) {
+            break;
+        }
+
+        $em = Database::getManager();
+        $userId = api_get_user_id();
+
+        $extraFieldValues = new ExtraFieldValue('message');
+
+        foreach ($idList as $messageId) {
+            $messageInfo = MessageManager::get_message_by_id($messageId);
+
+            if ($messageInfo['msg_status'] == MESSAGE_STATUS_OUTBOX
+                && $messageInfo['user_sender_id'] != $userId
+            ) {
+                continue;
+            }
+
+            if (in_array($messageInfo['msg_status'], [MESSAGE_STATUS_UNREAD, MESSAGE_STATUS_NEW])
+                && $messageInfo['user_receiver_id'] != $userId
+            ) {
+                continue;
+            }
+
+            $extraParams = [
+                'item_id' => $messageInfo['id'],
+                'extra_tags' => $tagList,
+            ];
+
+            $extraFieldValues->saveFieldValues($extraParams);
+        }
+        break;
     default:
         echo '';
 }

--- a/main/inc/lib/extra_field.lib.php
+++ b/main/inc/lib/extra_field.lib.php
@@ -167,6 +167,10 @@ class ExtraField extends Model
                 break;
             case 'course_announcement':
                 $this->extraFieldType = EntityExtraField::COURSE_ANNOUNCEMENT;
+                break;
+            case 'message':
+                $this->extraFieldType = EntityExtraField::MESSAGE_TYPE;
+                break;
         }
 
         $this->pageUrl = 'extra_fields.php?type='.$this->type;
@@ -199,6 +203,7 @@ class ExtraField extends Model
             'track_exercise',
             'lp_view',
             'course_announcement',
+            'message',
         ];
 
         if (api_get_configuration_value('allow_scheduled_announcements')) {

--- a/main/inc/lib/extra_field.lib.php
+++ b/main/inc/lib/extra_field.lib.php
@@ -1973,6 +1973,13 @@ class ExtraField extends Model
         return false;
     }
 
+    public function getHandlerEntityByFieldVariable(string $variable)
+    {
+        return Database::getManager()
+            ->getRepository('ChamiloCoreBundle:ExtraField')
+            ->findOneBy(['variable' => $variable, 'extraFieldType' => $this->extraFieldType]);
+    }
+
     /**
      * @param array $params
      *

--- a/main/inc/lib/message.lib.php
+++ b/main/inc/lib/message.lib.php
@@ -473,7 +473,8 @@ class MessageManager
         $smsParameters = [],
         $checkCurrentAudioId = false,
         $forceTitleWhenSendingEmail = false,
-        $status = 0
+        $status = 0,
+        array $extraParams = []
     ) {
         $group_id = (int) $group_id;
         $receiverUserId = (int) $receiverUserId;
@@ -691,6 +692,12 @@ class MessageManager
                     'update_date' => $now,
                 ];
                 $outbox_last_id = Database::insert($table, $params);
+
+                if ($extraParams) {
+                    $extraParams['item_id'] = $outbox_last_id;
+                    $extraFieldValues = new ExtraFieldValue('message');
+                    $extraFieldValues->saveFieldValues($extraParams);
+                }
 
                 // save attachment file for outbox messages
                 if (is_array($attachmentList)) {
@@ -1433,10 +1440,7 @@ class MessageManager
             $receiverUserInfo = api_get_user_info($row['user_receiver_id']);
         }
 
-        $message_content .= '<tr>';
         if ('true' === api_get_setting('allow_social_tool')) {
-            $message_content .= '<div class="row">';
-            $message_content .= '<div class="col-md-12">';
             $message_content .= '<ul class="list-message">';
 
             if (!empty($user_sender_id)) {
@@ -1467,8 +1471,6 @@ class MessageManager
 
             $message_content .= '&nbsp;<li>'.Display::dateToStringAgoAndLongDate($row['send_date']).'</li>';
             $message_content .= '</ul>';
-            $message_content .= '</div>';
-            $message_content .= '</div>';
         } else {
             switch ($type) {
                 case self::MESSAGE_TYPE_INBOX:

--- a/main/install/configuration.dist.php
+++ b/main/install/configuration.dist.php
@@ -1919,6 +1919,12 @@ $_configuration['auth_password_links'] = [
 // For a student: Shows only the list of teachers from my courses in the Chamilo inbox.
 // $_configuration['send_only_messages_to_teachers'] = true;
 
+// Allows add tag to filter messages in inbox. Requires add an tag type extrafield for messages.
+/*
+INSERT INTO extra_field (extra_field_type, field_type, variable, display_text, default_value, field_order, visible_to_self, visible_to_others, changeable, filter, created_at) VALUES (22, 10, 'tags', 'Tags', '', 0, 1,	0, 1, 1, NOW());
+*/
+//$_configuration['enable_message_tags'] = false;
+
 // Survey duplicate: Order survey questions by student name
 // $_configuration['survey_duplicate_order_by_name'] = true;
 

--- a/main/messages/inbox.php
+++ b/main/messages/inbox.php
@@ -62,6 +62,7 @@ if ($allowSocial) {
 // Right content
 $social_right_content = '';
 $keyword = '';
+$searchTags = [];
 if ($allowSocial) {
     $actionsLeft = '<a href="'.api_get_path(WEB_PATH).'main/messages/new_message.php">'.
         Display::return_icon('new-message.png', get_lang('ComposeMessage'), [], 32).'</a>';
@@ -72,12 +73,13 @@ if ($allowSocial) {
     if ($form->validate()) {
         $values = $form->getSubmitValues();
         $keyword = $values['keyword'];
+        $searchTags = $values['tags'] ?? [];
     }
     $actionsRight = $form->returnForm();
-    $social_right_content .= Display::toolbarAction('toolbar', [$actionsLeft, $actionsRight]);
+    $social_right_content .= Display::toolbarAction('toolbar', [$actionsLeft, $actionsRight], [2, 10]);
 }
 
-$social_right_content .= MessageManager::inboxDisplay($keyword);
+$social_right_content .= MessageManager::inboxDisplay($keyword, $searchTags);
 
 $tpl = new Template(null);
 

--- a/main/messages/new_message.php
+++ b/main/messages/new_message.php
@@ -242,6 +242,9 @@ function manageForm($default, $select_from_user_list = null, $sent_to = '', $tpl
         $default['content'] = '<p><br/></p>'.$forwardMessage.'<br />'.Security::filter_terms($message_reply_info['content']);
     }
 
+    $extrafield = new ExtraField('message');
+    $extraHtml = $extrafield->addElements($form);
+
     if (empty($group_id)) {
         $form->addLabel(
             '',
@@ -307,6 +310,16 @@ function manageForm($default, $select_from_user_list = null, $sent_to = '', $tpl
             $forwardId = isset($_POST['forward_id']) ? $_POST['forward_id'] : false;
 
             if (is_array($user_list) && count($user_list) > 0) {
+                $extraParams = [];
+
+                foreach ($form->exportValues() as $key => $value) {
+                    if (!str_contains($key, 'extra_')) {
+                        continue;
+                    }
+
+                    $extraParams[$key] = $value;
+                }
+
                 // All is well, send the message
                 foreach ($user_list as $userId) {
                     $res = MessageManager::send_message(
@@ -323,7 +336,10 @@ function manageForm($default, $select_from_user_list = null, $sent_to = '', $tpl
                         false,
                         $forwardId,
                         [],
-                        true
+                        true,
+                        false,
+                        0,
+                        $extraParams
                     );
 
                     if ($res) {
@@ -349,6 +365,8 @@ function manageForm($default, $select_from_user_list = null, $sent_to = '', $tpl
         $form->setConstants(['sec_token' => $token]);
         $html .= $form->returnForm();
     }
+
+    $html .= '<script>$(function () { '.$extraHtml['jquery_ready_content'].' });</script>';
 
     return $html;
 }

--- a/main/messages/outbox.php
+++ b/main/messages/outbox.php
@@ -55,6 +55,7 @@ if ($allowMessage) {
 
 $keyword = '';
 $social_right_content = '';
+$searchTags = [];
 if ($allowSocial) {
     // Block Social Menu
     $social_menu_block = SocialManager::show_social_menu('messages');
@@ -65,15 +66,17 @@ if ($allowSocial) {
     if ($form->validate()) {
         $values = $form->getSubmitValues();
         $keyword = $values['keyword'];
+        $searchTags = $values['tags'] ?? [];
     }
     $actionsRight = $form->returnForm();
     $social_right_content .= Display::toolbarAction(
         'toolbar',
-        [$actionsLeft, $actionsRight]
+        [$actionsLeft, $actionsRight],
+        [2, 10]
     );
 }
 
-$social_right_content .= MessageManager::outBoxDisplay($keyword);
+$social_right_content .= MessageManager::outBoxDisplay($keyword, $searchTags);
 
 $tpl = new Template(get_lang('Outbox'));
 // Block Social Avatar

--- a/main/template/default/layout/main.js.tpl
+++ b/main/template/default/layout/main.js.tpl
@@ -403,6 +403,31 @@ $(function() {
     }
 
     socialLikes();
+
+    {% if 'enable_message_tags'|api_get_configuration_value %}
+        // Used in MessageManager::addTagsFormToInbox
+        $('#frm_inbox_tags').on('submit', function (e) {
+            e.preventDefault();
+
+            var $submit = $(this).find(':submit');
+            var selectedData = $('#form_message_inbox_id input[name="id[]"]').serialize();
+
+            if (selectedData.length <= 0) {
+                return;
+            }
+
+            selectedData += '&'
+                + $('#extra_tags').select2('data').map(function (obj) {
+                    return encodeURI('tags[]=' + obj.id)
+                }).join('&');
+
+            $submit.prop('disabled', true);
+
+            $.post(_p.web_ajax + 'message.ajax.php?a=add_tags', selectedData, function () {
+                window.location.reload();
+            });
+        });
+    {% endif %}
 });
 
 $(window).resize(function() {

--- a/src/Chamilo/CoreBundle/Entity/ExtraField.php
+++ b/src/Chamilo/CoreBundle/Entity/ExtraField.php
@@ -40,6 +40,7 @@ class ExtraField extends BaseAttribute
     public const PORTFOLIO_TYPE = 19;
     public const LP_VIEW_TYPE = 20;
     public const COURSE_ANNOUNCEMENT = 21;
+    public const MESSAGE_TYPE = 22;
 
     /**
      * @var int

--- a/src/Chamilo/CoreBundle/Entity/Repository/ExtraFieldRelTagRepository.php
+++ b/src/Chamilo/CoreBundle/Entity/Repository/ExtraFieldRelTagRepository.php
@@ -44,4 +44,40 @@ class ExtraFieldRelTagRepository extends EntityRepository
 
         return $queryBuilder->getQuery()->getResult();
     }
+
+    public function getTagsByUserMessages(int $userId)
+    {
+        $qb = $this->createQueryBuilder('eft');
+        $qb
+            ->select('t')
+            ->distinct(true)
+            ->innerJoin('ChamiloCoreBundle:Tag', 't', Join::WITH, 'eft.tagId = t.id AND eft.fieldId = t.fieldId')
+            ->innerJoin('ChamiloCoreBundle:ExtraField', 'ef', Join::WITH, 'eft.fieldId = ef.id')
+            ->innerJoin('ChamiloCoreBundle:Message', 'm', Join::WITH, 'eft.itemId = m.id')
+            ->where($qb->expr()->eq('ef.variable', ':variable'))
+            ->andWhere($qb->expr()->eq('ef.extraFieldType', ':extraFieldType'))
+            ->andWhere(
+                $qb->expr()->orX(
+                    $qb->expr()->andX(
+                        $qb->expr()->eq('m.userReceiverId', ':userId'),
+                        $qb->expr()->in('m.msgStatus', [MESSAGE_STATUS_NEW, MESSAGE_STATUS_UNREAD])
+                    ),
+                    $qb->expr()->andX(
+                        $qb->expr()->eq('m.userSenderId', ':userId'),
+                        $qb->expr()->in('m.msgStatus', [MESSAGE_STATUS_OUTBOX])
+                    )
+                )
+            )
+            ->orderBy('t.tag', 'ASC')
+            ->setParameters(
+                [
+                    'variable' => 'tags',
+                    'extraFieldType' => ExtraField::MESSAGE_TYPE,
+                    'userId' => $userId,
+                ]
+            )
+        ;
+
+        return $qb->getQuery()->getResult();
+    }
 }


### PR DESCRIPTION
Allows add tag to filter messages in inbox. Requires add an tag type extrafield for messages.
```sql
INSERT INTO extra_field (extra_field_type, field_type, variable, display_text, default_value, field_order, visible_to_self, visible_to_others, changeable, filter, created_at) VALUES (22, 10, 'tags', 'Tags', '', 0, 1, 0, 1, 1, NOW());
```
```php
$_configuration['enable_message_tags'] = false;
```