### PR TITLE
Gh 5341 save colors with name

### DIFF
--- a/assets/vue/components/basecomponents/BaseColorPicker.vue
+++ b/assets/vue/components/basecomponents/BaseColorPicker.vue
@@ -5,11 +5,12 @@
       <ColorPicker
         format="hex"
         :model-value="hexColor"
+        class="w-11"
         @update:model-value="colorPicked"
       />
       <BaseInputText
         label=""
-        class="max-w-32"
+        class="w-32"
         input-class="mb-0"
         :model-value="hexColor"
         :error-text="inputHexError"
@@ -24,7 +25,10 @@
     >
       {{ error }}
     </small>
-    <div v-else class="h-4"></div>
+    <div
+      v-else
+      class="h-4"
+    ></div>
   </div>
 </template>
 

--- a/assets/vue/components/basecomponents/BaseRadioButtons.vue
+++ b/assets/vue/components/basecomponents/BaseRadioButtons.vue
@@ -8,7 +8,7 @@
         :name="name"
         :value="option.value"
       />
-      <label :for="name + index" class="ml-2 cursor-pointer">{{ option.label }}</label>
+      <label :for="`${name}-${index}`" class="ml-2 cursor-pointer">{{ option.label }}</label>
     </div>
   </div>
 </template>

--- a/assets/vue/components/basecomponents/BaseSelect.vue
+++ b/assets/vue/components/basecomponents/BaseSelect.vue
@@ -7,6 +7,7 @@
         :options="realOptions"
         :option-label="optionLabel"
         :option-value="optionValue"
+        :loading="isLoading"
         placeholder="--"
         @update:model-value="emit('update:modelValue', $event)"
       >
@@ -61,6 +62,10 @@ const props = defineProps({
   hastEmptyValue: {
     type: Boolean,
     default: false
+  },
+  isLoading: {
+    type: Boolean,
+    default: false,
   }
 })
 

--- a/assets/vue/components/basecomponents/BaseSelect.vue
+++ b/assets/vue/components/basecomponents/BaseSelect.vue
@@ -13,19 +13,23 @@
       >
         <template #emptyfilter>--</template>
         <template #empty>
-          <p class="pt-2 px-2">{{ t('No available options') }}</p>
+          <p class="pt-2 px-2">{{ t("No available options") }}</p>
         </template>
       </Dropdown>
-      <label v-t="label" :class="{ 'p-error': isInvalid }" :for="id" />
+      <label
+        v-t="label"
+        :class="{ 'p-error': isInvalid }"
+        :for="id"
+      />
     </div>
   </div>
 </template>
 
 <script setup>
-import {useI18n} from "vue-i18n";
-import {computed} from "vue";
+import { useI18n } from "vue-i18n"
+import { computed } from "vue"
 
-const {t} = useI18n()
+const { t } = useI18n()
 
 const props = defineProps({
   id: {
@@ -61,12 +65,12 @@ const props = defineProps({
   },
   hastEmptyValue: {
     type: Boolean,
-    default: false
+    default: false,
   },
   isLoading: {
     type: Boolean,
     default: false,
-  }
+  },
 })
 
 const emit = defineEmits(["update:modelValue"])
@@ -77,12 +81,8 @@ const realOptions = computed(() => {
       [props.optionLabel]: "--",
       [props.optionValue]: "",
     }
-    return [
-      emptyValue,
-      ...props.options,
-    ]
+    return [emptyValue, ...props.options]
   }
   return props.options
 })
-
 </script>

--- a/assets/vue/composables/theme.js
+++ b/assets/vue/composables/theme.js
@@ -41,6 +41,16 @@ export const useTheme = () => {
     return colorsPlainObject
   }
 
