### PR TITLE
Import user tool: Results may appear incorrect when importing more than one user

### DIFF
--- a/main/admin/user_import.php
+++ b/main/admin/user_import.php
@@ -400,7 +400,7 @@ function save_data(
             $csv_content = [];
             $csv_row = $header;
             $csv_content[] = $csv_row;
-            foreach ($userSaved as $user) {
+            foreach ($userSaved as &$user) {
                 $csv_row = [];
                 $csv_row[] = isset($user['id']) ? $user['id'] : '';
                 $csv_row[] = isset($user['FirstName']) ? $user['FirstName'] : '';
@@ -418,7 +418,7 @@ function save_data(
             $csv_content = [];
             $csv_row = $header;
             $csv_content[] = $csv_row;
-            foreach ($userError as $user) {
+            foreach ($userError as &$user) {
                 $csv_row = [];
                 $csv_row[] = isset($user['id']) ? $user['id'] : '';
                 $csv_row[] = isset($user['FirstName']) ? $user['FirstName'] : '';
@@ -437,7 +437,7 @@ function save_data(
             $csv_content = [];
             $csv_row = $header;
             $csv_content[] = $csv_row;
-            foreach ($userWarning as $user) {
+            foreach ($userWarning as &$user) {
                 $csv_row = [];
                 $csv_row[] = isset($user['id']) ? $user['id'] : '';
                 $csv_row[] = isset($user['FirstName']) ? $user['FirstName'] : '';


### PR DESCRIPTION
We detected an error on the user import result view.

When importing more than one user through the bulk import tool (/main/admin/user_import.php), upon completion of the process, the last record may appear with an incorrect status or directly as a duplicate of the first one. The problem lies in reusing the variable $user in the iterations of the arrays $userSaved, $userError, and $userWarning within the save_data function in main/admin/user_import.php.

As a quick and simple solution, I have chosen to make the $user in the foreach loops an assignment by reference. I don't see any inconvenience in doing so.

As a side note unrelated to the solution of this pull request, I think it might be the best solution, but I have doubts about whether it would be better to rename the variables, both the arrays and the assignments. For example:

> Array $userError to $usersError
> Asignación $user to $userError
>
> Code:
> `foreach ($usersError as $userError) { ....`