### PR TITLE
Fix url chat.ajax.php

### DIFF
--- a/plugin/bbb/admin.php
+++ b/plugin/bbb/admin.php
@@ -98,7 +98,7 @@ if (!$bbb->isServerRunning()) {
 $htmlHeadXtra[] = api_get_js_simple(
     api_get_path(WEB_PLUGIN_PATH).'bbb/resources/utils.js'
 );
-$htmlHeadXtra[] = "<script>var _p = {web_plugin: '".api_get_path(WEB_PLUGIN_PATH)."'}</script>";
+$htmlHeadXtra[] = "<script> _p.web_plugin = '".api_get_path(WEB_PLUGIN_PATH)."'</script>";
 
 $tpl = new Template($tool_name);
 $tpl->assign('meetings', $meetings);


### PR DESCRIPTION
Hi, 

chat.ajax.php and online.ajax.php are called in  plugin/bbb/admin.php with this url "/plugin/bbb/undefinedchat.ajax.php?action=startchatsession&_=1690044860183", the variable _p are overrided with only plugin path.
