### PR TITLE
Add support for passphrase for DKIM private key

### DIFF
--- a/app/config/mail.conf.dist.php
+++ b/app/config/mail.conf.dist.php
@@ -40,6 +40,7 @@ $platform_email['DKIM_SELECTOR'] = 'chamilo'; // an indicator of the application
 $platform_email['DKIM_DOMAIN'] = 'mydomain.com'; //the domain for e-mail sending, not necessarily api_get_path(WEB_PATH)
 $platform_email['DKIM_PRIVATE_KEY_STRING'] = ''; //the private key in a string format
 $platform_email['DKIM_PRIVATE_KEY'] = ''; //the private key as the path to a file. The file needs to be accessible to PHP!
+$platform_email['DKIM_PASSPHRASE'] = ''; //the passohrase for the private key defined in the last 2 lines
 // Some e-mail clients do not understand the descriptive LD+JSON format,
 // showing it as a loose JSON string to the final user. If this is your case,
 // you might want to set the variable below to 'false' to disable this header.

--- a/main/inc/lib/api.lib.php
+++ b/main/inc/lib/api.lib.php
@@ -9753,6 +9753,9 @@ function api_mail_html(
         }
         $mail->DKIM_private_string = api_get_mail_configuration_value('DKIM_PRIVATE_KEY_STRING');
         $mail->DKIM_private = api_get_mail_configuration_value('DKIM_PRIVATE_KEY');
+        if(!empty($platform_email['DKIM_PASSPHRASE'])) {
+            $mail->DKIM_passphrase = $platform_email['DKIM_PASSPHRASE'];
+        }
     }
 
     // Send the mail message.

--- a/main/inc/lib/api.lib.php
+++ b/main/inc/lib/api.lib.php
@@ -9753,8 +9753,8 @@ function api_mail_html(
         }
         $mail->DKIM_private_string = api_get_mail_configuration_value('DKIM_PRIVATE_KEY_STRING');
         $mail->DKIM_private = api_get_mail_configuration_value('DKIM_PRIVATE_KEY');
-        if(!empty($platform_email['DKIM_PASSPHRASE'])) {
-            $mail->DKIM_passphrase = $platform_email['DKIM_PASSPHRASE'];
+        if (!empty(api_get_mail_configuration_value['DKIM_PASSPHRASE'])) {
+            $mail->DKIM_passphrase = api_get_mail_configuration_value['DKIM_PASSPHRASE'];
         }
     }
 


### PR DESCRIPTION
Current DKIM config doesn't implement passphrase argument,  which is more or less the forced way openssl will generate a key.