### PR TITLE
fixing prevent first upload date while update (uploading)

### DIFF
--- a/main/dropbox/dropbox_functions.inc.php
+++ b/main/dropbox/dropbox_functions.inc.php
@@ -1233,7 +1233,6 @@ function store_add_dropbox($file = [], $work = null)
             $work->title = $dropbox_title;
             $work->filename = $dropbox_filename;
             $work->filesize = $dropbox_filesize;
-            $work->upload_date = api_get_utc_datetime();
             $work->last_upload_date = api_get_utc_datetime();
             $work->description = isset($_POST['description']) ? $_POST['description'] : '';
             $work->uploader_id = api_get_user_id();


### PR DESCRIPTION
fixing prevent first upload date while update (uploading)
when updating the published file, we want the date of the initial and last publication; the former indicates the start of the publishing process, the latter the current state
#5047