### PR TITLE
Wrong flag - Vietnam (Solved) - refs #4231

### DIFF
--- a/main/inc/lib/api.lib.php
+++ b/main/inc/lib/api.lib.php
@@ -5053,6 +5053,9 @@ function languageCodeToCountryIsoCodeForFlags($languageIsoCode)
         case 'uk': // Ukraine
             $country = 'ua';
             break;
+        case 'vi': // Vietnam - GH#4231
+            $country = 'vn';
+            break;
         case 'zh-TW':
         case 'zh':
             $country = 'cn';


### PR DESCRIPTION
ISO code problem:
vi = Virgin Islands