### PR TITLE
Fix the remind course expiration cron

### DIFF
--- a/main/cron/remind_course_expiration.php
+++ b/main/cron/remind_course_expiration.php
@@ -73,7 +73,7 @@ foreach ($sessions as $sessionId => $userIds) {
         INNER JOIN $sessionTable AS session
         ON sessionUser.session_id = session.id
         WHERE
-            session_id = $sessionId$userIds";
+            session_id = $sessionId";
     $result = Database::query($query);
     while ($row = Database::fetch_array($result)) {
         $usersToBeReminded[$row['user_id']][$row['session_id']] = [


### PR DESCRIPTION
The WHERE conditions has a wrong variable. Just change $sessionid$userids to $sessionid