### PR TITLE
Enhance usability: Display quiz question description by default

### DIFF
--- a/main/exercise/exercise_submit.php
+++ b/main/exercise/exercise_submit.php
@@ -1728,6 +1728,8 @@ foreach ($questionList as $questionId) {
         $remind_highlight = ' remind_highlight ';
     }
 
+    $openDescription = api_get_configuration_value('quiz_question_description_open_by_default') ? true : false;
+
     // Showing the exercise description
     if (!empty($objExercise->description)) {
         if ($objExercise->type == ONE_PER_PAGE || ($objExercise->type != ONE_PER_PAGE && $i == 1)) {
@@ -1738,7 +1740,7 @@ foreach ($questionList as $questionId) {
                 [],
                 'description',
                 'exercise-collapse',
-                false,
+                $openDescription,
                 true
             );
         }

--- a/main/install/configuration.dist.php
+++ b/main/install/configuration.dist.php
@@ -746,6 +746,8 @@ $_configuration['send_all_emails_to'] = [
 // If questions are reused between courses only deletes the non-reused questions
 // or reused questions where the quiz has the lowest iid value from c_quiz_rel_question
 // $_configuration['quiz_question_delete_automatically_when_deleting_exercise'] = false;
+// Opens the quiz question description by default
+//$_configuration['quiz_question_description_open_by_default'] = false;
 // Define how many seconds an AJAX request should be started to avoid loss of connection.
 //$_configuration['quiz_keep_alive_ping_interval'] = 0;
 // Hide search form in session list


### PR DESCRIPTION
This pull request adds a new option in configuration.php that to allow the question description block be expanded by default.

If the parameter "quiz_question_description_open_by_default" is not set, the question description will behave as it currently does. If it is true, the description will be opened by default.

**Description hidden (default behavior or quiz_question_description_open_by_default not set or false):**
![image](https://github.com/chamilo/chamilo-lms/assets/93096561/fee8fa43-37a7-4c78-a621-98a77c787752)

**Description  displayed (quiz_question_description_open_by_default is true):**
![image](https://github.com/chamilo/chamilo-lms/assets/93096561/484d51c9-36b0-4b71-aebb-b3c3694b3868)
