### PR TITLE
Feature: Option to hide "My Progress" tab

### DIFF
--- a/main/inc/lib/banner.lib.php
+++ b/main/inc/lib/banner.lib.php
@@ -89,19 +89,22 @@ function get_tabs($courseId = null)
             $navigation['session_my_space']['key'] = 'my-space';
             $navigation['session_my_space']['icon'] = 'my-space.png';
         } else {
-            $navigation['session_my_progress']['url'] = api_get_path(WEB_CODE_PATH);
-            // Link to my progress
-            switch (api_get_setting('gamification_mode')) {
-                case 1:
-                    $navigation['session_my_progress']['url'] .= 'gamification/my_progress.php';
-                    break;
-                default:
-                    $navigation['session_my_progress']['url'] .= 'auth/my_progress.php';
-            }
+            $hideMyProgressTab = api_get_configuration_value('hide_my_progress_tab');
+            if (true !== $hideMyProgressTab) {
+                $navigation['session_my_progress']['url'] = api_get_path(WEB_CODE_PATH);
+                // Link to my progress
+                switch (api_get_setting('gamification_mode')) {
+                    case 1:
+                        $navigation['session_my_progress']['url'] .= 'gamification/my_progress.php';
+                        break;
+                    default:
+                        $navigation['session_my_progress']['url'] .= 'auth/my_progress.php';
+                }
 
-            $navigation['session_my_progress']['title'] = get_lang('MyProgress');
-            $navigation['session_my_progress']['key'] = 'my-progress';
-            $navigation['session_my_progress']['icon'] = 'my-progress.png';
+                $navigation['session_my_progress']['title'] = get_lang('MyProgress');
+                $navigation['session_my_progress']['key'] = 'my-progress';
+                $navigation['session_my_progress']['icon'] = 'my-progress.png';
+            }
         }
     }
 

--- a/main/install/configuration.dist.php
+++ b/main/install/configuration.dist.php
@@ -983,6 +983,9 @@ $_configuration['gradebook_badge_sidebar'] = [
 // Block access to any user to "my progress" page
 //$_configuration['block_my_progress_page'] = false;
 
+// Hides the "my progress" tab from the navigation menu
+//$_configuration['hide_my_progress_tab'] = false;
+
 // Add user extra fields in report: main/mySpace/exercise_category_report.php
 //$_configuration['exercise_category_report_user_extra_fields'] = ['fields' => ['skype', 'rssfeeds']];
 


### PR DESCRIPTION
This pull request adds a new option to configuration.php, 'hide_my_progress_tab', allowing the 'My Progress' tab to be hidden from the navigation bar:

**$_configuration['hide_my_progress_tab'] = false;**

![hide_false](https://github.com/chamilo/chamilo-lms/assets/93096561/c68706a7-6433-4c58-8dca-4f80561c91df)


**$_configuration['hide_my_progress_tab'] = true;**

![hide_true](https://github.com/chamilo/chamilo-lms/assets/93096561/282f1b5a-01d8-4276-9b90-f75fa58d7fff)




