### PR TITLE
Fix "deny from all" statements in .htaccess files

### DIFF
--- a/app/cache/.htaccess
+++ b/app/cache/.htaccess
@@ -1,5 +1,10 @@
-order deny,allow
-deny from all
+<IfModule mod_authz_core.c>
+    Require all denied
+</IfModule>
+<IfModule !mod_authz_core.c>
+    Order deny,allow
+    Deny from all
+</IfModule>
 # pChart generated files should be allowed
 <FilesMatch "^[0-9a-f]+$">
     order allow,deny

--- a/app/home/.htaccess
+++ b/app/home/.htaccess
@@ -1,3 +1,9 @@
 <FilesMatch "(?i)\.(php5|php4|php|php3|php2|phtml|pl|py|jsp|asp|sh|cgi)$">
-    deny from all
+    <IfModule mod_authz_core.c>
+        Require all denied
+    </IfModule>
+    <IfModule !mod_authz_core.c>
+        Order allow,deny
+        Deny from all
+    </IfModule>
 </FilesMatch>

--- a/main/admin/archive_cleanup.php
+++ b/main/admin/archive_cleanup.php
@@ -47,8 +47,13 @@ if ($form->validate()) {
 
     $archive_path = api_get_path(SYS_ARCHIVE_PATH);
     $htaccess = <<<TEXT
-order deny,allow
-deny from all
+<IfModule mod_authz_core.c>
+    Require all denied
+</IfModule>
+<IfModule !mod_authz_core.c>
+    Order deny,allow
+    Deny from all
+</IfModule>
 # pChart generated files should be allowed
 <FilesMatch "^[0-9a-f]+$">
     order allow,deny

--- a/main/admin/user_import.php
+++ b/main/admin/user_import.php
@@ -41,8 +41,13 @@ function createDirectory($path = null)
                 mkdir($data, api_get_permissions_for_new_directories());
                 $block =
                     '<FilesMatch "\.(csv|xml)$">
-Order allow,deny
-Deny from all
+<IfModule mod_authz_core.c>
+    Require all denied
+</IfModule>
+<IfModule !mod_authz_core.c>
+    Order allow,deny
+    Deny from all
+</IfModule>
 </FilesMatch>
 Options -Indexes';
 

--- a/main/inc/lib/add_course.lib.inc.php
+++ b/main/inc/lib/add_course.lib.inc.php
@@ -173,8 +173,13 @@ class AddCourse
             "AuthName AllowLocalAccess
                        AuthType Basic
 
-                       order deny,allow
-                       deny from all
+                       <IfModule mod_authz_core.c>
+                           Require all denied
+                       </IfModule>
+                       <IfModule !mod_authz_core.c>
+                           Order deny,allow
+                           Deny from all
+                       </IfModule>
 
                        php_flag zlib.output_compression off"
         );


### PR DESCRIPTION
"Deny from all" statements do not work in Apache 2.4. They are replaced by "Require all denied".

A check was added to make the .htaccess files work with both Apache 2.2 & 2.4.