### PR TITLE
BUG - MULTICAMPUS: User can access a session that is assigned to another campus in which the user is not registered

### DIFF
--- a/main/inc/lib/sessionmanager.lib.php
+++ b/main/inc/lib/sessionmanager.lib.php
@@ -10065,4 +10065,21 @@ class SessionManager
             return -1;
         }
     }
+
+    /**
+     * @param array $listA
+     * @param array $listB
+     *
+     * @return int
+     */
+    private static function compareByCourse($listA, $listB)
+    {
+        if ($listA['title'] == $listB['title']) {
+            return 0;
+        } elseif ($listA['title'] > $listB['title']) {
+            return 1;
+        } else {
+            return -1;
+        }
+    }
 }

--- a/main/inc/lib/sessionmanager.lib.php
+++ b/main/inc/lib/sessionmanager.lib.php
@@ -10065,21 +10065,4 @@ class SessionManager
             return -1;
         }
     }
-
-    /**
-     * @param array $listA
-     * @param array $listB
-     *
-     * @return int
-     */
-    private static function compareByCourse($listA, $listB)
-    {
-        if ($listA['title'] == $listB['title']) {
-            return 0;
-        } elseif ($listA['title'] > $listB['title']) {
-            return 1;
-        } else {
-            return -1;
-        }
-    }
 }

--- a/main/inc/lib/sessionmanager.lib.php
+++ b/main/inc/lib/sessionmanager.lib.php
@@ -9922,8 +9922,8 @@ class SessionManager
     /**
      * Check if a session is assigned on access url.
      *
-     * @param string $sessionId
-     * @param int    $urlId
+     * @param int $sessionId
+     * @param int $urlId
      *
      * @return bool
      */

--- a/main/inc/lib/sessionmanager.lib.php
+++ b/main/inc/lib/sessionmanager.lib.php
@@ -9920,6 +9920,32 @@ class SessionManager
     }
 
     /**
+     * Check if a session is assigned on access url.
+     *
+     * @param string $sessionId
+     * @param int    $urlId
+     *
+     * @return bool
+     */
+    public static function sessionIsAssignedToUrl(int $sessionId, int $urlId = 0)
+    {
+        $urlId = empty($urlId) ? api_get_current_access_url_id() : (int) $urlId;
+
+        $session_table = Database::get_main_table(TABLE_MAIN_SESSION);
+        $table_access_url_rel_session = Database::get_main_table(TABLE_MAIN_ACCESS_URL_REL_SESSION);
+
+        $sql = " SELECT
+                COUNT(*) as count
+            FROM $session_table s
+            INNER JOIN $table_access_url_rel_session ar ON ar.session_id = s.id
+            WHERE s.id = $sessionId AND ar.access_url_id = $urlId ";
+
+        $result = Database::fetch_array(Database::query($sql));
+
+        return $result['count'] > 0;
+    }
+
+    /**
      * @param int $id
      *
      * @return bool

--- a/main/inc/lib/sessionmanager.lib.php
+++ b/main/inc/lib/sessionmanager.lib.php
@@ -9922,8 +9922,8 @@ class SessionManager
     /**
      * Check if a session is assigned on access url.
      *
-     * @param int $sessionId
-     * @param int $urlId
+     * @param int $sessionId The session ID.
+     * @param int $urlId     The access url ID.
      *
      * @return bool
      */

--- a/main/inc/lib/sessionmanager.lib.php
+++ b/main/inc/lib/sessionmanager.lib.php
@@ -9920,32 +9920,6 @@ class SessionManager
     }
 
     /**
-     * Check if a session is assigned on access url.
-     *
-     * @param int $sessionId The session ID.
-     * @param int $urlId     The access url ID.
-     *
-     * @return bool
-     */
-    public static function sessionIsAssignedToUrl(int $sessionId, int $urlId = 0)
-    {
-        $urlId = empty($urlId) ? api_get_current_access_url_id() : (int) $urlId;
-
-        $session_table = Database::get_main_table(TABLE_MAIN_SESSION);
-        $table_access_url_rel_session = Database::get_main_table(TABLE_MAIN_ACCESS_URL_REL_SESSION);
-
-        $sql = " SELECT
-                COUNT(*) as count
-            FROM $session_table s
-            INNER JOIN $table_access_url_rel_session ar ON ar.session_id = s.id
-            WHERE s.id = $sessionId AND ar.access_url_id = $urlId ";
-
-        $result = Database::fetch_array(Database::query($sql));
-
-        return $result['count'] > 0;
-    }
-
-    /**
      * @param int $id
      *
      * @return bool

--- a/main/session/about.php
+++ b/main/session/about.php
@@ -32,7 +32,7 @@ if (!$session) {
 
 if (api_is_multiple_url_enabled()) {
     $accessUrlId = api_get_current_access_url_id();
-    $sessionOnUrl = UrlManager::relation_url_session_exist($sessionId, $accessUrlId);
+    $sessionOnUrl = SessionManager::sessionIsAssignedToUrl($sessionId, $accessUrlId);
 
     if (!$sessionOnUrl) {
         api_not_allowed(true);

--- a/main/session/about.php
+++ b/main/session/about.php
@@ -29,6 +29,16 @@ $session = api_get_session_entity($sessionId);
 if (!$session) {
     api_not_allowed(true);
 }
+
+if (api_is_multiple_url_enabled()) {
+    $accessUrlId = api_get_current_access_url_id();
+    $sessionOnUrl = SessionManager::sessionIsAssignedToUrl($sessionId, $accessUrlId);
+
+    if(!$sessionOnUrl) {
+        api_not_allowed(true);
+    }
+}
+
 $htmlHeadXtra[] = api_get_asset('readmore-js/readmore.js');
 $courses = [];
 $sessionCourses = $em->getRepository('ChamiloCoreBundle:Session')->getCoursesOrderedByPosition($session);

--- a/main/session/about.php
+++ b/main/session/about.php
@@ -34,7 +34,7 @@ if (api_is_multiple_url_enabled()) {
     $accessUrlId = api_get_current_access_url_id();
     $sessionOnUrl = SessionManager::sessionIsAssignedToUrl($sessionId, $accessUrlId);
 
-    if(!$sessionOnUrl) {
+    if (!$sessionOnUrl) {
         api_not_allowed(true);
     }
 }

--- a/main/session/about.php
+++ b/main/session/about.php
@@ -32,7 +32,7 @@ if (!$session) {
 
 if (api_is_multiple_url_enabled()) {
     $accessUrlId = api_get_current_access_url_id();
-    $sessionOnUrl = SessionManager::sessionIsAssignedToUrl($sessionId, $accessUrlId);
+    $sessionOnUrl = UrlManager::relation_url_session_exist($sessionId, $accessUrlId);
 
     if (!$sessionOnUrl) {
         api_not_allowed(true);


### PR DESCRIPTION
Enviroment: Multicampus configuration
Steps:

1. Go to a chamilo multicampus site, for example site.com
2. Go to the campus catalog: site.com/main/auth/courses.php
3. Select one of the sessions and go to to its "about" page, for example: site.com/session/{session_id}/about/
4. Change the session id of the url for one of an existing session assigned to another campus
5. User can see the info of the session of the other campus an enroll in it

This PR adds a new function to SessionManager to allow check if a session is assigned to a access url

This new function is used on main/session/about.php to check if the session is assigned to the current access url
