### PR TITLE
Fix/create group category

### DIFF
--- a/public/main/admin/add_courses_to_usergroup.php
+++ b/public/main/admin/add_courses_to_usergroup.php
@@ -186,7 +186,7 @@ $actions = Display::url(
 $actions .= Display::url(get_lang('Advanced search'), '#', ['class' => 'advanced_options btn', 'id' => 'advanced_search']);
 
 echo Display::toolbarAction('add_users', [$actions]);
-echo Display::page_header($data['name'].': '.$tool_name);
+echo Display::page_header($data['title'].': '.$tool_name);
 
 echo '<div id="advanced_search_options" style="display:none">';
 $searchForm->display();

--- a/public/main/group/group_category.php
+++ b/public/main/group/group_category.php
@@ -103,7 +103,11 @@ if (isset($_GET['id'])) {
 } else {
     // Create a new category
     $action = 'add_category';
-    $form = new FormValidator('group_category');
+    $form = new FormValidator(
+        'group_category', 
+        'post', 
+        api_get_self().'?'.api_get_cidreq()
+    );
 }
 
 $form->addElement('header', $nameTools);

--- a/public/main/group/group_creation.php
+++ b/public/main/group/group_creation.php
@@ -311,7 +311,7 @@ EOT;
         foreach ($classes as $index => $class) {
             $number_of_users = count($obj->get_users_by_usergroup($class['id']));
             $description .= '<li>';
-            $description .= $class['name'];
+            $description .= $class['title'];
             $description .= ' ('.$number_of_users.' '.get_lang('Users').')';
             $description .= '</li>';
         }

--- a/public/main/inc/lib/groupmanager.lib.php
+++ b/public/main/inc/lib/groupmanager.lib.php
@@ -400,7 +400,7 @@ class GroupManager
         foreach ($classes as $class) {
             $userList = $obj->get_users_by_usergroup($class['id']);
             $groupId = self::create_group(
-                $class['name'],
+                $class['title'],
                 $categoryId,
                 0,
                 null


### PR DESCRIPTION
## Introduction
This small patch solves 3 problems in the course group section

### Problem 1
When accessing the page : **/main/group/group_creation.php**
![Capture2](https://github.com/user-attachments/assets/9d172e61-6d78-4a32-8e91-470cd9c0717c)

### Problem 2 
When you try to go to previous page from : **/main/group/group_category.php**
![Capture3](https://github.com/user-attachments/assets/a5957cfb-a672-4df5-af8a-27b7232437ac)

### Problem 3
When creating a group category by submit form from : **/main/group/group_category.php**
![Capture4](https://github.com/user-attachments/assets/2bcb397e-efc9-402e-8920-fc9ec01ba862)
