### PR TITLE
[BUG] Usuarios pueden acceder a listado de LPs ocultos y completarlo

### DIFF
--- a/main/inc/ajax/course_home.ajax.php
+++ b/main/inc/ajax/course_home.ajax.php
@@ -354,6 +354,12 @@ switch ($action) {
             $item['title'] = Display::url($item['title'], $course_url, ['target' => SESSION_LINK_TARGET]);
 
             foreach ($flat_list as $lp_id => $lp_item) {
+                if (api_is_anonymous() || api_is_student()) {
+                    if ($lp_item['lp_visibility'] == 0) {
+                        continue;
+                    }
+                }
+
                 $temp[$count]['id'] = $lp_id;
 
                 $lp = new learnpath($item['code'], $lp_id, api_get_user_id());
@@ -639,6 +645,12 @@ switch ($action) {
                 ['target' => SESSION_LINK_TARGET]
             );
             foreach ($flat_list as $lp_id => $lp_item) {
+                if (api_is_anonymous() || api_is_student()) {
+                    if ($lp_item['lp_visibility'] == 0) {
+                        continue;
+                    }
+                }
+
                 $temp[$count]['id'] = $lp_id;
                 $lp_url = api_get_path(WEB_CODE_PATH).'lp/lp_controller.php?cidReq='.$item['code'].'&id_session='.$session_id.'&lp_id='.$lp_id.'&action=view';
                 $last_date = Tracking::get_last_connection_date_on_the_course(

--- a/main/inc/ajax/course_home.ajax.php
+++ b/main/inc/ajax/course_home.ajax.php
@@ -354,10 +354,10 @@ switch ($action) {
             $item['title'] = Display::url($item['title'], $course_url, ['target' => SESSION_LINK_TARGET]);
 
             foreach ($flat_list as $lp_id => $lp_item) {
-                if (api_is_anonymous() || api_is_student()) {
-                    if ($lp_item['lp_visibility'] == 0) {
-                        continue;
-                    }
+                $isAllowedToEdit = api_is_allowed_to_edit(null, true);
+
+                if (!$isAllowedToEdit && 0 == $lp_item['lp_visibility']) {
+                    continue;
                 }
 
                 $temp[$count]['id'] = $lp_id;
@@ -645,10 +645,10 @@ switch ($action) {
                 ['target' => SESSION_LINK_TARGET]
             );
             foreach ($flat_list as $lp_id => $lp_item) {
-                if (api_is_anonymous() || api_is_student()) {
-                    if ($lp_item['lp_visibility'] == 0) {
-                        continue;
-                    }
+                $isAllowedToEdit = api_is_allowed_to_edit(null, true);
+
+                if (!$isAllowedToEdit && 0 == $lp_item['lp_visibility']) {
+                    continue;
                 }
 
                 $temp[$count]['id'] = $lp_id;


### PR DESCRIPTION
Actualmente un alumno de una sesión puede acceder a lecciones que están ocultas en los cursos si entra desde la pestaña de "Mis cursos" y pincha sobre el nombre de la sesión, video más explicativo de la problematica:

https://loom.com/share/b39ab824ea9f4ec388372aa170c64c56

Las modificaciones de este PR mantiene el comportamiento para usuarios que no sean anonimos ni estudiantes, para estes dos casos no mostraría la lección oculta.