### PR TITLE
Custom Certificate plugin: Fix bug for certificates with learnpath index as content type

### DIFF
--- a/main/lp/learnpathList.class.php
+++ b/main/lp/learnpathList.class.php
@@ -28,7 +28,7 @@ class LearnpathList
      * (only displays) items if he has enough permissions to view them.
      *
      * @param int    $user_id
-     * @param array  $courseInfo              Optional course code (otherwise we use api_get_course_id())
+     * @param array  $courseInfo              Optional course info array (otherwise we use api_get_course_info())
      * @param int    $session_id              Optional session id (otherwise we use api_get_session_id())
      * @param string $order_by
      * @param bool   $check_publication_dates

--- a/plugin/customcertificate/src/print_certificate.php
+++ b/plugin/customcertificate/src/print_certificate.php
@@ -402,7 +402,7 @@ foreach ($userList as $userInfo) {
 
                 $list = new LearnpathList(
                     $studentId,
-                    $courseCode,
+                    $courseInfo,
                     $sessionId,
                     null,
                     false,


### PR DESCRIPTION
The certificate generation for certificates with learnpath index as content type is actually broken.

If we use this option, the custom certificates plugin code will attempt to instantiate a new LearnpathList object by passing a course code instead of a course_info array.

https://github.com/chamilo/chamilo-lms/blob/69d982f3f89340ae26e67a125f424c1a285ec9da/plugin/customcertificate/src/print_certificate.php#L33

https://github.com/chamilo/chamilo-lms/blob/69d982f3f89340ae26e67a125f424c1a285ec9da/plugin/customcertificate/src/print_certificate.php#L39-L47

https://github.com/chamilo/chamilo-lms/blob/69d982f3f89340ae26e67a125f424c1a285ec9da/plugin/customcertificate/src/print_certificate.php#L403-L410

https://github.com/chamilo/chamilo-lms/blob/69d982f3f89340ae26e67a125f424c1a285ec9da/main/lp/learnpathList.class.php#L31

https://github.com/chamilo/chamilo-lms/blob/69d982f3f89340ae26e67a125f424c1a285ec9da/main/lp/learnpathList.class.php#L39-L52

This PR fixes the issue by instantiating a new LearnpathList with the correct parameters. Additionally, the description of the LearnpathList constructor for the $courseInfo parameter has been corrected