### PR TITLE
Edición usuario: Comprobación de si se ha introducido una fecha de expiración en caso de que se active esta opción

### DIFF
--- a/main/admin/user_edit.php
+++ b/main/admin/user_edit.php
@@ -479,6 +479,11 @@ if ($form->validate()) {
 
     $expiration_date = null;
     if (!$user_data['platform_admin'] && $user['radio_expiration_date'] == '1') {
+        if (empty($user['expiration_date'])) {
+            Display::addFlash(Display::return_message(get_lang('EmptyExpirationDate')));
+            header('Location: '.api_get_self().'?user_id='.$user_id);
+            exit();
+        }
         $expiration_date = $user['expiration_date'];
     }
 


### PR DESCRIPTION
Issue: #4953 

Este PR añade comprueba que exista una fecha de expiración en caso de que se active esta opción al guardar una ediciónd e usuario. 

Actualmente, en caso de que esté activada la fecha de expiración pero no se pase ninguna fecha, da como resultado una excepción no controlada.

