### PR TITLE
Statistics::getCourseCategories() - include courses without categories

### DIFF
--- a/main/inc/lib/statistics.lib.php
+++ b/main/inc/lib/statistics.lib.php
@@ -448,7 +448,7 @@ class Statistics
                 FROM $categoryTable
                 ORDER BY tree_pos";
         $res = Database::query($sql);
-        $categories = [];
+        $categories = [null => get_lang('NoCategory')];
         while ($category = Database::fetch_object($res)) {
             $categories[$category->code] = $category->name;
         }


### PR DESCRIPTION
Statistics::getCourseCategories() - needs to include an option for generating statistics for courses not belonging to a category.