### PR TITLE
Allow storing long texts in extra field value.

### DIFF
--- a/src/Chamilo/CoreBundle/Entity/ExtraFieldValues.php
+++ b/src/Chamilo/CoreBundle/Entity/ExtraFieldValues.php
@@ -32,7 +32,7 @@ class ExtraFieldValues extends BaseAttributeValue
 
     /**
      * @var string
-     * @ORM\Column(name="value", type="string", nullable=true, unique=false)
+     * @ORM\Column(name="value", type="text", nullable=true, unique=false)
      */
     protected $value;
 


### PR DESCRIPTION
Currently the value for an extra field is stored in a varchar(255) field in the extra_field_value table of the database. 
This is to small to store for example one of the standard templates available in the WYSIWYG editor.

Would it not be better to store the value in a longtext field?