### PR TITLE
chore: Set permissions for GitHub actions

### DIFF
--- a/.github/workflows/format_code.yml
+++ b/.github/workflows/format_code.yml
@@ -2,6 +2,9 @@ name: PHP format code 🔎
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
     build:
         name: PHP ${{ matrix.php-versions }} Test on ${{ matrix.operating-system }}

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -2,6 +2,9 @@ name: PHPUnit 🐛
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
     build:
         name: PHP ${{ matrix.php-versions }} Test on ${{ matrix.operating-system }}


### PR DESCRIPTION
 Restrict the GitHub token permissions only to the required ones; this way, even if the attackers will succeed in compromising your workflow, they won’t be able to do much.

- Included permissions for the action. https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions

https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs

[Keeping your GitHub Actions and workflows secure Part 1: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)

Signed-off-by: neilnaveen <42328488+neilnaveen@users.noreply.github.com>
