### PR TITLE
Fix for substr() on DateTime in Wiki

### DIFF
--- a/main/inc/lib/agenda.lib.php
+++ b/main/inc/lib/agenda.lib.php
@@ -1149,22 +1149,17 @@ class Agenda
                 if (isset($attachmentArray) && !empty($attachmentArray)) {
                     $counter = 0;
                     foreach ($attachmentArray as $attachmentItem) {
-                        if (empty($attachmentItem['id'])) {
-                            $this->addAttachment(
-                                $id,
-                                $attachmentItem,
-                                $attachmentCommentList[$counter],
-                                $this->course
-                            );
-                        } else {
-                            $this->updateAttachment(
-                                $attachmentItem['id'],
-                                $id,
-                                $attachmentItem,
-                                $attachmentCommentList[$counter],
-                                $this->course
-                            );
+                        if (empty($attachmentItems['id'])) {
+                            continue;
                         }
+
+                        $this->updateAttachment(
+                            $attachmentItem['id'],
+                            $id,
+                            $attachmentItem,
+                            $attachmentCommentList[$counter],
+                            $this->course
+                        );
                         $counter++;
                     }
                 }

--- a/main/inc/lib/agenda.lib.php
+++ b/main/inc/lib/agenda.lib.php
@@ -1149,17 +1149,22 @@ class Agenda
                 if (isset($attachmentArray) && !empty($attachmentArray)) {
                     $counter = 0;
                     foreach ($attachmentArray as $attachmentItem) {
-                        if (empty($attachmentItems['id'])) {
-                            continue;
+                        if (empty($attachmentItem['id'])) {
+                            $this->addAttachment(
+                                $id,
+                                $attachmentItem,
+                                $attachmentCommentList[$counter],
+                                $this->course
+                            );
+                        } else {
+                            $this->updateAttachment(
+                                $attachmentItem['id'],
+                                $id,
+                                $attachmentItem,
+                                $attachmentCommentList[$counter],
+                                $this->course
+                            );
                         }
-
-                        $this->updateAttachment(
-                            $attachmentItem['id'],
-                            $id,
-                            $attachmentItem,
-                            $attachmentCommentList[$counter],
-                            $this->course
-                        );
                         $counter++;
                     }
                 }

--- a/main/wiki/wiki.inc.php
+++ b/main/wiki/wiki.inc.php
@@ -2102,6 +2102,11 @@ class Wiki
         $group_name = $group_properties ? $group_properties['name'] : '';
         $allow_send_mail = false; //define the variable to below
         $email_assignment = null;
+
+        if (!is_string($lastime) && get_class($lastime) == 'DateTime') {
+            $lastime = $lastime->format('Y-m-d H:i:s');
+        }
+
         if ($type == 'P') {
             //if modifying a wiki page
             //first, current author and time


### PR DESCRIPTION
The substr() function throws an error because lastime is a DateTime instead of a string