### PR TITLE
My Progress - Mostrar LPs por orden de visualización y no por fecha de publicación

### DIFF
--- a/main/inc/lib/tracking.lib.php
+++ b/main/inc/lib/tracking.lib.php
@@ -8826,7 +8826,7 @@ class Tracking
                 $user->getId(),
                 $courseInfo,
                 $sessionId,
-                'lp.publicatedOn ASC',
+                null,
                 true,
                 $category->getId(),
                 false,


### PR DESCRIPTION
Dentro de Mi progreso (My progress) la tabla del listado de lecciones de un curso muestra los diferentes LPs ordenados por fecha de publicación en vez de orden de visualización.

Esto es porque main/inc/lib/tracking.lib.php invoca al constructor de LearnpathList pasandole como parámetro order_by "lp.publicatedOn ASC". En caso de que ese parametro llegase con valor nulo se establecería por defecto un order by por los campos display_order y name.

https://github.com/chamilo/chamilo-lms/blob/702672c2aa1248144580d7d6da5bc93f532902a0/main/lp/learnpathList.class.php#L69-L73

Este PR modifica el parámetro order_by con que se invoca LearnpathList  desde tracking.lib.php pasandoselo con valor nulo