### PR TITLE
Exception in return from 'getToolVisibility' if the tool is not found for a session

### DIFF
--- a/main/inc/lib/course_home.lib.php
+++ b/main/inc/lib/course_home.lib.php
@@ -1866,6 +1866,7 @@ class CourseHome
             );
         }
 
+        $visibility = false;
         if ($tool) {
             $visibility = $tool->getVisibility();
         }


### PR DESCRIPTION
It is possible to have sessions in which the visibility of the 'document' tool (or any other) is not set in the c_tool table. However, there will still be a record for the base course, allowing the session to inherit this configuration without specifically creating a new record in that table. This approach works in most use cases.

However, with the CKEditor File Manager, we might encounter a problem. In course_home.lib.php.getToolVisibility($toolName, $courseId, $sessionId = 0), an exception could be thrown when opening the File Manager. This is because it checks for the 'document' tool's visibility for the session, but the $visibility variable is not initialized unless there is a corresponding record for the session in the c_tool table

https://github.com/chamilo/chamilo-lms/blob/400f7a4bedce32ddb1e62352e604c3fb15b8c399/main/inc/lib/course_home.lib.php#L1868-L1873

![error](https://github.com/chamilo/chamilo-lms/assets/93096561/cfc320af-e45e-482f-a4e5-dabee4c89640)

This pull request fixes this issue by initializing the $visibility variable to false right before the if statement
