### PR TITLE
Survey: Permitir modificar código encuesta al copiar encuesta

### DIFF
--- a/main/survey/survey.lib.php
+++ b/main/survey/survey.lib.php
@@ -49,6 +49,33 @@ class SurveyManager
     }
 
     /**
+     * Checks if the survey code is unique.
+     *
+     * @param string $courseCode
+     *
+     * @return bool
+     * @assert ('') === false
+     */
+    public static function checkUniqueCode($courseCode)
+    {
+        if (empty($courseCode)) {
+            return false;
+        }
+        $courseId = api_get_course_int_id();
+        $table = Database::get_course_table(TABLE_SURVEY);
+        $courseCode = Database::escape_string($courseCode);
+
+        $sql = "SELECT * FROM $table
+                WHERE code = '$courseCode' AND c_id = $courseId";
+        $result = Database::query($sql);
+        if (Database::num_rows($result)) {
+            return false;
+        } else {
+            return true;
+        }
+    }
+
+    /**
      * Deletes all survey invitations of a user.
      *
      * @param int $user_id

--- a/main/survey/survey.lib.php
+++ b/main/survey/survey.lib.php
@@ -735,7 +735,8 @@ class SurveyManager
     public static function copy_survey(
         $survey_id,
         $new_survey_id = null,
-        $targetCourseId = null
+        $targetCourseId = null,
+        $surveyCode = null
     ) {
         $course_id = api_get_course_int_id();
         if (!$targetCourseId) {
@@ -757,7 +758,14 @@ class SurveyManager
 
         if (empty($new_survey_id)) {
             $params = $survey_data;
-            $params['code'] = self::generate_unique_code($params['code']);
+
+            if (!empty($surveyCode)) {
+                $surveyCode = preg_replace('/\s+/', '', $surveyCode);
+                $params['code'] = $surveyCode;
+            } else {
+                $params['code'] = self::generate_unique_code($params['code']);
+            }
+
             $params['c_id'] = $targetCourseId;
             unset($params['survey_id']);
             $params['session_id'] = api_get_session_id();

--- a/main/survey/surveyUtil.class.php
+++ b/main/survey/surveyUtil.class.php
@@ -3435,6 +3435,25 @@ class SurveyUtil
         $formToString = $form->returnForm();
 
         echo '<div id="dialog-confirm">'.$formToString.'</div>';
+
+        $form = new FormValidator(
+            'copy-survey',
+            'post',
+            null,
+            null,
+            ['class' => 'form-vertical']
+        );
+        $form->addElement(
+            'text',
+            'survey_code',
+            get_lang('SurveyCode'),
+            ['size' => 20, 'maxlength' => 20]
+        );
+
+        $formToString = $form->returnForm();
+
+        echo '<div id="dialog-copy-confirm">'.$formToString.'</div>';
+
         $table->display();
     }
 
@@ -3514,6 +3533,7 @@ class SurveyUtil
      *
      * @param int  $survey_id the id of the survey
      * @param bool $drh
+     * @param bool $surveyCode
      *
      * @return string html code that are the actions that can be performed on any survey
      *
@@ -3521,7 +3541,7 @@ class SurveyUtil
      *
      * @version January 2007
      */
