### PR TITLE
Server session: New expiration notification system

### DIFF
--- a/main/inc/ajax/session_clock.ajax.php
+++ b/main/inc/ajax/session_clock.ajax.php
@@ -1,0 +1,75 @@
+<?php
+
+require_once __DIR__.'/../../../vendor/autoload.php';
+require_once __DIR__.'/../../../app/AppKernel.php';
+
+$kernel = new AppKernel('', '');
+
+// Check for 'action' parameter in the GET request
+if (isset($_GET['action'])) {
+    $action = $_GET['action'];
+
+    if ($action == 'time') {
+        // Load the Chamilo configuration
+        $alreadyInstalled = false;
+        if (file_exists($kernel->getConfigurationFile())) {
+            require_once $kernel->getConfigurationFile();
+            $alreadyInstalled = true;
+        }
+
+        // Load the API library BEFORE loading the Chamilo configuration
+        require_once $_configuration['root_sys'].'main/inc/lib/api.lib.php';
+
+        if (api_get_configuration_value('session_lifetime_controller')) {
+            // Get the session
+            session_name('ch_sid');
+            session_start();
+
+            $session = new ChamiloSession();
+
+            $endTime =  0;
+            $isExpired = false;
+            $timeLeft = -1;
+
+            $currentTime = time();
+
+            // Existing code for time action
+            if ($alreadyInstalled && api_get_user_id()) {
+                $endTime = $session->end_time();
+                $isExpired = $session->is_expired();
+            } else {
+                // Chamilo not installed or user not logged in
+                $endTime = $currentTime + 315360000; // This sets a default end time far in the future
+                $isExpired = false;
+            }
+
+            $timeLeft = $endTime - $currentTime;
+        }
+        else {
+            $endTime =  999999;
+            $isExpired = false;
+            $timeLeft = 999999;
+        }
+
+        if ($endTime > 0) {
+            echo json_encode(['sessionEndDate' => $endTime, 'sessionTimeLeft' => $timeLeft, 'sessionExpired' => $isExpired]);
+        } else {
+            http_response_code(500);
+            echo json_encode(['error' => 'Error retrieving data from the current session']);
+        }
+    } elseif ($action == 'logout') {
+        require_once __DIR__.'/../../../main/inc/global-min.inc.php';
+
+        $userId = api_get_user_id();
+        online_logout($userId, false);
+        echo json_encode(['message' => 'Logged out successfully']);
+    } else {
+        // Handle unexpected action value
+        http_response_code(400);
+        echo json_encode(['error' => 'Invalid action parameter']);
+    }
+} else {
+    // No action provided
+    http_response_code(400);
+    echo json_encode(['error' => 'No action parameter provided']);
+}

--- a/main/install/configuration.dist.php
+++ b/main/install/configuration.dist.php
@@ -2548,3 +2548,6 @@ INSERT INTO extra_field_options (field_id, option_value, display_text, priority,
 
 // Set the followinf parameter to true to activate the integration of the mathjax script in all HTML documents
 //$_configuration['mathjax_enable_script_header_in_all_HTML_document'] = false;
+
+// Set the following parameter to true to enable a session lifetime controller that notifies users that their session is about to expire
+//$_configuration['session_lifetime_controller'] = false;

--- a/main/template/default/layout/main.js.tpl
+++ b/main/template/default/layout/main.js.tpl
@@ -731,3 +731,193 @@ function copyTextToClipBoard(elementId)
     /* Copy the text inside the text field */
     document.execCommand("copy");
 }
