### PR TITLE
Attachment upload fails in Calendar::editEvent()

### DIFF
--- a/main/inc/lib/agenda.lib.php
+++ b/main/inc/lib/agenda.lib.php
@@ -1149,17 +1149,22 @@ class Agenda
                 if (isset($attachmentArray) && !empty($attachmentArray)) {
                     $counter = 0;
                     foreach ($attachmentArray as $attachmentItem) {
-                        if (empty($attachmentItems['id'])) {
-                            continue;
+                        if (empty($attachmentItem['id'])) {
+                            $this->addAttachment(
+                                $id,
+                                $attachmentItem,
+                                $attachmentCommentList[$counter],
+                                $this->course
+                            );
+                        } else {
+                            $this->updateAttachment(
+                                $attachmentItem['id'],
+                                $id,
+                                $attachmentItem,
+                                $attachmentCommentList[$counter],
+                                $this->course
+                            );
                         }
-
-                        $this->updateAttachment(
-                            $attachmentItem['id'],
-                            $id,
-                            $attachmentItem,
-                            $attachmentCommentList[$counter],
-                            $this->course
-                        );
                         $counter++;
                     }
                 }


### PR DESCRIPTION
Uploading attachments to calendar events is not possible, file processing is skipped. 
Also, new attachments need to be added instead of being updated.