### PR TITLE
Tracking user access details: Permitir a los tutores generales de sesión ver detalle de acceso al curso

### DIFF
--- a/main/inc/ajax/myspace.ajax.php
+++ b/main/inc/ajax/myspace.ajax.php
@@ -11,7 +11,7 @@ $action = $_GET['a'];
 
 // Access restrictions.
 $is_allowedToTrack = api_is_platform_admin(true, true) ||
-    api_is_allowed_to_create_course() || api_is_course_tutor();
+    api_is_allowed_to_create_course() || api_is_course_tutor() || api_is_session_general_coach();
 
 if (!$is_allowedToTrack) {
     exit;


### PR DESCRIPTION
Actualmente los tutores generales de una sesión no pueden ver los detalles de acceso a los cursos de la sesión aunque sean también tutores en esos cursos, 

https://github.com/chamilo/chamilo-lms/blob/9610bd60afeb12bdec0ffa0d9e11dd1b89e96353/main/inc/ajax/myspace.ajax.php#L12-L18


Este problema se describe en este [issue](https://github.com/chamilo/chamilo-lms/issues/4981).


Este PR habilita a este tipo de usuarios la posibilidad de ver los detalles de acceso a los cursos