-    public static function modify_filter($survey_id, $drh = false)
+    public static function modify_filter($survey_id, $drh = false, $surveyCode = "")
     {
         /** @var CSurvey $survey */
         $survey = Database::getManager()->find('ChamiloCourseBundle:CSurvey', $survey_id);
@@ -3589,7 +3609,8 @@ class SurveyUtil
                 $actions[] = Display::url(
                     Display::return_icon('copy.png', get_lang('DuplicateSurvey')),
                     $codePath.'survey/survey_list.php?'
-                    .http_build_query($params + ['action' => 'copy_survey', 'survey_id' => $survey_id])
+                    .http_build_query($params + ['action' => 'copy_survey', 'survey_id' => $survey_id]),
+                    ['survey_id' => $survey_id, 'class' => 'copy_survey_popup']
                 );
 
                 $actions[] = Display::url(

--- a/main/survey/survey_list.php
+++ b/main/survey/survey_list.php
@@ -845,7 +845,13 @@ switch ($action) {
     case 'copy_survey':
         if (!empty($surveyId) && api_is_allowed_to_edit()) {
             if (!empty($surveyCode)) {
-                SurveyManager::copy_survey($surveyId, null, null, $surveyCode);
+                if (SurveyManager::checkUniqueCode($surveyCode)) {
+                    SurveyManager::copy_survey($surveyId, null, null, $surveyCode);
+                } else {
+                    Display::addFlash(Display::return_message(get_lang('CodeAlreadyExists'), 'warning', false));
+                    header('Location: '.$listUrl);
+                    exit;
+                }
             } else {
                 SurveyManager::copy_survey($surveyId);
             }

--- a/main/survey/survey_list.php
+++ b/main/survey/survey_list.php
@@ -56,6 +56,14 @@ $htmlHeadXtra[] = '<script>
                 modal: true
          });
 
+         $("#dialog-copy-confirm").dialog({
+            autoOpen: false,
+            show: "blind",
+            resizable: false,
+            height:300,
+            modal: true
+        });
+
         $(".multiplicate_popup").click(function() {
             var targetUrl = $(this).attr("href");
             $( "#dialog-confirm" ).dialog({
@@ -70,6 +78,30 @@ $htmlHeadXtra[] = '<script>
                 }
             });
             $("#dialog-confirm").dialog("open");
+            return false;
+        });
+
+        $(".copy_survey_popup").click(function() {
+            var targetUrl = $(this).attr("href");
+            $( "#dialog-copy-confirm" ).dialog({
+                width:800,
+                height:200,
+                buttons: {
+                    "'.addslashes(get_lang('CopySurvey')).'": function() {
+                        var surveyCode = $("input[name=survey_code]").val();
+                        location.href = targetUrl+"&survey_code="+surveyCode;
+                        $( this ).dialog( "close" );
+                    }
+                }
+            });
+            $("#dialog-copy-confirm").dialog({
+                open: function( event, ui ) {
+                    var timestampMiliseconds= new Date().getTime();
+                    var timestampSeconds = Math.floor(timestampMiliseconds / 1000);
+                    $("input[name=survey_code]").val(timestampSeconds);
+                }
+              });
+            $("#dialog-copy-confirm").dialog("open");
             return false;
         });
     });
@@ -108,6 +140,8 @@ if (isset($_GET['search']) && 'advanced' === $_GET['search']) {
 
 $listUrl = api_get_path(WEB_CODE_PATH).'survey/survey_list.php?'.api_get_cidreq();
 $surveyId = isset($_GET['survey_id']) ? $_GET['survey_id'] : 0;
+$surveyCode = isset($_GET['survey_code']) ? $_GET['survey_code'] : '';
+$surveyCode = Security::remove_XSS($surveyCode);
 
 // Action handling: performing the same action on multiple surveys
 if (isset($_POST['action']) && $_POST['action'] && isset($_POST['id']) && is_array($_POST['id'])) {
@@ -810,7 +844,11 @@ switch ($action) {
         break;
     case 'copy_survey':
         if (!empty($surveyId) && api_is_allowed_to_edit()) {
-            SurveyManager::copy_survey($surveyId);
+            if (!empty($surveyCode)) {
+                SurveyManager::copy_survey($surveyId, null, null, $surveyCode);
+            } else {
+                SurveyManager::copy_survey($surveyId);
+            }
             Display::addFlash(Display::return_message(get_lang('SurveyCopied'), 'confirmation', false));
             header('Location: '.$listUrl);
             exit;


### PR DESCRIPTION
Actualmente, al seleccionar la opción de copiar en el listado de encuestas de un curso, se inicia un proceso de clonación de la encuesta elegida. Durante este proceso, se verifica si el código de la encuesta ya está en uso. En caso afirmativo, se añade un índice al código de la encuesta, que se incrementa sucesivamente hasta confirmar que el nuevo código generado no está repetido

https://github.com/chamilo/chamilo-lms/blob/62ba004a428bb95dc5c09ab865c7f4539aff41db/main/survey/survey.lib.php#L26-L49

El campo en la base de datos destinado a almacenar este valor tiene una longitud máxima de 20 caracteres. Hemos detectado un problema: aunque el proceso de clonación descrito anteriormente funciona correctamente, puede resultar en la generación de un código de encuesta que excede los 20 caracteres. Al intentar almacenar este código en un nuevo registro de la base de datos, solo se guardan los primeros 20 caracteres, lo que puede ocasionar duplicaciones de códigos.

Además del problema mencionado, es esencial ofrecer a los usuarios la posibilidad de modificar el código de la encuesta al clonarla. Por ello, se propone implementar en Chamilo 1.11.x un sistema que permita al usuario introducir un código de encuesta personalizado al seleccionar la opción de copiar encuesta. Este sistema limitará la entrada a 20 caracteres y verificará que el código introducido no esté ya en uso en el sistema.

 Nuevo modal para introducción código de encuesta al copiar una encuesta:
![image](https://github.com/chamilo/chamilo-lms/assets/93096561/6e760261-79e0-4d73-a0df-2d619c55aeba)

![image](https://github.com/chamilo/chamilo-lms/assets/93096561/d69d50b3-4527-461b-99fb-309ecbeebd7a)


Referencia: #5091 