### PR TITLE
Formvalidator::addMultipleUploadJavascript() - dropZone parameter was speficied incorrect

### DIFF
--- a/main/inc/lib/formvalidator/FormValidator.class.php
+++ b/main/inc/lib/formvalidator/FormValidator.class.php
@@ -1899,7 +1899,7 @@ EOT;
                 previewMaxWidth: 300,
                 previewMaxHeight: 169,
                 previewCrop: true,
-                dropzone: $('#dropzone'),
+                dropZone: $('#dropzone'),
                 maxChunkSize: 10000000, // 10 MB
                 sequentialUploads: true,
             }).on('fileuploadchunksend', function (e, data) {


### PR DESCRIPTION
In Formvalidator::addMultipleUploadJavascript() the dropZone parameter was specified with the incorrect case ("dropzone" instead of "dropZone" with a capital "Z"). The caused the jQuery Multi Upload script to use the whole window as a dropzone for files.