### PR TITLE
Add git pre push script

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,12 @@ or, for Chamilo 1.11
 ```
 If your default php-cli uses PHP7.4 (see `ln -s /etc/alternatives/php`), you might have issues running with a so-called `platform_check.php` script when running `composer update` anyway. This is because this script doesn't user the proper launch context, and you might need to change your default settings on Ubuntu (i.e. change the link /etc/alternatives/php to point to the other php version) before launching `composer update`. You can always revert that operation later on if you need to go back to work on Chamilo 1.11 and Composer complains again.
 
+### git hooks
+
+To use the git hook sample scripts under `tests/scripts/git-hooks/`, the
+following commands can be used.
+
+    git config core.hooksPath tests/scripts/git-hooks/
 
 ## Changes from 1.x
 

--- a/tests/scripts/git-hooks/pre-push
+++ b/tests/scripts/git-hooks/pre-push
@@ -1,0 +1,53 @@
+#!/bin/sh
+
+# An example hook script to verify what is about to be pushed.  Called by "git
+# push" after it has checked the remote status, but before anything has been
+# pushed.  If this script exits with a non-zero status nothing will be pushed.
+#
+# This hook is called with the following parameters:
+#
+# $1 -- Name of the remote to which the push is being done
+# $2 -- URL to which the push is being done
+#
+# If pushing without using a named remote those arguments will be equal.
+#
+# Information about the commits which are being pushed is supplied as lines to
+# the standard input in the form:
+#
+#   <local ref> <local sha1> <remote ref> <remote sha1>
+#
+# This sample shows how to prevent push of commits where the log message starts
+# with "WIP" (work in progress).
+
+remote="$1"
+url="$2"
+
+z40=0000000000000000000000000000000000000000
+
+while read local_ref local_sha remote_ref remote_sha
+do
+	if [ "$local_sha" = $z40 ]
+	then
+		# Handle delete
+		:
+	else
+		if [ "$remote_sha" = $z40 ]
+		then
+			# New branch, examine all commits
+			range="$local_sha"
+		else
+			# Update to existing branch, examine new commits
+			range="$remote_sha..$local_sha"
+		fi
+
+		# Check for WIP commit
+		commit=`git rev-list -n 1 --grep '^WIP' "$range"`
+		if [ -n "$commit" ]
+		then
+			echo >&2 "Found WIP commit in $local_ref, not pushing"
+			exit 1
+		fi
+	fi
+done
+
+exit 0

--- a/tests/scripts/git-hooks/pre-push
+++ b/tests/scripts/git-hooks/pre-push
@@ -26,28 +26,28 @@ z40=0000000000000000000000000000000000000000
 
 while read local_ref local_sha remote_ref remote_sha
 do
-	if [ "$local_sha" = $z40 ]
-	then
-		# Handle delete
-		:
-	else
-		if [ "$remote_sha" = $z40 ]
-		then
-			# New branch, examine all commits
-			range="$local_sha"
-		else
-			# Update to existing branch, examine new commits
-			range="$remote_sha..$local_sha"
-		fi
+    if [ "$local_sha" = $z40 ]
+    then
+        # Handle delete
+        :
+    else
+        if [ "$remote_sha" = $z40 ]
+        then
+            # New branch, examine all commits
+            range="$local_sha"
+        else
+            # Update to existing branch, examine new commits
+            range="$remote_sha..$local_sha"
+        fi
 
-		# Check for WIP commit
-		commit=`git rev-list -n 1 --grep '^WIP' "$range"`
-		if [ -n "$commit" ]
-		then
-			echo >&2 "Found WIP commit in $local_ref, not pushing"
-			exit 1
-		fi
-	fi
+        # Check for WIP commit
+        commit=`git rev-list -n 1 --grep '^WIP' "$range"`
+        if [ -n "$commit" ]
+        then
+            echo >&2 "Found WIP commit in $local_ref, not pushing"
+            exit 1
+        fi
+    fi
 done
 
 exit 0

--- a/tests/scripts/git-hooks/pre-push
+++ b/tests/scripts/git-hooks/pre-push
@@ -42,7 +42,7 @@ do
         fi
 
         # Run coding standards check over modified files.
-        modified_files=`git diff --diff-filter=d --name-only "$range"`
+        modified_files=$(git diff --diff-filter=d --name-only "$range" | grep -v '\.\(jpg\|jpeg\|png\|gif\|bmp\|svg\|webp\)$')
         if [ -n "$modified_files" ]
         then
             $composer phpcs $modified_files

--- a/tests/scripts/git-hooks/pre-push
+++ b/tests/scripts/git-hooks/pre-push
@@ -41,14 +41,6 @@ do
             range="$remote_sha..$local_sha"
         fi
 
-        # Check for WIP commit
-        commit=`git rev-list -n 1 --grep '^WIP' "$range"`
-        if [ -n "$commit" ]
-        then
-            echo >&2 "Found WIP commit in $local_ref, not pushing"
-            exit 1
-        fi
-
         # Run coding standards check over modified files.
         modified_files=`git diff --diff-filter=d --name-only "$range"`
         if [ -n "$modified_files" ]

--- a/tests/scripts/git-hooks/pre-push
+++ b/tests/scripts/git-hooks/pre-push
@@ -23,6 +23,7 @@ remote="$1"
 url="$2"
 
 z40=0000000000000000000000000000000000000000
+composer=${composer-'composer'}
 
 while read local_ref local_sha remote_ref remote_sha
 do
@@ -46,6 +47,18 @@ do
         then
             echo >&2 "Found WIP commit in $local_ref, not pushing"
             exit 1
+        fi
+
+        # Run coding standards check over modified files.
+        modified_files=`git diff --diff-filter=d --name-only "$range"`
+        if [ -n "$modified_files" ]
+        then
+            $composer phpcs $modified_files
+            if [ $? -ne 0 ]
+            then
+                echo >&2 "A coding standards regressions was introduced, please fix it before pushing."
+                exit 1
+            fi
         fi
     fi
 done


### PR DESCRIPTION
The sample git pre-push scripts basically runs `composer phpcs`, which runs ecs, to verify coding standards regressions over the changed files.