+  const setColors = (colorsObj) => {
+    for (const key in colorsObj) {
+      if (colors[key] === undefined || colors[key] === null) {
+        console.error(`Color with key ${key} is on color set`)
+        continue
+      }
+      colors[key].value = colorFromCSSVariable(colorsObj[key])
+    }
+  }
+
   const colorToCSSVariable = (color) => {
     // according to documentation https://developer.mozilla.org/en-US/docs/Web/CSS/color_value/rgb#syntax
     // the format "r g b" should work but because how rules in css are defined does not
@@ -58,5 +68,6 @@ export const useTheme = () => {
   return {
     getColorTheme,
     getColors,
+    setColors,
   }
 }

--- a/assets/vue/services/colorThemeService.js
+++ b/assets/vue/services/colorThemeService.js
@@ -1,0 +1,33 @@
+import baseService from "./baseService"
+
+const url = "/api/color_themes"
+
+/**
+ * Gets the color themes
+ *
+ * @returns {Promise<Array>}
+ */
+async function getThemes() {
+  let results = await baseService.get(url)
+  return results["hydra:member"]
+}
+
+/**
+ * Update or create a theme with the title
+ *
+ * @param {string} title
+ * @param {Object} colors
+ * @returns {Promise<Object>}
+ */
+async function updateTheme(title, colors) {
+  await baseService.post(url, {
+    title: title,
+    variables: colors,
+    active: true,
+  })
+}
+
+export default {
+  getThemes,
+  updateTheme,
+}

--- a/assets/vue/views/admin/AdminConfigureColors.vue
+++ b/assets/vue/views/admin/AdminConfigureColors.vue
@@ -1,378 +1,410 @@
 <template class="personal-theme">
-  <h4 class="mb-4">{{ t("Configure chamilo colors") }}</h4>
+  <div class="flex flex-col md:flex-row gap-5">
+    <div>
+      <h4 class="mb-4">{{ t("Configure chamilo colors") }}</h4>
 
-  <!-- Advanced mode -->
-  <div v-show="isAdvancedMode">
-    <div class="flex flex-col gap-2 mb-3 md:grid md:grid-cols-2 xl:grid-cols-4">
-      <BaseColorPicker
-        v-model="colorPrimary"
-        :label="t('Primary color')"
-      />
-      <BaseColorPicker
-        v-model="colorPrimaryGradient"
-        :label="t('Primary color hover/background')"
-      />
-      <BaseColorPicker
-        v-model="colorPrimaryButtonText"
-        :error="colorPrimaryButtonTextError"
-        :label="t('Primary color button text')"
-      />
-      <BaseColorPicker
-        v-model="colorPrimaryButtonAlternativeText"
-        :error="colorPrimaryButtonAlternativeTextError"
-        :label="t('Primary color button alternative text')"
-      />
-    </div>
+      <!-- Advanced mode -->
+      <div v-show="isAdvancedMode">
+        <div
+          class="flex flex-col gap-2 mb-3 items-start md:items-end md:grid md:grid-cols-1 lg:grid-cols-2 xl:grid-cols-3"
+        >
+          <BaseColorPicker
+            v-model="colorPrimary"
+            :label="t('Primary color')"
+          />
+          <BaseColorPicker
+            v-model="colorPrimaryGradient"
+            :label="t('Primary color hover/background')"
+          />
+          <BaseColorPicker
+            v-model="colorPrimaryButtonText"
+            :error="colorPrimaryButtonTextError"
+            :label="t('Primary color button text')"
+          />
+          <BaseColorPicker
+            v-model="colorPrimaryButtonAlternativeText"
+            :error="colorPrimaryButtonAlternativeTextError"
+            :label="t('Primary color button alternative text')"
+          />
+        </div>
 
-    <div class="flex flex-col gap-2 mb-3 md:grid md:grid-cols-2 xl:grid-cols-4">
-      <BaseColorPicker
-        v-model="colorSecondary"
-        :label="t('Secondary color')"
-      />
-      <BaseColorPicker
-        v-model="colorSecondaryGradient"
-        :label="t('Secondary color hover/background')"
-      />
-      <BaseColorPicker
-        v-model="colorSecondaryButtonText"
-        :error="colorSecondaryButtonTextError"
-        :label="t('Secondary color button text')"
-      />
-    </div>
+        <div
+          class="flex flex-col gap-2 mb-3 items-start md:items-end md:grid md:grid-cols-1 lg:grid-cols-2 xl:grid-cols-3"
+        >
+          <BaseColorPicker
+            v-model="colorSecondary"
+            :label="t('Secondary color')"
+          />
+          <BaseColorPicker
+            v-model="colorSecondaryGradient"
+            :label="t('Secondary color hover/background')"
+          />
+          <BaseColorPicker
+            v-model="colorSecondaryButtonText"
+            :error="colorSecondaryButtonTextError"
+            :label="t('Secondary color button text')"
+          />
+        </div>
 
-    <div class="flex flex-col gap-2 mb-3 md:grid md:grid-cols-2 xl:grid-cols-4">
-      <BaseColorPicker
-        v-model="colorTertiary"
-        :label="t('Tertiary color')"
-      />
-      <BaseColorPicker
-        v-model="colorTertiaryGradient"
-        :label="t('Tertiary color hover/background')"
-      />
-    </div>
+        <div
+          class="flex flex-col gap-2 mb-3 items-start md:items-end md:grid md:grid-cols-1 lg:grid-cols-2 xl:grid-cols-3"
+        >
+          <BaseColorPicker
+            v-model="colorTertiary"
+            :label="t('Tertiary color')"
+          />
+          <BaseColorPicker
+            v-model="colorTertiaryGradient"
+            :label="t('Tertiary color hover/background')"
+          />
+        </div>
 
-    <div class="flex flex-col gap-2 mb-3 md:grid md:grid-cols-2 xl:grid-cols-4">
-      <BaseColorPicker
-        v-model="colorSuccess"
-        :label="t('Success color')"
-      />
-      <BaseColorPicker
-        v-model="colorSuccessGradient"
-        :label="t('Success color hover/background')"
-      />
-      <BaseColorPicker
-        v-model="colorSuccessButtonText"
-        :error="colorSuccessButtonTextError"
-        :label="t('Success color button text')"
-      />
-    </div>
+        <div
+          class="flex flex-col gap-2 mb-3 items-start md:items-end md:grid md:grid-cols-1 lg:grid-cols-2 xl:grid-cols-3"
+        >
+          <BaseColorPicker
+            v-model="colorSuccess"
+            :label="t('Success color')"
+          />
+          <BaseColorPicker
+            v-model="colorSuccessGradient"
+            :label="t('Success color hover/background')"
+          />
+          <BaseColorPicker
+            v-model="colorSuccessButtonText"
+            :error="colorSuccessButtonTextError"
+            :label="t('Success color button text')"
+          />
+        </div>
 
-    <div class="flex flex-col gap-2 mb-3 md:grid md:grid-cols-2 xl:grid-cols-4">
-      <BaseColorPicker
-        v-model="colorInfo"
-        :label="t('Info color')"
-      />
-      <BaseColorPicker
-        v-model="colorInfoGradient"
-        :label="t('Info color hover/background')"
-      />
-      <BaseColorPicker
-        v-model="colorInfoButtonText"
-        :error="colorInfoButtonTextError"
-        :label="t('Info color button text')"
-      />
-    </div>
+        <div
+          class="flex flex-col gap-2 mb-3 items-start md:items-end md:grid md:grid-cols-1 lg:grid-cols-2 xl:grid-cols-3"
+        >
+          <BaseColorPicker
+            v-model="colorInfo"
+            :label="t('Info color')"
+          />
+          <BaseColorPicker
+            v-model="colorInfoGradient"
+            :label="t('Info color hover/background')"
+          />
+          <BaseColorPicker
+            v-model="colorInfoButtonText"
+            :error="colorInfoButtonTextError"
+            :label="t('Info color button text')"
+          />
+        </div>
 
-    <div class="flex flex-col gap-2 mb-3 md:grid md:grid-cols-2 xl:grid-cols-4">
-      <BaseColorPicker
-        v-model="colorWarning"
-        :label="t('Warning color')"
-      />
-      <BaseColorPicker
-        v-model="colorWarningGradient"
-        :label="t('Warning color hover/background')"
-      />
-      <BaseColorPicker
-        v-model="colorWarningButtonText"
-        :error="colorWarningButtonTextError"
-        :label="t('Warning color button text')"
-      />
-    </div>
+        <div
+          class="flex flex-col gap-2 mb-3 items-start md:items-end md:grid md:grid-cols-1 lg:grid-cols-2 xl:grid-cols-3"
+        >
+          <BaseColorPicker
+            v-model="colorWarning"
+            :label="t('Warning color')"
+          />
+          <BaseColorPicker
+            v-model="colorWarningGradient"
+            :label="t('Warning color hover/background')"
+          />
+          <BaseColorPicker
+            v-model="colorWarningButtonText"
+            :error="colorWarningButtonTextError"
+            :label="t('Warning color button text')"
+          />
+        </div>
 
-    <div class="flex flex-col gap-2 mb-3 md:grid md:grid-cols-2 xl:grid-cols-4">
-      <BaseColorPicker
-        v-model="colorDanger"
-        :label="t('Danger color')"
-      />
-      <BaseColorPicker
-        v-model="colorDangerGradient"
-        :label="t('Danger color hover/background')"
-      />
-    </div>
+        <div
+          class="flex flex-col gap-2 mb-3 items-start md:items-end md:grid md:grid-cols-1 lg:grid-cols-2 xl:grid-cols-3"
+        >
+          <BaseColorPicker
+            v-model="colorDanger"
+            :label="t('Danger color')"
+          />
+          <BaseColorPicker
+            v-model="colorDangerGradient"
+            :label="t('Danger color hover/background')"
+          />
+        </div>
 
-    <div class="flex flex-col gap-2 mb-3 md:grid md:grid-cols-2 xl:grid-cols-4">
-      <BaseColorPicker
-        v-model="formColor"
-        :label="t('Form outline color')"
-      />
-    </div>
-  </div>
+        <div
+          class="flex flex-col gap-2 mb-3 items-start md:items-end md:grid md:grid-cols-1 lg:grid-cols-2 xl:grid-cols-3"
+        >
+          <BaseColorPicker
+            v-model="formColor"
+            :label="t('Form outline color')"
+          />
+        </div>
+      </div>
 
-  <!-- Simple mode -->
-  <div v-show="!isAdvancedMode">
-    <div class="flex flex-col gap-2 mb-3 md:grid md:grid-cols-2 xl:grid-cols-4">
-      <BaseColorPicker
-        v-model="colorPrimary"
-        :label="t('Primary color')"
-      />
-      <BaseColorPicker
-        v-model="colorSecondary"
-        :label="t('Secondary color')"
-      />
-      <BaseColorPicker
-        v-model="colorTertiary"
-        :label="t('Tertiary color')"
-      />
-    </div>
+      <!-- Simple mode -->
+      <div v-show="!isAdvancedMode">
+        <div
+          class="flex flex-col gap-2 mb-3 items-start md:items-end md:grid md:grid-cols-1 lg:grid-cols-2 xl:grid-cols-3"
+        >
+          <BaseColorPicker
+            v-model="colorPrimary"
+            :label="t('Primary color')"
+          />
+          <BaseColorPicker
+            v-model="colorSecondary"
+            :label="t('Secondary color')"
+          />
+          <BaseColorPicker
+            v-model="colorTertiary"
+            :label="t('Tertiary color')"
+          />
+        </div>
 
-    <div class="flex flex-col gap-2 mb-3 md:grid md:grid-cols-2 xl:grid-cols-4">
-      <BaseColorPicker
-        v-model="colorSuccess"
-        :label="t('Success color')"
-      />
-      <BaseColorPicker
-        v-model="colorInfo"
-        :label="t('Info color')"
-      />
-      <BaseColorPicker
-        v-model="colorWarning"
-        :label="t('Warning color')"
-      />
-      <BaseColorPicker
-        v-model="colorDanger"
-        :label="t('Danger color')"
-      />
-    </div>
+        <div
+          class="flex flex-col gap-2 mb-3 items-start md:items-end md:grid md:grid-cols-1 lg:grid-cols-2 xl:grid-cols-3"
+        >
+          <BaseColorPicker
+            v-model="colorSuccess"
+            :label="t('Success color')"
+          />
+          <BaseColorPicker
+            v-model="colorInfo"
+            :label="t('Info color')"
+          />
+          <BaseColorPicker
+            v-model="colorWarning"
+            :label="t('Warning color')"
+          />
+          <BaseColorPicker
+            v-model="colorDanger"
+            :label="t('Danger color')"
+          />
+        </div>
 
-    <div class="flex flex-col gap-2 mb-3 md:grid md:grid-cols-2 xl:grid-cols-4">
-      <BaseColorPicker
-        v-model="formColor"
-        :label="t('Form outline color')"
-      />
-    </div>
-  </div>
+        <div
+          class="flex flex-col gap-2 mb-3 items-start md:items-end md:grid md:grid-cols-1 lg:grid-cols-2 xl:grid-cols-3"
+        >
+          <BaseColorPicker
+            v-model="formColor"
+            :label="t('Form outline color')"
+          />
+        </div>
+      </div>
 
-  <div class="flex flex-wrap mb-4 gap-3">
-    <BaseButton
-      :label="t('Save')"
-      icon="send"
-      type="primary"
-      @click="saveColors"
-    />
-    <BaseButton
-      :label="isAdvancedMode ? t('Hide advanced mode') : t('Show advanced mode')"
-      icon="cog"
-      type="black"
-      @click="isAdvancedMode = !isAdvancedMode"
-    />
-  </div>
-
-  <hr />
-  <h5 class="mb-4">{{ t("You can see examples of how chamilo will look here") }}</h5>
-
-  <div class="mb-4">
-    <p class="mb-3 text-lg">{{ t("Buttons") }}</p>
-    <div class="flex flex-row flex-wrap mb-3">
-      <BaseButton
-        :label="t('Primary')"
-        class="mr-2 mb-2"
-        icon="eye-on"
-        type="primary"
-      />
-      <BaseButton
-        :label="t('Primary alternative')"
-        class="mr-2 mb-2"
-        icon="eye-on"
-        type="primary-alternative"
-      />
-      <BaseButton
-        :label="t('Secondary')"
-        class="mr-2 mb-2"
-        icon="eye-on"
-        type="secondary"
-      />
-      <BaseButton
-        :label="t('Tertiary')"
-        class="mr-2 mb-2"
-        icon="eye-on"
-        type="black"
-      />
-    </div>
-    <div class="flex flex-row flex-wrap mb-3">
-      <BaseButton
-        :label="t('Success')"
-        class="mr-2 mb-2"
-        icon="send"
-        type="success"
-      />
-      <BaseButton
-        :label="t('Info')"
-        class="mr-2 mb-2"
-        icon="send"
-        type="info"
-      />
-      <BaseButton
-        :label="t('Warning')"
-        class="mr-2 mb-2"
-        icon="send"
-        type="warning"
-      />
-      <BaseButton
-        :label="t('Danger')"
-        class="mr-2 mb-2"
-        icon="delete"
-        type="danger"
-      />
-    </div>
-    <div class="flex flex-row flex-wrap mb-3">
-      <BaseButton
-        :label="t('Disabled')"
-        class="mr-2 mb-2"
-        disabled
-        icon="eye-on"
-        type="primary"
-      />
-      <BaseButton
-        class="mr-2 mb-2"
-        icon="cog"
-        only-icon
-        type="primary"
-      />
-    </div>
-  </div>
-
-  <div class="mb-4">
-    <p class="mb-3 text-lg">{{ t("Dropdowns") }}</p>
-    <div class="flex flex-row gap-3">
-      <BaseButton
-        class="mr-3 mb-2"
-        icon="cog"
-        only-icon
-        popup-identifier="menu"
-        type="primary"
-        @click="toggle"
-      />
-      <BaseMenu
-        id="menu"
-        ref="menu"
-        :model="menuItems"
-      />
-      <BaseDropdown
-        v-model="dropdown"
-        :label="t('Dropdown')"
-        :options="[
-          {
-            label: t('Option 1'),
-            value: 'option_1',
-          },
-          {
-            label: t('Option 2'),
-            value: 'option_2',
-          },
-          {
-            label: t('Option 3'),
-            value: 'option_3',
-          },
-        ]"
-        class="w-36"
-        input-id="dropdown"
-        name="dropdown"
-        option-label="label"
-        option-value="value"
-      />
-    </div>
-  </div>
-
-  <div class="mb-4">
-    <p class="mb-3 text-lg">{{ t("Checkbox and radio buttons") }}</p>
-    <BaseCheckbox
-      id="check1"
-      v-model="checkbox1"
-      :label="t('Checkbox 1')"
-      name="checkbox1"
-    />
-    <BaseCheckbox
-      id="check2"
-      v-model="checkbox2"
-      :label="t('Checkbox 2')"
-      name="checkbox2"
-    />
-    <div class="mb-2"></div>
-    <BaseRadioButtons
-      v-model="radioValue"
-      :initial-value="radioValue"
-      :options="radioButtons"
-      name="radio"
-    />
-  </div>
-
-  <div class="mb-4">
-    <p class="mb-3 text-lg">{{ t("Toggle") }}</p>
-    <BaseToggleButton
-      :model-value="toggleState"
-      :off-label="t('Show all')"
-      :on-label="t('Hide all')"
-      off-icon="eye-on"
-      on-icon="eye-off"
-      size="normal"
-      without-borders
-      @update:model-value="toggleState = !toggleState"
-    />
-  </div>
-
-  <div class="mb-4">
-    <p class="mb-3 text-lg">{{ t("Forms") }}</p>
-    <BaseInputText
-      :label="t('This is the default form')"
-      :model-value="null"
-    />
-    <BaseInputText
-      :is-invalid="true"
-      :label="t('This is a form with an error')"
-      :model-value="null"
-    />
-    <BaseInputDate
-      id="date"
-      :label="t('Date')"
-      class="w-32"
-    />
-  </div>
-
-  <div class="mb-4">
-    <p class="mb-3 text-lg">{{ t("Dialogs") }}</p>
-    <BaseButton
-      :label="t('Show dialog')"
-      icon="eye-on"
-      type="black"
-      @click="isDialogVisible = true"
-    />
-    <BaseDialogConfirmCancel
-      :is-visible="isDialogVisible"
-      :title="t('Dialog example')"
-      @confirm-clicked="isDialogVisible = false"
-      @cancel-clicked="isDialogVisible = false"
-    />
-  </div>
-  <div class="mb-4">
-    <p class="mb-3 text-lg">{{ t("Some more elements") }}</p>
-    <div class="course-tool cursor-pointer">
-      <div class="course-tool__link hover:primary-gradient hover:bg-primary-gradient/10">
-        <span
-          aria-hidden="true"
-          class="course-tool__icon mdi mdi-bookshelf"
+      <div class="flex flex-wrap mb-4 gap-3">
+        <BaseButton
+          :label="t('Save')"
+          icon="send"
+          type="primary"
+          @click="saveColors"
+        />
+        <BaseButton
+          :label="isAdvancedMode ? t('Hide advanced mode') : t('Show advanced mode')"
+          icon="cog"
+          type="black"
+          @click="isAdvancedMode = !isAdvancedMode"
         />
       </div>
