### PR TITLE
Plugin test2pdf - Invisible icon by default on courses

### DIFF
--- a/plugin/test2pdf/src/test2pdf_plugin.class.php
+++ b/plugin/test2pdf/src/test2pdf_plugin.class.php
@@ -65,6 +65,16 @@ class Test2pdfPlugin extends Plugin
     }
 
     /**
+     * By default new icon is invisible.
+     *
+     * @return bool
+     */
+    public function isIconVisibleByDefault()
+    {
+        return false;
+    }
+
+    /**
      * This method drops the plugin tables.
      */
     public function uninstall()


### PR DESCRIPTION
On install by default the test2pdf plugin doesn´t make the tool icon on the course invisible.

if the tool is visible, a studen could use the tool to download the answers of a test.

This PR add the function isIconVisibleByDefault to the [Test2pdfPlugin class](https://github.com/contidos-dixitais/chamilo-lms/blob/75d5c268d3ab6ca16c020ee26cf179db6daf4926/plugin/test2pdf/src/test2pdf_plugin.class.php#L67-L75) that returns a false bool value, so on the install process the icon is invisible by default