### PR TITLE
Survey: Mejorar la exportación de elementos "open-question" cuando se necesita más de una pagina

### DIFF
--- a/main/survey/reporting.php
+++ b/main/survey/reporting.php
@@ -148,7 +148,7 @@ function formExportSubmit(formId) {
 }
 async function exportToPdf() {
     window.scrollTo(0, 0);
-    
+
     $("#dialog-confirm").dialog({
         autoOpen: false,
         show: "blind",
@@ -179,6 +179,8 @@ async function exportToPdf() {
     pdf.addImage(pageData, "JPEG", 35, 60, 515, headerY);
 
     var divs = doc.getElementsByClassName("question-item");
+    var currentHeight = 60 + headerY;
+    var maxHeightPerPage = 842;
     var pages = [];
     var page = 1;
     for (var i = 0; i < divs.length; i += 1) {
@@ -225,10 +227,45 @@ async function exportToPdf() {
 
         var tables = divs[i].getElementsByClassName("open-question");
         for (var j = 0; j < tables.length; j += 1) {
-            var canvas = await html2canvas(tables[j], config);
-            var pageData = canvas.toDataURL("image/jpeg", 0.7);
-            if (pageData) {
-                pdf.addImage(pageData, "JPEG", 40, positionY + (10 * lines.length), 500, 500 / canvas.width * canvas.height);
+            const canvas = await html2canvas(tables[j]);
+            var canvasWidth = canvas.width;
+            var canvasHeight = canvas.height;
+            var imgWidth = 515;
+            var imgHeight = canvasHeight;
+            var y = currentHeight;
+            var renderedHeight = 0;
+
+            while (renderedHeight < imgHeight) {
+                var remainingHeight = imgHeight - renderedHeight;
+                var heightToDraw = Math.min(remainingHeight, maxHeightPerPage - y);
+                var sourceHeight = heightToDraw * (canvasWidth / imgWidth);
+
+                // New canvas for cropping image
+                var sectionCanvas = document.createElement("canvas");
+                sectionCanvas.width = canvasWidth;
+                sectionCanvas.height = sourceHeight;
+                var ctx = sectionCanvas.getContext("2d");
+
+                // Draw the image section on new canvas
+                ctx.drawImage(canvas, 0, renderedHeight, canvasWidth, sourceHeight, 0, 0, canvasWidth, sourceHeight);
+
+                var sectionImgData = sectionCanvas.toDataURL("image/jpeg", 0.7);
+
+                pdf.addImage(sectionImgData, "JPEG", 40, y, imgWidth, heightToDraw);
+
+                renderedHeight += sourceHeight;
+                y = heightToDraw + y;
+
+                if (renderedHeight < imgHeight && remainingHeight > maxHeightPerPage - y) {
+                    pdf.addPage();
+                    page++;
+                    y = 40;
+                    currentHeight = 40;
+                }
+            }
+
+            if (renderedHeight >= imgHeight) {
+                currentHeight = y;
             }
         }
 

--- a/main/survey/reporting.php
+++ b/main/survey/reporting.php
@@ -148,7 +148,6 @@ function formExportSubmit(formId) {
 }
 async function exportToPdf() {
     window.scrollTo(0, 0);
-
     $("#dialog-confirm").dialog({
         autoOpen: false,
         show: "blind",

--- a/main/survey/reporting.php
+++ b/main/survey/reporting.php
@@ -148,6 +148,7 @@ function formExportSubmit(formId) {
 }
 async function exportToPdf() {
     window.scrollTo(0, 0);
+
     $("#dialog-confirm").dialog({
         autoOpen: false,
         show: "blind",
@@ -231,7 +232,7 @@ async function exportToPdf() {
             var canvasHeight = canvas.height;
             var imgWidth = 515;
             var imgHeight = canvasHeight;
-            var y = currentHeight;
+            var y = j === 0 ? currentHeight + 60 : currentHeight;
             var renderedHeight = 0;
 
             while (renderedHeight < imgHeight) {


### PR DESCRIPTION
Actualmente en los informes detallados por pregunta de una encuesta nos podemos encontrar que un elemento de respuesta de tipo "Abierta" sea muy extensa, sin embargo cuando exportamos a PDF únicamente genera una única página

![image](https://github.com/chamilo/chamilo-lms/assets/93096561/e4b46482-1bda-455c-974f-a5bf25ece30a)

Este pull request introduce una mejora en la función exportToPdf para conseguir que al exportar la pregunta y respuestas se genere un pdf con varias paginas, generando un canvas a partir del elemento "open-question" con el que se juega con el tamaño necesario del canvas y el tamaño disponible para cada pagina
