### PR TITLE
MailConfig - Usar el método API para obtener el valor de SMTP_UNIQUE_SENDER

### DIFF
--- a/main/inc/lib/api.lib.php
+++ b/main/inc/lib/api.lib.php
@@ -10258,8 +10258,6 @@ function api_unserialize_content($type, $serialized, $ignoreErrors = false)
  */
 function api_set_noreply_and_from_address_to_mailer(PHPMailer $mailer, array $sender, array $replyToAddress = [])
 {
-    $platformEmail = $GLOBALS['platform_email'];
-
     $noReplyAddress = api_get_setting('noreply_email_address');
     $avoidReplyToAddress = false;
 
@@ -10291,8 +10289,8 @@ function api_set_noreply_and_from_address_to_mailer(PHPMailer $mailer, array $se
 
     //If the SMTP configuration only accept one sender
     if (
-        isset($platformEmail['SMTP_UNIQUE_SENDER']) &&
-        $platformEmail['SMTP_UNIQUE_SENDER']
+        !empty(api_get_mail_configuration_value('SMTP_UNIQUE_SENDER')) &&
+        api_get_mail_configuration_value('SMTP_UNIQUE_SENDER')
     ) {
         $senderName = $notification->getDefaultPlatformSenderName();
         $senderEmail = $notification->getDefaultPlatformSenderEmail();


### PR DESCRIPTION
En este commit se sustituye el uso de $platformEmail['SMTP_UNIQUE_SENDER'] por api_get_mail_configuration_value('SMTP_UNIQUE_SENDER').

En la mayoría de los casos daría igual, pero en entornos multiurl, tal y como está ahora la lógica, no se tendría en cuenta el valor especifico de los campus hijo; este pull request corrige este problema,