### PR TITLE
Feature - DRH Session import - Option to hide the old relationships checkbox

### DIFF
--- a/main/install/configuration.dist.php
+++ b/main/install/configuration.dist.php
@@ -1362,6 +1362,9 @@ VALUES (2, 13, 'session_courses_read_only_mode', 'Lock Course In Session', 1, 1,
     ]
 ];*/
 
+// This option hide the old relationships in the session import view for drh users
+//$_configuration['session_import_drh_hide_old_relationships_check_box'] = false;
+
 /*
  * Fields visibility in the profile user page
 $_configuration['profile_fields_visibility'] = [

--- a/main/session/session_import_drh.php
+++ b/main/session/session_import_drh.php
@@ -27,7 +27,16 @@ $form = new FormValidator(
 );
 
 $form->addElement('file', 'import_file', get_lang('ImportFileLocation'));
-$form->addCheckbox('remove_old_relationships', [get_lang('RemoveOldRelationships'), get_lang('RemoveOldRelationshipsHelp')]);
+
+$displayRemoveOldRelationshipsCheckbox = true;
+if (true === api_get_configuration_value('session_import_drh_hide_old_relationships_check_box')) {
+    $displayRemoveOldRelationshipsCheckbox = false;
+}
+
+if ($displayRemoveOldRelationshipsCheckbox) {
+    $form->addCheckbox('remove_old_relationships', [get_lang('RemoveOldRelationships'), get_lang('RemoveOldRelationshipsHelp')]);
+}
+
 $form->addButtonImport(get_lang('ImportSession'));
 
 if ($form->validate()) {


### PR DESCRIPTION
In the session import process for a DRH user, we have the option in configuration.php to set default values for fields. However, in some cases, it is preferable that a potentially dangerous option, such as the checkbox to delete all previous relationships, is not displayed.

This pull request adds a new option to configuration.php, session_import_drh_hide_old_relationships_check_box, which, if set to true, it will hide the checkbox