+
+function checkSessionTime()
+{
+    fetch('/main/inc/ajax/session_clock.ajax.php?action=time')
+    .then(response => {
+        if (!response.ok) {
+            throw new Error('Server error: ' + response.statusText);
+        }
+        return response.json();
+    })
+    .then(data => {
+        if (data.sessionTimeLeft <= 0) {
+            if (!document.getElementById('session-checker-overlay')) {
+                clearInterval(sessionCounterInterval);
+
+                var counterOverlay = document.getElementById('session-count-overlay');
+                if (counterOverlay) {
+                    counterOverlay.remove();
+                }
+
+                var now = new Date();
+                var day = String(now.getDate()).padStart(2, '0');
+                var month = String(now.getMonth() + 1).padStart(2, '0');
+                var year = now.getFullYear();
+                var hour = String(now.getHours()).padStart(2, '0');
+                var minutes = String(now.getMinutes()).padStart(2, '0');
+
+                var dateTimeSessionExpired = day + '/' + month + '/' + year + ' ' + hour + ':' + minutes;
+
+                document.body.insertAdjacentHTML('afterbegin', '<div id="session-checker-overlay" style="position:fixed;top:0;left:0;width:100%;height:100%;background:rgba(0,0,0,1);display:flex;justify-content:center;align-items:center;z-index:1000;"><div id="session-checker-modal" style="background:white;padding:20px;border-radius:5px;box-shadow:0010pxrgba(0,0,0,0.5);width:35%;text-align:center;"><p style="margin-bottom:20px;">{{ 'SessionExpiredAtJS' | get_lang | escape('js')}} ' + dateTimeSessionExpired + '.</p><button class="btn btn-primary" onclick="window.location.pathname = \'/\';">OK</button></div></div>');
+            }
+        } else if (data.sessionTimeLeft <= 110) {
+            sessionRemainingSeconds = data.sessionTimeLeft - 5;
+
+            if (sessionRemainingSeconds < 0) {
+                sessionRemainingSeconds = 0;
+            }
+
+            if (!document.getElementById('session-count-overlay')) {
+                document.body.insertAdjacentHTML('afterbegin', '<div id="session-count-overlay" style="position:fixed;top:0;left:0;width:100%;height:100%;background:rgba(0,0,0,0.5);display:flex;justify-content:center;align-items:center;z-index:1000;"><div id="session-checker-modal" style="background:white;padding:20px;border-radius:5px;box-shadow:0010pxrgba(0,0,0,0.5);width:35%;text-align:center;"><p id="session-counter" style="margin-bottom:20px;">{{ 'DueToInactivityTheSessionIsGoingToCloseJS' | get_lang | escape('js')}} ' + sessionRemainingSeconds + ' {{ 'Seconds' | get_lang | escape('js')}}</p><button class="btn btn-primary" id="btn-session-extend" onclick="extendSession();">{{ 'KeepGoingJS' | get_lang | escape('js')}}</button></div></div>');
+
+                sessionCounterInterval = setInterval(updateSessionTimeCounter, 1000);
+            }
+            setTimeout(checkSessionTime, 60000);
+        } else {
+            clearInterval(sessionCounterInterval);
+
+            var counterOverlay = document.getElementById('session-count-overlay');
+            if (counterOverlay) {
+                counterOverlay.remove();
+            }
+
+            setTimeout(checkSessionTime, 60000);
+        }
+    })
+    .catch(error => console.error('Error:', error));
+}
+
+function extendSession() {
+    fetch('/main/inc/ajax/online.ajax.php')
+    .then(response => {
+        if (!response.ok) {
+            throw new Error('Server error: ' + response.statusText);
+        }
+        return response;
+    })
+    .then(data => {
+        console.log('Session extended');
+
+        clearInterval(sessionCounterInterval);
+
+        var counterOverlay = document.getElementById('session-count-overlay');
+        if (counterOverlay) {
+            counterOverlay.remove();
+        }
+    })
+    .catch(error => console.error('Error:', error));
+}
+
+function updateSessionTimeCounter() {
+    var sessionCounter = document.getElementById('session-counter');
+    if (sessionRemainingSeconds > 3) {
+        sessionCounter.innerHTML = '{{ 'DueToInactivityTheSessionIsGoingToCloseJS' | get_lang | escape('js')}} ' + sessionRemainingSeconds + ' {{ 'Seconds' | get_lang | escape('js')}}';
+        sessionRemainingSeconds--;
+    } else if (sessionRemainingSeconds <= 3 && sessionRemainingSeconds > 1) {
+        var currentUrl = window.location.href;
+        if (currentUrl.includes('lp_controller.php') && currentUrl.includes('lp_id=') && currentUrl.includes('action=view')) {
+
+            if (!sessionClosing) {
+                var btnSessionExtend = document.getElementById('btn-session-extend');
+                if (btnSessionExtend) {
+                    btnSessionExtend.remove();
+                }
+
+                document.getElementById('session-counter').innerHTML = '{{ 'SessionIsClosingJS' | get_lang | escape('js')}}';
+
+                setTimeout(function() {
+                    fetch('/main/inc/ajax/session_clock.ajax.php?action=logout')
+                    .then(response => response.json())
+                    .then(data => {
+                        if (!document.getElementById('session-checker-overlay')) {
+                            clearInterval(sessionCounterInterval);
+
+                            var counterOverlay = document.getElementById('session-count-overlay');
+                            if (counterOverlay) {
+                                counterOverlay.remove();
+                            }
+
+                            var now = new Date();
+                            var day = String(now.getDate()).padStart(2, '0');
+                            var month = String(now.getMonth() + 1).padStart(2, '0');
+                            var year = now.getFullYear();
+                            var hour = String(now.getHours()).padStart(2, '0');
+                            var minutes = String(now.getMinutes()).padStart(2, '0');
+
+                            var dateTimeSessionExpired = day + '/' + month + '/' + year + ' ' + hour + ':' + minutes;
+
+                            document.body.insertAdjacentHTML('afterbegin', '<div id="session-checker-overlay" style="position:fixed;top:0;left:0;width:100%;height:100%;background:rgba(0,0,0,1);display:flex;justify-content:center;align-items:center;z-index:1000;"><div id="session-checker-modal" style="background:white;padding:20px;border-radius:5px;box-shadow:0010pxrgba(0,0,0,0.5);width:35%;text-align:center;"><p style="margin-bottom:20px;">{{ 'SessionExpiredAtJS' | get_lang | escape('js')}} ' + dateTimeSessionExpired + '.</p><button class="btn btn-primary" onclick="window.location.pathname = \'/\';">OK</button></div></div>');
+                        }
+                    })
+                    .catch((error) => {
+                    console.error('Error:', error);
+                    });
+                }, 1000);
+
+                lastCall();
+            }
+            sessionClosing = true;
+        }
+        else {
+            if (!sessionClosing) {
+                var btnSessionExtend = document.getElementById('btn-session-extend');
+                if (btnSessionExtend) {
+                    btnSessionExtend.remove();
+                }
+
+                document.getElementById('session-counter').innerHTML = '{{ 'SessionIsClosingJS' | get_lang | escape('js')}}';
+
+                setTimeout(function() {
+                    fetch('/main/inc/ajax/session_clock.ajax.php?action=logout')
+                    .then(response => response.json())
+                    .then(data => {
+                        if (!document.getElementById('session-checker-overlay')) {
+                            clearInterval(sessionCounterInterval);
+
+                            var counterOverlay = document.getElementById('session-count-overlay');
+                            if (counterOverlay) {
+                                counterOverlay.remove();
+                            }
+
+                            var now = new Date();
+                            var day = String(now.getDate()).padStart(2, '0');
+                            var month = String(now.getMonth() + 1).padStart(2, '0');
+                            var year = now.getFullYear();
+                            var hour = String(now.getHours()).padStart(2, '0');
+                            var minutes = String(now.getMinutes()).padStart(2, '0');
+
+                            var dateTimeSessionExpired = day + '/' + month + '/' + year + ' ' + hour + ':' + minutes;
+
+                            document.body.insertAdjacentHTML('afterbegin', '<div id="session-checker-overlay" style="position:fixed;top:0;left:0;width:100%;height:100%;background:rgba(0,0,0,1);display:flex;justify-content:center;align-items:center;z-index:1000;"><div id="session-checker-modal" style="background:white;padding:20px;border-radius:5px;box-shadow:0010pxrgba(0,0,0,0.5);width:35%;text-align:center;"><p style="margin-bottom:20px;">{{ 'SessionExpiredAtJS' | get_lang | escape('js')}} ' + dateTimeSessionExpired + '.</p><button class="btn btn-primary" onclick="window.location.pathname = \'/\';">OK</button></div></div>');
+                        }
+                    })
+                    .catch((error) => {
+                    console.error('Error:', error);
+                    });
+                }, 1000);
+            }
+            sessionClosing = true;
+        }
+    }
+    else {
+        clearInterval(sessionCounterInterval);
+
+        var counterOverlay = document.getElementById('session-count-overlay');
+        if (counterOverlay) {
+            counterOverlay.remove();
+        }
+
+        var now = new Date();
+        var day = String(now.getDate()).padStart(2, '0');
+        var month = String(now.getMonth() + 1).padStart(2, '0');
+        var year = now.getFullYear();
+        var hour = String(now.getHours()).padStart(2, '0');
+        var minutes = String(now.getMinutes()).padStart(2, '0');
+
+        var dateTimeSessionExpired = day + '/' + month + '/' + year + ' ' + hour + ':' + minutes;
+
+        document.body.insertAdjacentHTML('afterbegin', '<div id="session-checker-overlay" style="position:fixed;top:0;left:0;width:100%;height:100%;background:rgba(0,0,0,1);display:flex;justify-content:center;align-items:center;z-index:1000;"><div id="session-checker-modal" style="background:white;padding:20px;border-radius:5px;box-shadow:0010pxrgba(0,0,0,0.5);width:35%;text-align:center;"><p style="margin-bottom:20px;">{{ 'SessionExpiredAtJS' | get_lang | escape('js')}} ' + dateTimeSessionExpired + '.</p><button class="btn btn-primary" onclick="window.location.pathname = \'/\';">OK</button></div></div>');
+    }
+}

