### PR TITLE
Session configuration: Option to hide visibility options after end date

### DIFF
--- a/main/inc/lib/sessionmanager.lib.php
+++ b/main/inc/lib/sessionmanager.lib.php
@@ -8079,16 +8079,31 @@ class SessionManager
 
         $form->addElement('checkbox', 'show_description', null, get_lang('ShowDescription'));
 
+        $visibilityOptions = [
+            SESSION_VISIBLE_READ_ONLY => get_lang('SessionReadOnly'),
+            SESSION_VISIBLE => get_lang('SessionAccessible'),
+            SESSION_INVISIBLE => api_ucfirst(get_lang('SessionNotAccessible')),
+        ];
+
+        $visibilityOptionsConfiguration = api_get_configuration_value('session_visibility_after_end_date_options_configuration');
+        if (!empty($visibilityOptionsConfiguration)) {
+            foreach ($visibilityOptionsConfiguration['visibility_options_to_hide'] as $option) {
+                $option = trim($option);
+                if (defined($option)) {
+                    $constantValue = constant($option);
+                    if (isset($visibilityOptions[$constantValue])) {
+                        unset($visibilityOptions[$constantValue]);
+                    }
+                }
+            }
+        }
+
         $visibilityGroup = [];
         $visibilityGroup[] = $form->createElement(
             'select',
             'session_visibility',
             null,
-            [
-                SESSION_VISIBLE_READ_ONLY => get_lang('SessionReadOnly'),
-                SESSION_VISIBLE => get_lang('SessionAccessible'),
-                SESSION_INVISIBLE => api_ucfirst(get_lang('SessionNotAccessible')),
-            ]
+            $visibilityOptions
         );
         $form->addGroup(
             $visibilityGroup,

--- a/main/install/configuration.dist.php
+++ b/main/install/configuration.dist.php
@@ -2375,6 +2375,14 @@ INSERT INTO `extra_field` (`extra_field_type`, `field_type`, `variable`, `displa
 // they are only accessible during the active duration).
 //$_configuration['session_coach_access_after_duration_end'] = false;
 
+// Hide visibility options for session visibility after end date
+// admitsive options: SESSION_VISIBLE_READ_ONLY, SESSION_VISIBLE, SESSION_INVISIBLE
+/*$_configuration['session_visibility_after_end_date_options_configuration'] = [
+    'visibility_options_to_hide' => [
+        'SESSION_VISIBLE_READ_ONLY '
+    ]
+];*/
+
 // Restrict the list of students to subscribe in the course session. And disable
 // registration for users in all courses from Resume Session page
 //$_configuration['session_course_users_subscription_limited_to_session_users'] = false;


### PR DESCRIPTION
This pull request adds an option in configuration.php to configure visibility options after the end date in a session.

![image](https://github.com/chamilo/chamilo-lms/assets/93096561/57a6c794-75ad-462b-b78a-c48ce81d4b0b)

It is configured by indicating which options we want to hide, which can be three, SESSION_VISIBLE_READ_ONLY, SESSION_VISIBLE or SESSION_INVISIBLE

![image](https://github.com/chamilo/chamilo-lms/assets/93096561/30eb7f19-5001-47d0-ae54-dff08f4fa381)

The end result is that the configuration combo will not show the indicated options

![image](https://github.com/chamilo/chamilo-lms/assets/93096561/3834ec61-14d9-4ebc-9015-6b8e00d145d7)
