### PR TITLE
Flash messages not shown after simple upload

### DIFF
--- a/main/dropbox/index.php
+++ b/main/dropbox/index.php
@@ -77,6 +77,8 @@ if (isset($_POST['submitWork'])) {
     $check = Security::check_token();
     if ($check) {
         store_add_dropbox();
+
+        echo Display::getFlashToString();
     }
 }
 


### PR DESCRIPTION
When using the simple upload (not the javascript widget) in the dropbox tool, feedback/flash messages set by store_add_dropbox() are not shown in the interface.

I think the reason is that flash messages are normally shown somewhere in the header function of the Display class.
The store_add_dropbox() function however is called after displaying the header ( (=Display::display_header()).) 
and the flash messages are cleared from the session variable ("flash_messages") in the footer (=Display::display_footer()) at the end of the script.

So the messages need to be shown by calling Display::getFlashToString() after processing the file.