### PR TITLE
[C2] Messages: Fix the profile image of users

### DIFF
--- a/assets/vue/components/basecomponents/BaseUserAvatar.vue
+++ b/assets/vue/components/basecomponents/BaseUserAvatar.vue
@@ -1,5 +1,11 @@
 <template>
-  <Avatar :image="`${imageUrl}?w=${imageSize}&h=${imageSize}&fit=crop`" :shape="shape" />
+  <Avatar
+    :image="`${imageUrl}?w=${imageSize}&h=${imageSize}&fit=crop`"
+    :shape="shape"
+    :size="size"
+    class="rounded-full"
+    :class="avatarClass"
+  />
 </template>
 
 <script setup>
@@ -27,14 +33,25 @@ const props = defineProps({
 });
 
 const imageSize = computed(() => {
-  if ('large' === props.size) {
-    return 56;
+  // these numbers are aproximate, they were calculated with a size
+  // that allow to see the image clear
+  if (props.size === "xlarge") {
+    return 250;
+  } else if (props.size === "large") {
+    return 125;
   }
-
-  if ('xlarge' === props.size) {
-    return 42;
-  }
-
-  return 28;
+  return 75;
 });
+
+const avatarClass = computed(() => {
+  let clazz = ""
+  if (props.size === "xlarge") {
+    clazz += "h-28 w-28 "
+  } else if (props.size === "large") {
+    clazz += "h-16 w-16 "
+  } else if (props.size === "normal") {
+    clazz += "h-10 w-10 "
+  }
+  return clazz
+})
 </script>

--- a/assets/vue/components/message/MessageLayout.vue
+++ b/assets/vue/components/message/MessageLayout.vue
@@ -16,11 +16,14 @@ import { useStore } from "vuex"
 import { useRoute } from "vue-router"
 import { onMounted, provide, readonly, ref, watch } from "vue"
 import { useSocialInfo } from "../../composables/useSocialInfo"
+import { useSecurityStore } from "../../store/securityStore"
 
 const store = useStore()
 const route = useRoute()
 
-const { user, isCurrentUser, groupInfo, isGroup, loadUser } = useSocialInfo()
+const { isCurrentUser, groupInfo, isGroup, loadUser } = useSocialInfo()
+
+const { user } = useSecurityStore()
 
 provide("social-user", user)
 provide("is-current-user", isCurrentUser)

--- a/assets/vue/components/social/UserProfileCard.vue
+++ b/assets/vue/components/social/UserProfileCard.vue
@@ -1,10 +1,10 @@
 <template>
   <BaseCard plain>
     <div class="p-4 text-center user-profile-card">
-      <img
-        :src="user.illustrationUrl"
-        alt="Profile picture"
-        class="mb-4 w-24 h-24 mx-auto rounded-full"
+      <BaseUserAvatar
+        :image-url="user.illustrationUrl"
+        :alt="t('Profile picture')"
+        size="xlarge"
       />
       <div
         v-if="visibility.firstname && visibility.lastname"
@@ -116,12 +116,14 @@ import BaseButton from "../basecomponents/BaseButton.vue"
 import { useI18n } from "vue-i18n"
 import Divider from "primevue/divider"
 import axios from "axios"
+import { useSecurityStore } from "../../store/securityStore"
+import BaseUserAvatar from "../basecomponents/BaseUserAvatar.vue"
 
 const { t } = useI18n()
 const store = useStore()
+const { isAdmin } = useSecurityStore()
 const user = inject("social-user")
 const isCurrentUser = inject("is-current-user")
-const isAdmin = ref(false)
 const extraInfo = ref([])
 const chatEnabled = ref(true)
 const isUserOnline = ref(false)
@@ -162,6 +164,4 @@ function flagIconExists(code) {
 }
 
 function chatWith(userId, completeName, isOnline, avatarSmall) {}
-
-isAdmin.value = user.value.role === "admin"
 </script>

--- a/assets/vue/views/message/MessageShow.vue
+++ b/assets/vue/views/message/MessageShow.vue
@@ -63,13 +63,12 @@
     </div>
 
     <div>
-      {{ t("From") }}
-
-      <BaseChip
+      <span class="mr-2">{{ t("From") }}</span>
+      <BaseUserAvatar
         v-if="item.sender"
-        :value="item.sender"
-        image-field="illustrationUrl"
-        label-field="username"
+        :image-url="item.sender.illustrationUrl"
+        :alt="t('Sender profile picture')"
+        class="mr-2 mb-2"
       />
       <span
         v-else
@@ -78,26 +77,24 @@
     </div>
 
     <div>
-      {{ t("To") }}
-
-      <BaseChip
+      <span class="mr-2">{{ t("To") }}</span>
+      <BaseUserAvatar
         v-for="receiver in item.receiversTo"
         :key="receiver.receiver.id"
-        :value="receiver.receiver"
-        image-field="illustrationUrl"
-        label-field="username"
+        :image-url="receiver.receiver.illustrationUrl"
+        :alt="t('Receiver profile picture')"
+        class="mr-2 mb-2"
       />
     </div>
 
     <div>
-      {{ t("Cc") }}
-
-      <BaseChip
+      <span class="mr-2">{{ t("Cc") }}</span>
+      <BaseUserAvatar
         v-for="receiver in item.receiversCc"
         :key="receiver.receiver.id"
-        :value="receiver.receiver"
-        image-field="illustrationUrl"
-        label-field="username"
+        :image-url="receiver.receiver.illustrationUrl"
+        :alt="t('Carbon copy receiver profile picture')"
+        class="mr-2 mb-2"
       />
     </div>
 
@@ -154,6 +151,7 @@ import { useFormatDate } from "../../composables/formatDate"
 import { useMessageRelUserStore } from "../../store/messageRelUserStore"
 import messageTagService from "../../services/messageTagService"
 import { useSecurityStore } from "../../store/securityStore"
+import BaseUserAvatar from "../../components/basecomponents/BaseUserAvatar.vue"
 
 const confirm = useConfirm()
 const { t } = useI18n()


### PR DESCRIPTION
* Use the component BaseUserAvatar to show images of users
* Use pinia store to get user instead of vuex (we are currently migrating to pinia)

The message screen now looks like 

![image](https://github.com/chamilo/chamilo-lms/assets/50702276/deb5a10a-1244-43cc-950a-77f7b910b9bf)

There is no design for this in figma file https://www.figma.com/file/xVjyMvmrZdlr8ZyKeoQ5n5/Dashboard?node-id=99-16149&t=kofcZkADJlifIV9C-0, at least I couldn't find it. 

So I decide to use 40x40 pictures like figma design for course cards to show the avatar of the user. This will be the normal size. For large and xlarge I selected some arbitrary values. Xlarge is the size of your profile picture on the left.