### PR TITLE
Change psalm error level to 7

### DIFF
--- a/psalm.xml
+++ b/psalm.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <psalm
-        errorLevel="6"
+        errorLevel="7"
         resolveFromConfigFile="true"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xmlns="https://getpsalm.org/schema/config"


### PR DESCRIPTION
Let us go iterative here, let us increase psalm level to 7 for now.
Let us decrease the level, i.e. increase strictness, later.

Context: having green CI would help to port to 8.2.

It seems like no changes are needed to pass paslm error level 7, so let us stay change to that for now.
BTW Thanks to @AngelFQC for pointing out to configuration.