### PR TITLE
Survey: Multiple Choice with free text - Fix for "Add Choice" button - refs #4225

### DIFF
--- a/main/survey/survey_question.php
+++ b/main/survey/survey_question.php
@@ -434,9 +434,6 @@ class survey_question
 
         // Adding an answer
         if (isset($_POST['buttons']) && isset($_POST['buttons']['add_answer'])) {
-            if (isset($_REQUEST['type']) && 'multiplechoiceother' === $_REQUEST['type']) {
-                $counter--;
-            }
             $counter++;
             Session::write('answer_count', $counter);
         }


### PR DESCRIPTION
En la ruta 'main/survey/survey_question.php': Remuevo el código de la línea 437 a la 439 porque hace que el contador se mantenga en un mismo número en el caso de que el tipo sea "multiplechoiceother".