### PR TITLE
USER IMPORT: Agregar al CSV de error el id y username de usuarios que ya existen con el mismo email

### DIFF
--- a/main/admin/user_import.php
+++ b/main/admin/user_import.php
@@ -153,6 +153,8 @@ function validate_data($users, $checkUniqueEmail = false)
                 } else {
                     $userFromEmail = api_get_user_info_from_email($user['Email']);
                     if (!empty($userFromEmail)) {
+                        $user['id'] = $userFromEmail['id'];
+                        $user['UserName'] = $userFromEmail['username'];
                         $user['message'] .= Display::return_message(get_lang('EmailUsedTwice'), 'warning');
                         $user['has_error'] = true;
                     } else {


### PR DESCRIPTION
En la herramienta de importación de usuarios podemos checkear la opción que impide la creación de un nuevo usuario si este ya existe en Chamilo.

Estos casos despues los podemos revisar en el CSV generado de casos de error en la importación. Creemos que sería util para nuestras gestiones con clientes poder tener en ese listado el ID y USERNAME del usuario que ya existe.

Este pull recoge esos datos y el resto del proceso existente los agregaría al CSV