### PR TITLE
CERTIFICATE - Add new tag

### DIFF
--- a/main/inc/lib/document.lib.php
+++ b/main/inc/lib/document.lib.php
@@ -2057,20 +2057,24 @@ class DocumentManager
         $info_grade_certificate = UserManager::get_info_gradebook_certificate($courseCode, $sessionId, $user_id);
         $date_long_certificate = '';
         $date_certificate = '';
+        $date_short_no_time = '';
         $url = '';
         if ($info_grade_certificate) {
             $date_certificate = $info_grade_certificate['created_at'];
             $url = api_get_path(WEB_PATH).'certificates/index.php?id='.$info_grade_certificate['id'];
         }
         $date_no_time = api_convert_and_format_date(api_get_utc_datetime(), DATE_FORMAT_LONG_NO_DAY);
+        $date_short_no_time = api_convert_and_format_date(api_get_utc_datetime(), DATE_FORMAT_NUMBER);
         if (!empty($date_certificate)) {
             $date_long_certificate = api_convert_and_format_date($date_certificate);
             $date_no_time = api_convert_and_format_date($date_certificate, DATE_FORMAT_LONG_NO_DAY);
+            $date_short_no_time = api_convert_and_format_date($date_certificate, DATE_FORMAT_NUMBER);
         }
 
         if ($is_preview) {
             $date_long_certificate = api_convert_and_format_date(api_get_utc_datetime());
             $date_no_time = api_convert_and_format_date(api_get_utc_datetime(), DATE_FORMAT_LONG_NO_DAY);
+            $date_short_no_time = api_convert_and_format_date(api_get_utc_datetime(), DATE_FORMAT_NUMBER);
         }
 
         $externalStyleFile = api_get_path(SYS_CSS_PATH).'themes/'.api_get_visual_theme().'/certificate.css';
@@ -2126,6 +2130,7 @@ class DocumentManager
             $official_code,
             $date_long_certificate,
             $date_no_time,
+            $date_short_no_time,
             $courseCode,
             $course_info['name'],
             isset($info_grade_certificate['grade']) ? $info_grade_certificate['grade'] : '',
@@ -2151,6 +2156,7 @@ class DocumentManager
             '((official_code))',
             '((date_certificate))',
             '((date_certificate_no_time))',
+            '((date_simple_certificate))',
             '((course_code))',
             '((course_title))',
             '((gradebook_grade))',

--- a/plugin/customcertificate/src/index.php
+++ b/plugin/customcertificate/src/index.php
@@ -286,6 +286,7 @@ $strInfo .= '((teacher_lastname))<br />';
 $strInfo .= '((official_code))<br />';
 $strInfo .= '((date_certificate))<br />';
 $strInfo .= '((date_certificate_no_time))<br />';
+$strInfo .= '((date_simple_certificate))<br />';
 $strInfo .= '((course_code))<br />';
 $strInfo .= '((course_title))<br />';
 $strInfo .= '((gradebook_grade))<br />';


### PR DESCRIPTION
This pull adds a new certificate tag (date_simple_certificate) that transform the certificate date as a short date format

There are two file modifications:

The first one is main/inc/lib/document.lib.php where the logic was added

The second one is on plugin/customcertificate/src/index.php to add the tag name to the list of available tags