### PR TITLE
Plugin: Keycloak: Align properly the Keycloak login button

### DIFF
--- a/main/inc/lib/template.lib.php
+++ b/main/inc/lib/template.lib.php
@@ -1308,8 +1308,8 @@ class Template
         $plugin = null;
         if ($pluginKeycloak) {
             $pluginUrl = api_get_path(WEB_PLUGIN_PATH).'keycloak/start.php?sso';
-            $pluginUrl = Display::url('Keycloak', $pluginUrl, ['class' => 'btn btn-primary']);
-            $html .= '<div>'.$pluginUrl.'</div>';
+            $pluginUrl = Display::url('Keycloak', $pluginUrl, ['class' => 'btn btn-block btn-primary']);
+            $html .= '<div style="margin-top: 10px">'.$pluginUrl.'</div>';
         }
 
         $html .= '<div></div>';


### PR DESCRIPTION
When `Keycloak` plugin is enabled, a new button for logging in via Keycloak is displayed below the normal "Login" button.
This PR fixes the visual appearance of this "Keycloak" button.

Before:
![image](https://github.com/chamilo/chamilo-lms/assets/1327828/ac999699-7c0e-4ea8-94bf-19b0e2a8577b)

After:
![image](https://github.com/chamilo/chamilo-lms/assets/1327828/e3173779-261b-49cc-b452-4c1d90d406dc)
