### PR TITLE
Exercise list actions: Restrict Actions for Hidden Exercises in Base Course

### DIFF
--- a/main/exercise/exercise.class.php
+++ b/main/exercise/exercise.class.php
@@ -9909,15 +9909,29 @@ class Exercise
                                 );
                             } else {
                                 if ($row['active'] == 0 || $visibility == 0) {
-                                    $visibility = Display::url(
-                                        Display::return_icon(
-                                            'invisible.png',
-                                            get_lang('Activate'),
-                                            '',
-                                            ICON_SIZE_SMALL
-                                        ),
-                                        'exercise.php?'.api_get_cidreq().'&choice=enable&sec_token='.$token.'&exerciseId='.$row['iid']
+                                    $visibleOnBaseCourse = api_get_item_visibility(
+                                        $courseInfo,
+                                        TOOL_QUIZ,
+                                        $row['iid'],
+                                        0
                                     );
+
+                                    if ($visibleOnBaseCourse) {
+                                        $visibility = Display::url(
+                                            Display::return_icon(
+                                                'invisible.png',
+                                                get_lang('Activate'),
+                                                '',
+                                                ICON_SIZE_SMALL
+                                            ),
+                                            'exercise.php?'.api_get_cidreq().'&choice=enable&sec_token='.$token.'&exerciseId='.$row['iid']
+                                        );
+                                    } else {
+                                        $visibility = Display::return_icon(
+                                            'invisible.png',
+                                            get_lang('Activate')
+                                        );
+                                    }
                                 } else {
                                     // else if not active
                                     $visibility = Display::url(

--- a/main/exercise/exercise.php
+++ b/main/exercise/exercise.php
@@ -266,6 +266,18 @@ if (!empty($action) && $is_allowedToEdit) {
                         break;
                     }
 
+                    $visibleOnBaseCourse = api_get_item_visibility(
+                        $courseInfo,
+                        TOOL_QUIZ,
+                        $objExerciseTmp->iid,
+                        0
+                    );
+
+                    if (!$visibleOnBaseCourse) {
+                        Display::addFlash(Display::return_message(get_lang('CanNotHide') . ' ' . $objExerciseTmp->name, 'error'));
+                        break;
+                    }
+
                     // enables an exercise
                     if (empty($sessionId)) {
                         $objExerciseTmp->enable();


### PR DESCRIPTION
When an exercise is deactivated in the base course (indicated by a closed eye icon), Chamilo does not allow its visibility to be changed from a session. Despite this, the system allows clicking on the icon, and although it does not modify the state of the exercise, it gives the impression that it does, even displaying a success message after the action.

![image](https://github.com/chamilo/chamilo-lms/assets/93096561/cdfd735d-d73f-4bd8-8d79-6077c6c00335)

This pull request ensures that if an exercise is hidden in the base course, its icon is not clickable. Additionally, for bulk actions, it checks if there are hidden exercises in the base course and, if so, indicates that the status of these cannot be changed.

![image](https://github.com/chamilo/chamilo-lms/assets/93096561/492a9721-95a2-42ac-9227-4239a50f42d5)

