### PR TITLE
dropbox tool : "view" parameter check does not display error

### DIFF
--- a/main/dropbox/dropbox_init.inc.php
+++ b/main/dropbox/dropbox_init.inc.php
@@ -283,10 +283,10 @@ $(function () {
 $checked_files = false;
 if (!$view || $view == 'received') {
     $part = 'received';
-} elseif ($view = 'sent') {
+} elseif ($view == 'sent') {
     $part = 'sent';
 } else {
-    header('location: index.php?'.api_get_cidreq().'&view='.$view.'&error=Error');
+    header('location: index.php?'.api_get_cidreq().'&view=received&error=Error');
     exit;
 }
 


### PR DESCRIPTION
The check on a valid "view" parameter does not work as expected.

When the $view variable is compared to 'sent' the operator is wrong, a single "=" is used to assign the value "sent" to the variable instead of a double "==" for comparison.

Fixing this bug revealed another bug, because in the following redirect to an error message, the $view parameter is passed on, which causes an infinite redirect loop.

As a fix the user is redirect to the "reveived" view, with an error message, because it is treated as the default view for the tool.