### PR TITLE
Enhance usability: Display advanced params options in questions editor by default

### DIFF
--- a/main/exercise/question.class.php
+++ b/main/exercise/question.class.php
@@ -1791,7 +1791,9 @@ abstract class Question
         }
 
         $form->addButtonAdvancedSettings('advanced_params');
-        $form->addHtml('<div id="advanced_params_options" style="display:none">');
+
+        $displayAdvancedParamsOptions = api_get_configuration_value('quiz_question_edit_open_advanced_params_by_default') ? 'block' : 'none';
+        $form->addHtml('<div id="advanced_params_options" style="display:'.$displayAdvancedParamsOptions.'">');
 
         if (isset($zoomOptions['options'])) {
             $form->addElement('text', 'imageZoom', get_lang('ImageURL'));

--- a/main/install/configuration.dist.php
+++ b/main/install/configuration.dist.php
@@ -746,6 +746,8 @@ $_configuration['send_all_emails_to'] = [
 // If questions are reused between courses only deletes the non-reused questions
 // or reused questions where the quiz has the lowest iid value from c_quiz_rel_question
 // $_configuration['quiz_question_delete_automatically_when_deleting_exercise'] = false;
+// Opens advanced parameters options by default when creating or editing quiz questions
+//$_configuration['quiz_question_edit_open_advanced_params_by_default'] = false;
 // Define how many seconds an AJAX request should be started to avoid loss of connection.
 //$_configuration['quiz_keep_alive_ping_interval'] = 0;
 // Hide search form in session list


### PR DESCRIPTION
This pull request adds a new option in configuration.php that allows for displaying advanced option parameters by default when editing or creating a question for the quiz.

If the parameter "quiz_question_edit_open_advanced_params_by_default" is not set, the question editor will behave as it currently does. If it is true, the advanced options will be opened by default when entering the editor."



**Advanced params hidden (default behavior or quiz_question_edit_open_advanced_params_by_default not set or false):**
![image](https://github.com/chamilo/chamilo-lms/assets/93096561/03f7a42a-5f54-4fe6-b1f6-6b548ea603ea)





**Advanced params displayed (quiz_question_edit_open_advanced_params_by_default is true):**
![image](https://github.com/chamilo/chamilo-lms/assets/93096561/430edc83-df95-4985-8c60-1f2e27c81b35)




