### PR TITLE
Reports - Improvements on message tracking

### DIFF
--- a/main/inc/lib/message.lib.php
+++ b/main/inc/lib/message.lib.php
@@ -3073,7 +3073,7 @@ class MessageManager
                  WHERE user_receiver_id = $userId" .
                  ($startDate ? " AND send_date >= '$startDate'" : "") .
                  ($endDate ? " AND send_date <= '$endDate'" : "") .
-               "UNION
+               " UNION
                SELECT DISTINCT user_receiver_id
                  FROM $messagesTable
                  WHERE user_sender_id = $userId" .

--- a/main/inc/lib/message.lib.php
+++ b/main/inc/lib/message.lib.php
@@ -3048,6 +3048,57 @@ class MessageManager
     }
 
     /**
+     * Retrieves a list of users with whom the specified user has exchanged messages within an optional date range.
+     *
+     * @param   int         $userId The user ID for whom to retrieve message exchange.
+     * @param   string|null $startDate Start date to filter the messages (optional).
+     * @param   string|null $endDate End date to filter the messages (optional).
+     *
+     * @return array Array of user information for each user with whom the specified user has exchanged messages.
+     */
+    public static function getMessageExchangeWithUser($userId, $startDate = null, $endDate = null)
+    {
+        $messagesTable = Database::get_main_table(TABLE_MESSAGE);
+        $userId = (int) $userId;
+
+        if ($startDate !== null) {
+            $startDate = Database::escape_string($startDate);
+        }
+        if ($endDate !== null) {
+            $endDate = Database::escape_string($endDate);
+        }
+
+        $sql = "SELECT DISTINCT user_sender_id AS user_id
+                 FROM $messagesTable
+                 WHERE user_receiver_id = $userId" .
+                 ($startDate ? " AND send_date >= '$startDate'" : "") .
+                 ($endDate ? " AND send_date <= '$endDate'" : "") .
+               "UNION
+               SELECT DISTINCT user_receiver_id
+                 FROM $messagesTable
+                 WHERE user_sender_id = $userId" .
+                 ($startDate ? " AND send_date >= '$startDate'" : "") .
+                 ($endDate ? " AND send_date <= '$endDate'" : "");
+
+        $result = Database::query($sql);
+        $users = Database::store_result($result);
+
+        $userList = [];
+        foreach ($users as $userData) {
+            $userId = $userData['user_id'];
+            if (empty($userId)) {
+                continue;
+            }
+            $userInfo = api_get_user_info($userId);
+            if ($userInfo) {
+                $userList[$userId] = $userInfo;
+            }
+        }
+
+        return $userList;
+    }
+
+    /**
      * @param int      $userId
      * @param int      $otherUserId
      * @param datetime $startDate

--- a/main/mySpace/myStudents.php
+++ b/main/mySpace/myStudents.php
@@ -2406,7 +2406,7 @@ if ($allow && (api_is_drh() || api_is_platform_admin())) {
     } else {
         $users = MessageManager::getUsersThatHadConversationWithUser($student_id);
     }
-    $users = MessageManager::getUsersThatHadConversationWithUser($student_id);
+
     echo Display::page_subheader2(get_lang('MessageTracking'));
 
     $table = new HTML_Table(['class' => 'table']);

--- a/main/mySpace/myStudents.php
+++ b/main/mySpace/myStudents.php
@@ -2402,9 +2402,9 @@ if (!empty($sessionId)) {
 $allow = api_get_configuration_value('allow_user_message_tracking');
 if ($allow && (api_is_drh() || api_is_platform_admin())) {
     if ($filterMessages) {
-        $users = MessageManager::getUsersThatHadConversationWithUser($student_id, $coachAccessStartDate, $coachAccessEndDate);
+        $users = MessageManager::getMessageExchangeWithUser($student_id, $coachAccessStartDate, $coachAccessEndDate);
     } else {
-        $users = MessageManager::getUsersThatHadConversationWithUser($student_id);
+        $users = MessageManager::getMessageExchangeWithUser($student_id);
     }
 
     echo Display::page_subheader2(get_lang('MessageTracking'));


### PR DESCRIPTION
Currently, tracking messages from the user report would only indicate cases when the user receives a message, not when the user sends a message, since it is assumed by default that a sent message will be answered, but this is not always the case. If we want to fully track, we must include those sent messages.

![image](https://github.com/chamilo/chamilo-lms/assets/93096561/36a6b3b6-c27c-405a-9262-6b618dc5dc03)

We created a new method (getMessageExchangeWithUser) in main/inc/lib/message.lib.php to obtain both the users from whom they have received messages and to whom they have sent messages and we modified the loading of this data in main/mySpace/myStudents.php.

On the other hand, a bug was identified where the message load is duplicated:

https://github.com/chamilo/chamilo-lms/blob/5041118ba52005fa85c47da68335c1503681429c/main/mySpace/myStudents.php#L2404-L2409