-      <p class="course-tool__title">{{ t("Documents") }}</p>
+    </div>
+
+    <div class="bg-gray-20 h-0.5 md:h-auto md:w-0.5" />
+
+    <div>
+      <h6 class="mb-4">{{ t("You can see examples of how chamilo will look here") }}</h6>
+
+      <div class="mb-4">
+        <p class="mb-3 text-lg">{{ t("Buttons") }}</p>
+        <div class="flex flex-row flex-wrap mb-3">
+          <BaseButton
+            :label="t('Primary')"
+            class="mr-2 mb-2"
+            icon="eye-on"
+            type="primary"
+          />
+          <BaseButton
+            :label="t('Primary alternative')"
+            class="mr-2 mb-2"
+            icon="eye-on"
+            type="primary-alternative"
+          />
+          <BaseButton
+            :label="t('Secondary')"
+            class="mr-2 mb-2"
+            icon="eye-on"
+            type="secondary"
+          />
+          <BaseButton
+            :label="t('Tertiary')"
+            class="mr-2 mb-2"
+            icon="eye-on"
+            type="black"
+          />
+        </div>
+        <div class="flex flex-row flex-wrap mb-3">
+          <BaseButton
+            :label="t('Success')"
+            class="mr-2 mb-2"
+            icon="send"
+            type="success"
+          />
+          <BaseButton
+            :label="t('Info')"
+            class="mr-2 mb-2"
+            icon="send"
+            type="info"
+          />
+          <BaseButton
+            :label="t('Warning')"
+            class="mr-2 mb-2"
+            icon="send"
+            type="warning"
+          />
+          <BaseButton
+            :label="t('Danger')"
+            class="mr-2 mb-2"
+            icon="delete"
+            type="danger"
+          />
+        </div>
+        <div class="flex flex-row flex-wrap mb-3">
+          <BaseButton
+            :label="t('Disabled')"
+            class="mr-2 mb-2"
+            disabled
+            icon="eye-on"
+            type="primary"
+          />
+          <BaseButton
+            class="mr-2 mb-2"
+            icon="cog"
+            only-icon
+            type="primary"
+          />
+        </div>
+      </div>
+
+      <div class="mb-4">
+        <p class="mb-3 text-lg">{{ t("Dropdowns") }}</p>
+        <div class="flex flex-row gap-3">
+          <BaseButton
+            class="mr-3 mb-2"
+            icon="cog"
+            only-icon
+            popup-identifier="menu"
+            type="primary"
+            @click="toggle"
+          />
+          <BaseMenu
+            id="menu"
+            ref="menu"
+            :model="menuItems"
+          />
+          <BaseDropdown
+            v-model="dropdown"
+            :label="t('Dropdown')"
+            :options="[
+              {
+                label: t('Option 1'),
+                value: 'option_1',
+              },
+              {
+                label: t('Option 2'),
+                value: 'option_2',
+              },
+              {
+                label: t('Option 3'),
+                value: 'option_3',
+              },
+            ]"
+            class="w-36"
+            input-id="dropdown"
+            name="dropdown"
+            option-label="label"
+            option-value="value"
+          />
+        </div>
+      </div>
+
+      <div class="mb-4">
+        <p class="mb-3 text-lg">{{ t("Checkbox and radio buttons") }}</p>
+        <div class="flex flex-col md:flex-row gap-3 md:gap-5">
+          <BaseRadioButtons
+            v-model="radioValue"
+            :initial-value="radioValue"
+            :options="radioButtons"
+            name="radio"
+          />
+          <div>
+            <BaseCheckbox
+              id="check1"
+              v-model="checkbox1"
+              :label="t('Checkbox 1')"
+              name="checkbox1"
+            />
+            <BaseCheckbox
+              id="check2"
+              v-model="checkbox2"
+              :label="t('Checkbox 2')"
+              name="checkbox2"
+            />
+          </div>
+        </div>
+      </div>
+
+      <div class="mb-4">
+        <p class="mb-3 text-lg">{{ t("Toggle") }}</p>
+        <BaseToggleButton
+          :model-value="toggleState"
+          :off-label="t('Show all')"
+          :on-label="t('Hide all')"
+          off-icon="eye-on"
+          on-icon="eye-off"
+          size="normal"
+          without-borders
+          @update:model-value="toggleState = !toggleState"
+        />
+      </div>
+
+      <div class="mb-4">
+        <p class="mb-3 text-lg">{{ t("Forms") }}</p>
+        <BaseInputText
+          :label="t('This is the default form')"
+          :model-value="null"
+        />
+        <BaseInputText
+          :is-invalid="true"
+          :label="t('This is a form with an error')"
+          :model-value="null"
+        />
+        <BaseInputDate
+          id="date"
+          :label="t('Date')"
+          class="w-32"
+        />
+      </div>
+
+      <div class="mb-4">
+        <p class="mb-3 text-lg">{{ t("Dialogs") }}</p>
+        <BaseButton
+          :label="t('Show dialog')"
+          icon="eye-on"
+          type="black"
+          @click="isDialogVisible = true"
+        />
+        <BaseDialogConfirmCancel
+          :is-visible="isDialogVisible"
+          :title="t('Dialog example')"
+          @confirm-clicked="isDialogVisible = false"
+          @cancel-clicked="isDialogVisible = false"
+        />
+      </div>
+      <div class="mb-4">
+        <p class="mb-3 text-lg">{{ t("Some more elements") }}</p>
+        <div class="course-tool cursor-pointer">
+          <div class="course-tool__link hover:primary-gradient hover:bg-primary-gradient/10">
+            <span
+              aria-hidden="true"
+              class="course-tool__icon mdi mdi-bookshelf"
+            />
+          </div>
+          <p class="course-tool__title">{{ t("Documents") }}</p>
+        </div>
+      </div>
     </div>
   </div>
 </template>


### PR DESCRIPTION
Fix #5341 

Update color selection page in Chamilo

![image](https://github.com/chamilo/chamilo-lms/assets/50702276/9cd90245-9bcb-426d-90c6-f0c484386c55)


Right now, the endpoints of the backend allow storing a theme with a name. I retrieve the list of themes and show them in a selector. Change the theme a press on save, store the theme in the backend as the active theme.

The backend does not allow overriding a theme, creates a new every time.

To allow the user to define their custom theme, there are a couple of options:
1. Make a button like "Create new theme with these colors" that shows a text field to set a name and a save button
2. Edit the dropdown in place. Vue prime allows to make a field editable https://primevue.org/dropdown/#editable. The flow would be:
    * Is user select a theme, the theme changes, if the user click on save theme will be set as active.
    * If the user writes something in the field, a click on save would save the theme with the name written.

I'm not sure about the 2 one, will the user notice that the field is editable?
  
Right now there is no default theme, so the theme selector shows no option. There will be some themes in database Chamilo automatically? Or do I need to change something in the frontend to show the first theme?

 