### PR TITLE
BUG - Setting a default view for the admin session list on one site of a multi campus environment could break the list on the other sites

### DIFF
--- a/main/inc/lib/api.lib.php
+++ b/main/inc/lib/api.lib.php
@@ -9066,6 +9066,9 @@ function api_get_configuration_value($variable)
                 // Try to found element with id = 1 (master portal)
                 if (array_key_exists(1, $_configuration[$variable])) {
                     return $_configuration[$variable][1];
+                } else {
+                    // The value was there for other URLs but not the main URL nor the current URL
+                    return null;
                 }
             }
         }

--- a/main/inc/lib/sessionmanager.lib.php
+++ b/main/inc/lib/sessionmanager.lib.php
@@ -9570,7 +9570,7 @@ class SessionManager
         $default = 'all';
         $view = api_get_configuration_value('default_session_list_view');
 
-        if (!empty($view)) {
+        if (!empty($view) && ( $view == 'all' || $view == 'close' || $view == 'active' || $view == 'custom' )) {
             $default = $view;
         }
 

--- a/main/inc/lib/sessionmanager.lib.php
+++ b/main/inc/lib/sessionmanager.lib.php
@@ -9570,7 +9570,7 @@ class SessionManager
         $default = 'all';
         $view = api_get_configuration_value('default_session_list_view');
 
-        if (!empty($view) && ($view == 'all' || $view == 'close' || $view == 'active' || $view == 'custom')) {
+        if (!empty($view)) {
             $default = $view;
         }
 

--- a/main/inc/lib/sessionmanager.lib.php
+++ b/main/inc/lib/sessionmanager.lib.php
@@ -9570,7 +9570,7 @@ class SessionManager
         $default = 'all';
         $view = api_get_configuration_value('default_session_list_view');
 
-        if (!empty($view) && ( $view == 'all' || $view == 'close' || $view == 'active' || $view == 'custom' )) {
+        if (!empty($view) && ($view == 'all' || $view == 'close' || $view == 'active' || $view == 'custom')) {
             $default = $view;
         }
 


### PR DESCRIPTION
Chamilo has a configuration setting to set the default view for the admin session list, there are four possible values: https://github.com/chamilo/chamilo-lms/blob/1.11.x/main/install/configuration.dist.php

```
// Set the default tab in the admin session list. Values: all, close, active, custom.
//$_configuration['default_session_list_view'] = 'all';
```

At a multicampus enviroment, if we set it for a campus, for example:

`$_configuration['default_session_list_view'][2] = 'active';`

... works on that site, but this config  breaks the list on the others sites because [SesionManager.getDefaultSessionTab()](https://github.com/chamilo/chamilo-lms/blob/1.11.x/main/inc/lib/sessionmanager.lib.php#L9568-L9578) checks only if api_get_configuration_value('default_session_list_view') is empty:

```
    public static function getDefaultSessionTab()
    {
        $default = 'all';
        $view = api_get_configuration_value('default_session_list_view');

        if (!empty($view) ) {
            $default = $view;
        }

        return $default;
    }
```

![imagen](https://user-images.githubusercontent.com/48205899/210331624-1375b3de-7fca-4855-9332-89e7d70e2467.png)

This PR fixes it checking on SesionManager.getDefaultSessionTab() if the view name is one of the four possible values


```
    public static function getDefaultSessionTab()
    {
        $default = 'all';
        $view = api_get_configuration_value('default_session_list_view');

        if (!empty($view) && ( $view == 'all' || $view == 'close' || $view == 'active' || $view == 'custom' )) {
            $default = $view;
        }

        return $default;
    }
```