### PR TITLE
Plugin BuyCourses: Fix problemas con importes mayor o igual a 1000

### DIFF
--- a/plugin/buycourses/src/buy_course_plugin.class.php
+++ b/plugin/buycourses/src/buy_course_plugin.class.php
@@ -3107,7 +3107,7 @@ class BuyCoursesPlugin extends Plugin
         $priceWithoutTax = $product['price'];
         $product['total_price'] = $product['price'];
         $product['tax_amount'] = 0;
-        $precision = 2;
+
         if ($this->checkTaxEnabledInProduct($productType)) {
             if (is_null($product['tax_perc'])) {
                 $globalParameters = $this->getGlobalParameters();
@@ -3118,7 +3118,7 @@ class BuyCoursesPlugin extends Plugin
             }
             //$taxPerc = is_null($product['tax_perc']) ? $globalTaxPerc : $product['tax_perc'];
 
-            $taxAmount = round($priceWithoutTax * $taxPerc / 100, $precision);
+            $taxAmount = round($priceWithoutTax * $taxPerc / 100, 2);
             $product['tax_amount'] = $taxAmount;
             $priceWithTax = $priceWithoutTax + $taxAmount;
             $product['total_price'] = $priceWithTax;
@@ -3126,25 +3126,25 @@ class BuyCoursesPlugin extends Plugin
 
         $product['tax_perc_show'] = $taxPerc;
         $product['price_formatted'] = $this->getPriceWithCurrencyFromIsoCode(
-            number_format($product['price'], $precision),
+            $product['price'],
             $product['iso_code']
         );
 
-        $product['tax_amount_formatted'] = number_format($product['tax_amount'], $precision);
+        $product['tax_amount_formatted'] = number_format($product['tax_amount'], 2);
 
         $product['total_price_formatted'] = $this->getPriceWithCurrencyFromIsoCode(
-            number_format($product['total_price'], $precision),
+            $product['total_price'],
             $product['iso_code']
         );
 
         if ($coupon != null) {
             $product['discount_amount_formatted'] = $this->getPriceWithCurrencyFromIsoCode(
-                number_format($product['discount_amount'], $precision),
+                $product['discount_amount'],
                 $product['iso_code']
             );
 
             $product['price_without_discount_formatted'] = $this->getPriceWithCurrencyFromIsoCode(
-                number_format($product['price_without_discount'], $precision),
+                $product['price_without_discount'],
                 $product['iso_code']
             );
         }


### PR DESCRIPTION
Corrección al problema reportado en el plugin de Venta de cursos con importes mayor o igual a 1000: #4673 

[number_format ](https://www.php.net/manual/en/function.number-format.php) transforma el número a un string con los millares agrupados, en diferentes partes del código del plugin se pasa el valor formateado por **number_format** a una función que realmente espera un valor de tipo float (getPriceWithCurrencyFromIsoCode(float $price, string $isoCode)) lo que provoca el fallo.

Se opta por eliminar **number_format** en las partes del código del plugin donde da problemas porque, por una parte, hay otros valores numéricos de importes donde no se estaba utilizando en el mismo código del plugin y por otra parte, por defecto transforma los valores a un string con una coma como separador de miles  y un punto como separador de decimales, no encontrando  en Chamilo una forma de indicarle de manera estándar que según la localización utilice como separadores de miles y decimales uno u otro símbolo; revisando el código de Chamilo por casos similares se observa como se hardcodea el uso de comas como separador de decimales mientras que en otros casos ni se indica.