### PR TITLE
[C2] Tinymce problems in development

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,10 +155,14 @@ Load the (your-domain)/main/install/index.php URL to start the installer (which 
 If the installer is pure-HTML and doesn't appear with a clean layout, that's because you didn't follow these instructions carefully.
 Go back to the beginning of this section and try again.
 
-If you want hot reloading for assets use the command `yarn run encore dev-server`. This will refresh automatically
-your assets when you modify them under `assets/vue`. Access your chamilo instance as usual. In the background, this will serve
+If you want hot reloading for assets, use the command `yarn dev-server`\*. This will refresh automatically
+your assets when you modify them under `assets/vue`. Access your Chamilo instance as usual. In the background, this will serve
 assets from a custom server on http://localhost:8080. Do not access this url directly since
 [Encore](https://symfony.com/doc/current/frontend.html#webpack-encore) is in charge of changing url assets as needed.
+
+\* This will not show tinymce WYSIWYG editors because this third party plugin is not configured to take assets from localhost:8080 and thus,
+they will not work. If you plan to work with the editor, the only option is to use `yarn watch`. This command will compile all assets when you
+modify something, but you will need to refresh the browser window to see the changes.
 
 ### Supporting PHP 7.4 and 8.1 in parallel
 

--- a/assets/vue/components/basecomponents/BaseTinyEditor.vue
+++ b/assets/vue/components/basecomponents/BaseTinyEditor.vue
@@ -173,6 +173,7 @@ const defaultEditorConfig = {
 
 if (props.fullPage) {
   defaultEditorConfig.plugins.push("fullpage")
+  defaultEditorConfig.toolbar += " | fullpage"
 }
 
 const editorConfig = computed(() => ({


### PR DESCRIPTION
Modify documentation about how to run development Vue server in a corner case when dev-server cannot be used. 
Enable fullpage plugin of tinymce in toolbar options, otherwise this plugin will not be shown to the user.

@AngelFQC using the command dev-server the plugin TiniMCE still make the request to the server with the default url instead of using http://localhost:8000. 

For now, I documented this case because I think this will need to be addressed in encore, and I'm not sure is solvable.

Do you have any idea if encore could change the request made by the plugin? (The requests that are failing in development are the ones made to load the skins CSS of TinyMCE, they are loaded from the script Editor.js that I think lives in the plugin)

These are the lines where we tell encore to load these files from server, and using dev-server the new url serving the assets is not taken into account
```
Encore.copyFiles({
  from: "./node_modules/tinymce/skins",
  to: "libs/tinymce/skins/[path][name].[ext]",
})
```