### PR TITLE
[BUG] Tracking fails for SCORM LPs on IExplorer

### DIFF
--- a/main/lp/scorm_api.php
+++ b/main/lp/scorm_api.php
@@ -874,7 +874,11 @@ function SetValue(param, val) {
 /**
  * Saves the current data from JS memory to the LMS database
  */
-function savedata(item_id, forceIframeSave = 0) {
+function savedata(item_id, forceIframeSave) {
+    if (!forceIframeSave) {
+        forceIframeSave = 0;
+    }
+
     // Origin can be 'commit', 'finish' or 'terminate' (depending on the calling function)
     logit_lms('function savedata(' + item_id + ')', 3);
 

--- a/main/lp/scorm_api.php
+++ b/main/lp/scorm_api.php
@@ -874,22 +874,13 @@ function SetValue(param, val) {
 /**
  * Saves the current data from JS memory to the LMS database
  */
-function savedata(item_id, forceIframeSave) {
-    if (!forceIframeSave) {
-        forceIframeSave = 0;
-    }
+function savedata(item_id) {
+    var forceIframeSave = arguments.length > 1 && arguments[1] !== undefined
+    ? arguments[1]
+    : 0;
 
     // Origin can be 'commit', 'finish' or 'terminate' (depending on the calling function)
     logit_lms('function savedata(' + item_id + ')', 3);
-
-    // Status is NOT modified here see the lp_ajax_save_item.php file
-    if (olms.lesson_status != '') {
-        //olms.updatable_vars_list['cmi.core.lesson_status'] = true;
-    }
-
-    if (typeof(forceIframeSave) == 'undefined') {
-        forceIframeSave = 0;
-    }
 
     old_item_id = olms.info_lms_item[0];
     var item_to_save = olms.lms_item_id;


### PR DESCRIPTION
Tracking for SCORM LPs is not working on IExplorer because the EMACScript version that supports IE has no support for default parameters, so when the [method savedata(item_id, forceIframeSave) from main/lp/scorm_api.php](https://github.com/chamilo/chamilo-lms/blob/1.11.x/main/lp/scorm_api.php#L877) is invoked the forceIframeSave = 0 is interpreted by the IE engine as a wrong syntax.

![imagen](https://user-images.githubusercontent.com/48205899/163206855-b3010bf0-8936-4b61-8593-ae09facf94cf.png)

We could fix it checking inside the method if the forceIframeSave has a value. If it has no value we could set it as zero.

![imagen](https://user-images.githubusercontent.com/48205899/163207188-74498195-47d7-4d4b-95f4-305468816c43.png)

![imagen](https://user-images.githubusercontent.com/48205899/163208006-2bdac467-3272-4532-b62a-523fd5e4dc96.png)

