### PR TITLE
Notification: Add types global and specific users

### DIFF
--- a/main/inc/ajax/message.ajax.php
+++ b/main/inc/ajax/message.ajax.php
@@ -29,7 +29,7 @@ switch ($action) {
         break;
     case 'mark_notification_as_read':
         if (api_get_configuration_value('notification_event')) {
-            $id = isset($_REQUEST['id']) ? $_REQUEST['id'] : 0;
+            $id = $_REQUEST['id'] ?? 0;
             $notificationManager = new NotificationEvent();
             $notificationManager->markAsRead($id);
             echo 1;

--- a/main/inc/lib/NotificationEvent.php
+++ b/main/inc/lib/NotificationEvent.php
@@ -30,17 +30,22 @@ class NotificationEvent extends Model
 
     public function eventTypeToString($eventTypeId)
     {
-        $list = $this->getEventsForSelect();
+        $list = $this->getEventsForSelect(false);
 
         return $list[$eventTypeId];
     }
 
-    public function getEventsForSelect()
+    public function getEventsForSelect($onlyEnabled = true): array
     {
-        return [
+        $eventTypes = [
             self::ACCOUNT_EXPIRATION => get_lang('AccountExpiration'),
-            self::JUSTIFICATION_EXPIRATION => get_lang('JustificationExpiration'),
         ];
+
+        if (!$onlyEnabled || api_get_plugin_setting('justification', 'tool_enable') === 'true') {
+            $eventTypes[self::JUSTIFICATION_EXPIRATION] = get_lang('JustificationExpiration');
+        }
+
+        return $eventTypes;
     }
 
     public function getForm(FormValidator $form, $data = [])
@@ -52,9 +57,12 @@ class NotificationEvent extends Model
         $eventType = $data['event_type'];
         switch ($eventType) {
             case self::JUSTIFICATION_EXPIRATION:
-                $plugin = Justification::create();
-                $list = $plugin->getList();
-                $list = array_column($list, 'name', 'id');
+                $list = [];
+                if (api_get_plugin_setting('justification', 'tool_enable') === 'true'
+                    && $list = Justification::create()->getList()
+                ) {
+                    $list = array_column($list, 'name', 'id');
+                }
                 $form->addSelect('event_id', get_lang('JustificationType'), $list);
                 $form->freeze('event_id');
 
@@ -94,9 +102,12 @@ class NotificationEvent extends Model
 
             switch ($eventType) {
                 case self::JUSTIFICATION_EXPIRATION:
-                    $plugin = Justification::create();
-                    $list = $plugin->getList();
-                    $list = array_column($list, 'name', 'id');
+                    $list = [];
+                    if (api_get_plugin_setting('justification', 'tool_enable') === 'true'
+                        && $list = Justification::create()->getList()
+                    ) {
+                        $list = array_column($list, 'name', 'id');
+                    }
                     $form->addSelect('event_id', get_lang('JustificationType'), $list);
                     break;
                 default:

--- a/main/install/configuration.dist.php
+++ b/main/install/configuration.dist.php
@@ -1527,6 +1527,16 @@ id INT unsigned NOT NULL auto_increment PRIMARY KEY,
         event_type VARCHAR(255)
     );
 ALTER TABLE notification_event ADD COLUMN event_id INT NULL;
+CREATE TABLE IF NOT EXISTS notification_event_rel_user (
+    id INT UNSIGNED AUTO_INCREMENT NOT NULL,
+    event_id INT unsigned,
+    user_id INT,
+    INDEX FK_EVENT (event_id),
+    INDEX FK_USER (user_id),
+    PRIMARY KEY (id)
+);
+ALTER TABLE notification_event_rel_user ADD CONSTRAINT FK_EVENT FOREIGN KEY (event_id) REFERENCES notification_event (id) ON DELETE CASCADE;
+ALTER TABLE notification_event_rel_user ADD CONSTRAINT FK_USER FOREIGN KEY (user_id) REFERENCES user (id) ON DELETE CASCADE;
 */
 // create new user text extra field called 'notification_event' to save the persistent settings.
 // $_configuration['notification_event'] = false;

--- a/main/notification_event/add.php
+++ b/main/notification_event/add.php
@@ -18,7 +18,9 @@ $form = $manager->getAddForm($form);
 if (isset($_POST) && isset($_POST['title']) && $form->validate()) {
     $values = $form->getSubmitValues();
     $manager->save($values);
-    Display::addFlash(Display::return_message(get_lang('Saved')));
+    Display::addFlash(
+        Display::return_message(get_lang('Saved'), 'success')
+    );
     $url = api_get_path(WEB_CODE_PATH).'notification_event/list.php?';
     header('Location: '.$url);
     exit;

--- a/main/notification_event/edit.php
+++ b/main/notification_event/edit.php
@@ -27,6 +27,7 @@ $fields = [];
 $form = new FormValidator('edit', 'post', api_get_self().'?id='.$id);
 $form = $manager->getForm($form, $notification);
 
+$notification['users'] = array_keys($notification['users']);
 $form->setDefaults($notification);
 $form->addButtonSave(get_lang('Update'));
 

--- a/main/notification_event/edit.php
+++ b/main/notification_event/edit.php
@@ -35,7 +35,9 @@ if ($form->validate()) {
     $values['id'] = $id;
     $values['persistent'] = isset($values['persistent']) ? 1 : 0;
     $manager->update($values);
-    Display::addFlash(get_lang('Updated'));
+    Display::addFlash(
+        Display::return_message(get_lang('Updated'), 'success')
+    );
     $url = api_get_path(WEB_CODE_PATH).'notification_event/list.php?';
     header('Location: '.$url);
     exit;

--- a/main/notification_event/list.php
+++ b/main/notification_event/list.php
@@ -21,17 +21,17 @@ $tpl->assign('list', $list);
 $content = $tpl->fetch($tpl->get_template('notification_event/list.tpl'));
 
 $actionLinks = '';
-$action = isset($_REQUEST['a']) ? $_REQUEST['a'] : '';
+$action = $_REQUEST['a'] ?? '';
 $id = isset($_REQUEST['id']) ? (int) $_REQUEST['id'] : 0;
 
-switch ($action) {
-    case 'delete':
-        $manager->delete($id);
+if ($action == 'delete') {
+    $manager->delete($id);
 
-        Display::addFlash(Display::return_message(get_lang('Deleted')));
-        header('Location: '.api_get_self());
-        exit;
-        break;
+    Display::addFlash(
+        Display::return_message(get_lang('Deleted'), 'success')
+    );
+    header('Location: '.api_get_self());
+    exit;
 }
 
 $actionLinks .= Display::toolbarButton(

--- a/main/template/default/layout/notification.tpl
+++ b/main/template/default/layout/notification.tpl
@@ -116,6 +116,10 @@
                                 template = template.replace("{close_link}", closeLink);
                             }
                             $('#notificationsContainer').append(template);
+
+                            if (!notifications[i].event_text) {
+                                $('#notificationsContainer li[id="' + notifications[i].id + '"] .notification-event-text').remove();
+                            }
                         }
                     }
 


### PR DESCRIPTION
Refs BT#19838

Extends `$_configuration['notification_event']`

It requires DB changes

```sql
CREATE TABLE IF NOT EXISTS notification_event_rel_user (
    id INT UNSIGNED AUTO_INCREMENT NOT NULL,
    event_id INT unsigned,
    user_id INT,
    INDEX FK_EVENT (event_id),
    INDEX FK_USER (user_id),
    PRIMARY KEY (id)
);
ALTER TABLE notification_event_rel_user ADD CONSTRAINT FK_EVENT FOREIGN KEY (event_id) REFERENCES notification_event (id) ON DELETE CASCADE;
ALTER TABLE notification_event_rel_user ADD CONSTRAINT FK_USER FOREIGN KEY (user_id) REFERENCES user (id) ON DELETE CASCADE;
```