### PR TITLE
fix mystudents report lp time

### DIFF
--- a/main/mySpace/myStudents.php
+++ b/main/mySpace/myStudents.php
@@ -1774,6 +1774,8 @@ if (empty($details)) {
                                     $formattedWorkTime
                                 );
                             }
+                        } else {
+                            $formattedLpTime = api_time_to_hms($totalLpTime);
                         }
                     }
                 } else {


### PR DESCRIPTION
If lp_minimum_time is set to true on configuration.php and the minimum time on the lp config is set to 0 (zero), time spent on the lp is not show on /main/mySpace/myStudents.php report

![image](https://github.com/chamilo/chamilo-lms/assets/93096561/ba3aa4cf-5ac2-4822-b62f-7e5715e4987c)

This little PR fix it, now if the minimum time set for the lp is zero it would show the correct time spent on the lp

![image](https://github.com/chamilo/chamilo-lms/assets/93096561/0f44d643-d7e6-427a-9aa6-c08514890319)
