### PR TITLE
Fix imagegif() call, function has no third parameter

### DIFF
--- a/main/inc/lib/image.lib.php
+++ b/main/inc/lib/image.lib.php
@@ -575,7 +575,7 @@ class GDWrapper extends ImageWrapper
                     @imagetruecolortopalette($this->bg, true, $compress);
                 }
 
-                return imagegif($this->bg, $file, $compress);
+                return imagegif($this->bg, $file);
                 break;
             default:
                 return 0;


### PR DESCRIPTION
The imagegif() function has no third parameter, the $compress parameter can't be used.
The function is used in GDWrapper::send_image()