### PR TITLE
LP View: Opción deshabilitar botón "Abrir contenido en una nueva pestaña"

### DIFF
--- a/main/install/configuration.dist.php
+++ b/main/install/configuration.dist.php
@@ -1634,6 +1634,9 @@ requires extension "php-soap"  sudo apt-get install php-soap
 // LP view menu location. Options: "left" or "right"
 // $_configuration['lp_menu_location'] = 'left';
 
+// Hide the "Open in new window" button in learning paths when viewing long content (using the button disconnects SCORM tracking - more details in #4954)
+//$_configuration['lp_ios_hide_open_in_new_window_button'] = false;
+
 // Show notification events
 /*CREATE TABLE IF NOT EXISTS notification_event (
 id INT unsigned NOT NULL auto_increment PRIMARY KEY,

--- a/main/lp/lp_view.php
+++ b/main/lp/lp_view.php
@@ -656,6 +656,13 @@ $template->assign(
     )
 );
 
+// Check if the 'Open in new window' button for IOs hosts must be hidden
+$iosHideOpenInNewWindow = false;
+if (api_get_configuration_value('lp_ios_hide_open_in_new_window_button') === true) {
+    $iosHideOpenInNewWindow = api_get_configuration_value('lp_ios_hide_open_in_new_window_button');
+}
+$template->assign('ios_hide_open_in_new_window', $iosHideOpenInNewWindow);
+
 $frameReady = Display::getFrameReadyBlock(
     '#content_id, #content_id_blank',
     $itemType,

--- a/main/template/default/learnpath/view.tpl
+++ b/main/template/default/learnpath/view.tpl
@@ -255,23 +255,27 @@
                     'style',
                     'width:100%; overflow:auto; position:auto; -webkit-overflow-scrolling:touch !important;'
                 );
-                $('<a>')
-                    .attr({
-                        'id': 'btn-content-new-tab',
-                        'target': '_blank',
-                        'href': '{{ iframe_src }}'
-                    })
-                    .css({
-                        'position': 'absolute',
-                        'right': '5px',
-                        'top': '5px',
-                        'z-index': '9999',
-                        'font-weight': 'bold'
-                    })
-                    .addClass('btn btn-default btn-sm')
-                    .text('{{ 'OpenContentInNewTab'|get_lang|escape('js') }}')
-                    .prependTo('#wrapper-iframe');
-                $('#wrapper-iframe').css('position', 'relative');
+
+                {% if ios_hide_open_in_new_window == true %}
+                    $('<a>')
+                        .attr({
+                            'id': 'btn-content-new-tab',
+                            'target': '_blank',
+                            'href': '{{ iframe_src }}'
+                        })
+                        .css({
+                            'position': 'absolute',
+                            'right': '5px',
+                            'top': '5px',
+                            'z-index': '9999',
+                            'font-weight': 'bold'
+                        })
+                        .addClass('btn btn-default btn-sm')
+                        .text('{{ 'OpenContentInNewTab'|get_lang|escape('js') }}')
+                        .prependTo('#wrapper-iframe');
+                    $('#wrapper-iframe').css('position', 'relative');
+                {% endif %}
+
                 // Fix another issue whereby buttons do not react to click below
                 // second screen in learning paths on Apple devices
                 document.getElementById('content_id').setAttribute('style', 'overflow: auto;');

--- a/main/template/default/learnpath/view.tpl
+++ b/main/template/default/learnpath/view.tpl
@@ -256,7 +256,7 @@
                     'width:100%; overflow:auto; position:auto; -webkit-overflow-scrolling:touch !important;'
                 );
 
-                {% if ios_hide_open_in_new_window == true %}
+                {% if ios_hide_open_in_new_window == false %}
                     $('<a>')
                         .attr({
                             'id': 'btn-content-new-tab',


### PR DESCRIPTION
Issue: #4954 

Este PR añade una nueva opción en configuration.php que activada permite ocultar el botón de "Abrir contenido en una nueva pestaña" cuando cargamos una lección en dispositivos iOS o MacOS + Safari:

`$_configuration['lp_ios_hide_open_in_new_window_button'] = false;`

Por defecto siempre se muestra el botón, salvo que el valor de esta opción sea "true"