### PR TITLE
Fix styles for BaseMenu

### DIFF
--- a/assets/vue/components/basecomponents/BaseMenu.vue
+++ b/assets/vue/components/basecomponents/BaseMenu.vue
@@ -2,7 +2,7 @@
   <Menu
     :id="id"
     ref="menu"
-    :model="innerModel"
+    :model="model"
     :popup="true"
     class="app-topbar__user-submenu"
   />
@@ -11,9 +11,9 @@
 
 <script setup>
 import Menu from "primevue/menu";
-import {ref, computed} from "vue";
+import {ref} from "vue";
 
-const props = defineProps({
+defineProps({
   id: {
     type: String,
     required: true,
@@ -22,16 +22,7 @@ const props = defineProps({
     type: Array,
     required: true,
   },
-})
-
-const innerModel = computed(() => {
-  return props.model.map(e => {
-    return {
-      ...e,
-      'class': 'text-primary',
-    };
-  });
-})
+});
 
 const menu = ref(null);
 


### PR DESCRIPTION
This will fix the menu items according to figma. Right now, the menu looks like this:

![course-title-menu-wrong-styles](https://github.com/chamilo/chamilo-lms/assets/50702276/61d41b7e-d6f5-43ae-a1d1-7eb1c924b2bc)

This commit will make it look like: 
![course-title-menu-right-styles](https://github.com/chamilo/chamilo-lms/assets/50702276/20547937-373f-4c88-8b19-748f61805999)

This will simplify the code since the default behaviour is sufficient to implement this.
