### PR TITLE
Elfinder  file manager: Fix Multi-URL Mode Document Access Issue in Chamilo 1.11.x

### DIFF
--- a/main/inc/lib/elfinder/filemanager.php
+++ b/main/inc/lib/elfinder/filemanager.php
@@ -18,8 +18,10 @@ if (file_exists($file)) {
     $language = $iso;
 }
 $questionId = isset($_REQUEST['question_id']) ? (int) $_REQUEST['question_id'] : 0;
+$sessionId = api_get_session_id();
 
 $template->assign('question_id', $questionId);
+$template->assign('session_id', $sessionId);
 $template->assign('elfinder_lang', $language);
 $template->assign('elfinder_translation_file', $includeFile);
 $template->display('default/javascript/editor/ckeditor/elfinder.tpl');

--- a/main/template/default/javascript/editor/elfinder_standalone.tpl
+++ b/main/template/default/javascript/editor/elfinder_standalone.tpl
@@ -19,24 +19,40 @@
 
     $().ready(function() {
         var funcNum = getUrlParam('CKEditorFuncNum');
+        var sessionId = {{session_id}};
         var elf = $('#elfinder').elfinder({
             url : '{{ _p.web_lib ~ 'elfinder/connectorAction.php?' }}{{ course_condition }}',  // connector URL (REQUIRED)
             getFileCallback : function(file) {
-                if (window.opener) {
-                    if (window.opener.CKEDITOR) {
-                        window.opener.CKEDITOR.tools.callFunction(funcNum, file.url);
-                    }
+                if (!file.name.includes("__0") || file.name.includes("__" + sessionId + "__")) {
+                    if (window.opener) {
+                        if (window.opener.CKEDITOR) {
+                            window.opener.CKEDITOR.tools.callFunction(funcNum, file.url);
+                        }
 
-                    if (window.opener.addImageToQuestion) {
-                        window.opener.addImageToQuestion(file.url, {{ question_id }});
+                        if (window.opener.addImageToQuestion) {
+                            window.opener.addImageToQuestion(file.url, {{ question_id }});
+                        }
                     }
+                    window.close();
                 }
-
-                window.close();
             },
             startPathHash: 'l2_Lw', // Sets the course driver as default
             resizable: false,
-            lang: '{{ elfinder_lang }}'
+            lang: '{{ elfinder_lang }}',
+            handlers : {
+                sync : function (event, elfinderInstance) {
+                    let files = elfinderInstance.files();
+                    for (const key in files) {
+                        for (const subkey in files[key]) {
+                           if (subkey === "name") {
+                                 if (files[key][subkey].includes("__0") && !files[key][subkey].includes("__" + sessionId + "__")) {
+                                    $('#' + files[key].hash).hide();
+                                }
+                            }
+                        }
+                    }
+                }
+            }
         }).elfinder('instance');
     });
 </script>


### PR DESCRIPTION
Chamilo 1.11.x in multi-url mode has a minor flaw that may allow access to documents from other sessions through the elfinder file manager.

This issue could cause users from sessions from different children sites sharing the same base course view all documents uploaded regardless of the session because elfinder cannot distinguish which session a document belongs to.

**Steps to Replicate:**

1. Create a base course and upload Document A.
2. Create Session 1, add the course to the session, and upload Document B.
3. Create Session 2, add the course to the session, and upload Document C.

Now, from the elfinder file manager, (any instance of the CKEditor for example), we should only see Documents A and B. However, Documents A, B, and C are visible.

**Proposed Mitigation:**
This PR implements the following actions to mitigate the issue:

1. When files are loaded in the file manager, it checks if the files belong to the current session (those that have a session number pattern like "{session_number}" in the name). If they do not belong to the session, the file manager icons are removed.
2. At the time of attempting to manage any of the files, it verifies if the file belongs to the current session checking the name pattern,. If it does not belong, interactions with the file are not allowed.