--- a/main/template/default/layout/main.js.tpl
+++ b/main/template/default/layout/main.js.tpl
@@ -5,6 +5,9 @@ var offline_button = '<img src="' + _p.web_img + 'statusoffline.png">';
 var connect_lang = '{{ "ChatConnected"|get_lang | escape('js')}}';
 var disconnect_lang = '{{ "ChatDisconnected"|get_lang | escape('js')}}';
 var chatLang = '{{ "GlobalChat"|get_lang | escape('js')}}';
+var sessionRemainingSeconds = 0;
+var sessionCounterInterval;
+var sessionClosing = false;
 
 {% if 'hide_chat_video'|api_get_configuration_value %}
     var hide_chat_video = true;
@@ -443,6 +446,10 @@ $(function() {
             });
         });
     {% endif %}
+
+    if (window.self === window.top) {
+        checkSessionTime();
+    }
 });
 
 $(window).resize(function() {


### PR DESCRIPTION
Some teachers use lessons with a minimum duration time that requires students to stay connected for a certain period to progress and move on to the next lesson.

The problem arises when a student leaves the lesson inactive and returns to it after some time, usually a long time. When they do, their progress timer still displays the elapsed time, but in reality, if the session lasts, for example, two hours and eight hours have passed, the student is unaware because they do not receive a notification that their session has expired.

We have built a session expiration system that, after a certain amount of time, displays a screen indicating the session has expired, and even shows a countdown in the last few seconds.

Initially, this would require a subprocess that checks every X seconds for the remaining session time. This subprocess would need to be analyzed to determine if its execution would extend the session, which would be an undesirable effect.

When a user's session has expired, the system hides the entire campus with a black screen and indicates the end of the session.

This PR references this issue: #4776 

![01](https://github.com/chamilo/chamilo-lms/assets/93096561/8b5833ad-beba-413e-b35b-cb11b8bce17b)

![image](https://github.com/chamilo/chamilo-lms/assets/93096561/5746d10f-6449-4cb7-a9f5-20b17d0d0d99)

This session control can be enabled from configuration.php by setting the 'session_lifetime_controller' option to true.

