### PR TITLE
Implementation of Session Copy in User List to Enhance Usability

### DIFF
--- a/main/admin/user_list.php
+++ b/main/admin/user_list.php
@@ -66,7 +66,7 @@ if ($variables) {
 }
 
 Session::write('variables_to_show', $variablesToShow);
-
+$allowSessionCopyToClipboard = api_get_configuration_value('admin_user_list_allow_copy_to_clipboard_sessions_list');
 $htmlHeadXtra[] = '<script>
 function load_course_list (div_course,my_user_id) {
      $.ajax({
@@ -80,8 +80,30 @@ function load_course_list (div_course,my_user_id) {
             $("div#"+div_course).html(datos);
             $("div#div_"+my_user_id).attr("class","blackboard_show");
             $("div#div_"+my_user_id).attr("style","");
-        }
-    });
+    $.ajax({
+  contentType: "application/x-www-form-urlencoded",
+  beforeSend: function (myObject) {
+    $("div#" + div_session).html("<img src='.../inc/lib/javascript/indicator.gif'>");
+  },
+  type: "POST",
+  url: "$url$session.",
+  data: "user_id=" + my_user_id,
+  success: function (datos) {
+    $("div#" + div_session).html(datos);
+    $("divdiv_s_" + my_user_id).attr("class", "blackboard_show");
+    $("divdiv_s_" + my_user_id).attr("style", "");'.
+    ($allowSessionCopyToClipboard ?
+    'var textToCopy = datos.replace(/<br\s*\/?>/gi, '\n');
+    navigator.clipboard.writeText(textToCopy)
+      .then(() => {
+        console.info("Text copied to clipboard");
+      })
+      .catch(err => {
+        console.error("Error copying to clipboard: ", err);
+      });'  
+      : '')
+    .'}
+  });
 }
 
 function load_session_list(div_session, my_user_id) {

--- a/main/install/configuration.dist.php
+++ b/main/install/configuration.dist.php
@@ -2537,6 +2537,9 @@ INSERT INTO extra_field_options (field_id, option_value, display_text, priority,
 // Block session about page access for all users
 // $_configuration['session_about_block_all_access'] = false;
 
+// Enables copying the list of sessions a user is registered for to the clipboard when the 'show Sessions' button is clicked
+// $_configuration['admin_user_list_allow_copy_to_clipboard_sessions_list'] = false;
+
 // Block course about page access for all users
 // $_configuration['course_about_block_all_access'] = false;
 


### PR DESCRIPTION
The project aims to enhance functionality and usability in user management within an application by allowing administrators to easily copy the list of sessions a user is registered in. Currently, when accessing the user list and clicking on the session icon, a modal appears showing the active sessions of the selected user. 

However, this modal automatically closes when it loses focus, which can be inconvenient for administrators who need to manipulate or reference this information more extensively.

To address this, a new option will be introduced in the general configuration file (configuration.php). This option, named "admin_user_list_allow_copy_to_clipboard_sessions_list," will enable administrators to activate or deactivate the functionality of copying the session list to the clipboard. 

The option will accept boolean values, true or false, with the default being false.

In the user_list, we check the value of $allowSessionCopyToClipboard to allow copying.