### PR TITLE
Scheduled Announcements: Add user extra fields as tags

### DIFF
--- a/main/inc/lib/ScheduledAnnouncement.php
+++ b/main/inc/lib/ScheduledAnnouncement.php
@@ -412,6 +412,16 @@ class ScheduledAnnouncement extends Model
                                 '((lp_progress))' => $progress,
                             ];
 
+                            $scheduledAnnouncementsUserExtraFieldsAsTags = api_get_configuration_value('scheduled_announcements_user_extra_fields_as_tags');
+                            if ($scheduledAnnouncementsUserExtraFieldsAsTags && $scheduledAnnouncementsUserExtraFieldsAsTags['extraFields']) {
+                                foreach ($scheduledAnnouncementsUserExtraFieldsAsTags['extraFields'] as $extraField) {
+                                    $extraValue = UserManager::get_extra_user_data_by_field($user['user_id'], $extraField);
+                                    $tagValue = $extraValue[$extraField];
+
+                                    $tags["(($extraField))"] = $tagValue;
+                                }
+                            }
+
                             $message = str_replace(array_keys($tags), $tags, $message);
                             $message .= $attachments;
 
@@ -461,6 +471,13 @@ class ScheduledAnnouncement extends Model
             '((user_picture))',
             '((lp_progress))',
         ];
+
+        $scheduledAnnouncementsUserExtraFieldsAsTags = api_get_configuration_value('scheduled_announcements_user_extra_fields_as_tags');
+        if ($scheduledAnnouncementsUserExtraFieldsAsTags && $scheduledAnnouncementsUserExtraFieldsAsTags['extraFields']) {
+            foreach ($scheduledAnnouncementsUserExtraFieldsAsTags['extraFields'] as $extraField) {
+                array_push($tags, "(($extraField))");
+            }
+        }
 
         return $tags;
     }

--- a/main/install/configuration.dist.php
+++ b/main/install/configuration.dist.php
@@ -683,6 +683,14 @@ ALTER TABLE c_survey_question ADD is_required TINYINT(1) DEFAULT 0 NOT NULL;
 //$_configuration['allow_scheduled_announcements'] = false;
 // Add "attachment" file upload extra field label in: main/admin/extra_fields.php?type=scheduled_announcement&action=add
 // Add "send_to_coaches" checkbox options field label in: main/admin/extra_fields.php?type=scheduled_announcement&action=add
+// Add selected user extra fields to the scheduled announcement tags
+/*
+$_configuration['scheduled_announcements_user_extra_fields_as_tags'] =  [
+    'extraFields' => [
+        'corporate_address',
+        'car_license_plate',
+    ]
+];*/
 // Add the list of emails as a bcc when sending an email.
 // Configure a cron task pointing at main/cron/scheduled_announcement.php
 /*


### PR DESCRIPTION
This PR adds a new funcionality that allows to add selected user extra fields to the tags list of the scheduled announcements.

We have to add a new configuration.php parameter, "scheduled_announcements_user_extra_fields_as_tags" to set the user extra fields to show on the editor