### PR TITLE
Plugin BBB: Fix bug that breaks bbb.lib.php library

### DIFF
--- a/plugin/bbb/lib/bbb.lib.php
+++ b/plugin/bbb/lib/bbb.lib.php
@@ -918,7 +918,7 @@ class bbb
             'where' => array(
                 'c_id = ? AND session_id = ? AND meeting_name = ? AND status = 1' =>
                  array($courseId, $sessionId, $meetingName),
-        );
+        ));
 
         if ($this->hasGroupSupport()) {
             $groupId = api_get_group_id();


### PR DESCRIPTION
There is a missing bracket ( '**)**' ) on https://github.com/contidos-dixitais/chamilo-lms/blob/1.11.x/plugin/bbb/lib/bbb.lib.php#L917-L921

This missing bracket not only breaks the plugin, also breaks the homepage  and user_portal.php and everywhere the bbb plugin is used 