### PR TITLE
Fix link to group in calendar view

### DIFF
--- a/main/calendar/agenda.php
+++ b/main/calendar/agenda.php
@@ -14,10 +14,16 @@ if (!empty($course_info)) {
 
 $action = isset($_GET['action']) ? Security::remove_XSS($_GET['action']) : null;
 
+$group_id = api_get_group_id();
+
 $url = null;
 if (empty($action)) {
     if (!empty($course_info)) {
-        $url = api_get_path(WEB_CODE_PATH).'calendar/agenda_js.php?type=course&'.api_get_cidreq();
+        if (!empty($group_id)) {
+            $url = api_get_path(WEB_CODE_PATH).'calendar/agenda_js.php?type=course&'.api_get_cidreq() . '&user_id=GROUP:' . $group_id;
+        } else {
+            $url = api_get_path(WEB_CODE_PATH).'calendar/agenda_js.php?type=course&'.api_get_cidreq();
+        }
     } else {
         $url = api_get_path(WEB_CODE_PATH).'calendar/agenda_js.php?';
     }
@@ -31,7 +37,6 @@ $logInfo = [
 ];
 Event::registerLog($logInfo);
 
-$group_id = api_get_group_id();
 $groupInfo = GroupManager::get_group_properties($group_id);
 $eventId = $_REQUEST['id'] ?? null;
 $type = $event_type = $_GET['type'] ?? null;

--- a/main/calendar/agenda_js.php
+++ b/main/calendar/agenda_js.php
@@ -322,6 +322,8 @@ $extraSettings = Agenda::returnFullCalendarExtraSettings();
 
 $tpl->assign('fullcalendar_settings', $extraSettings);
 
+$tpl->assign('group_id', (!empty($group_id) ? $group_id : 0));
+
 $templateName = $tpl->get_template('agenda/month.tpl');
 $content = $tpl->fetch($templateName);
 $tpl->assign('content', $content);

--- a/main/inc/lib/agenda.lib.php
+++ b/main/inc/lib/agenda.lib.php
@@ -1149,21 +1149,8 @@ class Agenda
                 if (isset($attachmentArray) && !empty($attachmentArray)) {
                     $counter = 0;
                     foreach ($attachmentArray as $attachmentItem) {
-                        if (empty($attachmentItem['id'])) {
-                            $this->addAttachment(
-                                $id,
-                                $attachmentItem,
-                                $attachmentCommentList[$counter],
-                                $this->course
-                            );
-                        } else {
-                            $this->updateAttachment(
-                                $attachmentItem['id'],
-                                $id,
-                                $attachmentItem,
-                                $attachmentCommentList[$counter],
-                                $this->course
-                            );
+                        if (empty($attachmentItems['id'])) {
+                            continue;
                         }
                         $counter++;
                     }

--- a/main/inc/lib/agenda.lib.php
+++ b/main/inc/lib/agenda.lib.php
@@ -1152,6 +1152,14 @@ class Agenda
                         if (empty($attachmentItems['id'])) {
                             continue;
                         }
+                        
+                        $this->updateAttachment(
+                            $attachmentItem['id'],
+                            $id,
+                            $attachmentItem,
+                            $attachmentCommentList[$counter],
+                            $this->course
+                        );
                         $counter++;
                     }
                 }

--- a/main/inc/lib/agenda.lib.php
+++ b/main/inc/lib/agenda.lib.php
@@ -1149,17 +1149,22 @@ class Agenda
                 if (isset($attachmentArray) && !empty($attachmentArray)) {
                     $counter = 0;
                     foreach ($attachmentArray as $attachmentItem) {
-                        if (empty($attachmentItems['id'])) {
-                            continue;
+                        if (empty($attachmentItem['id'])) {
+                            $this->addAttachment(
+                                $id,
+                                $attachmentItem,
+                                $attachmentCommentList[$counter],
+                                $this->course
+                            );
+                        } else {
+                            $this->updateAttachment(
+                                $attachmentItem['id'],
+                                $id,
+                                $attachmentItem,
+                                $attachmentCommentList[$counter],
+                                $this->course
+                            );
                         }
-
-                        $this->updateAttachment(
-                            $attachmentItem['id'],
-                            $id,
-                            $attachmentItem,
-                            $attachmentCommentList[$counter],
-                            $this->course
-                        );
                         $counter++;
                     }
                 }

--- a/main/inc/lib/agenda.lib.php
+++ b/main/inc/lib/agenda.lib.php
@@ -2296,6 +2296,7 @@ class Agenda
                     );
                     $event['sent_to'] = '<div class="label_tag notice">'.$sent_to.'</div>';
                     $event['type'] = 'group';
+                    $event['group_id'] = $row['to_group_id'];
                 }
 
                 // Event sent to a user?

--- a/main/template/default/agenda/month.tpl
+++ b/main/template/default/agenda/month.tpl
@@ -727,6 +727,9 @@ $(function() {
                         {% endif %}
                         '{{ "Edit"|get_lang }}' : function() {
                             url =  "{{ _p.web_main }}calendar/agenda.php?action=edit&type=fromjs&id="+calEvent.id+'&course_id='+calEvent.course_id+"";
+                            if (typeof calEvent.group_id != "undefined" && {{ group_id }} != 0) {
+                              url = url + '&gidReq=' + calEvent.group_id;
+                            }
                             window.location.href = url;
                             $("#dialog-form").dialog( "close" );
                         },


### PR DESCRIPTION
When accessing the calendar from within a course group, the group data gets lost when editing an event.
The breadcrumb does not contain the group info anymore.