### PR TITLE
Anuncios (announcements) - Al pulsar volver al listado atrás se deshabilitan las opciones en algunos anuncios

### DIFF
--- a/main/inc/lib/AnnouncementManager.php
+++ b/main/inc/lib/AnnouncementManager.php
@@ -1913,7 +1913,7 @@ class AnnouncementManager
         while ($row = Database::fetch_array($result, 'ASSOC')) {
             if (!in_array($row['id'], $displayed)) {
                 $actionUrl = api_get_path(WEB_CODE_PATH).'announcements/announcements.php?'
-                    .api_get_cidreq_params($courseInfo['code'], $session_id, $row['to_group_id']);
+                    .api_get_cidreq_params($courseInfo['code'], $session_id);
                 $sent_to_icon = '';
                 // the email icon
                 if ($row['email_sent'] == '1') {

--- a/main/inc/lib/AnnouncementManager.php
+++ b/main/inc/lib/AnnouncementManager.php
@@ -1913,7 +1913,7 @@ class AnnouncementManager
         while ($row = Database::fetch_array($result, 'ASSOC')) {
             if (!in_array($row['id'], $displayed)) {
                 $actionUrl = api_get_path(WEB_CODE_PATH).'announcements/announcements.php?'
-                    .api_get_cidreq_params($courseInfo['code'], $session_id);
+                    .api_get_cidreq_params($courseInfo['code'], $session_id, $group_id);
                 $sent_to_icon = '';
                 // the email icon
                 if ($row['email_sent'] == '1') {


### PR DESCRIPTION
En algunos casos desde el listado de anuncios, al acceder a uno de ellos y volver atrás con el icono de volver al listado, este se vuelve a cargar pero desactivando los iconos de acciones de cada anuncio

![imagen](https://user-images.githubusercontent.com/48205899/200653732-129ef2d8-dddf-4058-930c-0a9e3c1c1865.png)

![imagen](https://user-images.githubusercontent.com/48205899/200656611-d7ad154f-a86e-400c-8459-85e09dddc0c0.png)

Concretando más se da en cursos donde tenemos algún grupo de usuarios creado, por lo que si vamos a la herramienta de anuncios ...

main/announcements/announcements.php?cidReq={course_code}&id_session={session_code}&gradebook=0&origin=&gidReq=0

Obtendremos un listado con todos los anuncios, con las acciones habilitadas en cada uno de los anuncios ...

Pero si entramos en el detalle de un de los anuncio que fue creado para un grupo en concreto y volvemos al listado pulsando el icono de acción de volver al listado, veremos como en el listado aparece con alguno de los anuncios con las opciones deshabilitadas.

La causa está en que en el enlace del icono de volver al listado que aparece en el detalle de un anuncio agrega el parámetro "gidReq" de código de grupo al que pertenece el propio anuncio, por lo que, al volver atrás, se evaluará ese parámetro y deshabilitará las acciones en los anuncios que no pertenecen al código de grupo del parámetro.

https://github.com/chamilo/chamilo-lms/blob/1.11.x/main/inc/lib/AnnouncementManager.php#L1915-L1916

Interpreto que no hace falta que el enlace de volver atrás al listado necesite ese parámetro, por lo que este pull request lo quita.
