### PR TITLE
Enhancement - Session duration extension per user

### DIFF
--- a/main/session/resume_session.php
+++ b/main/session/resume_session.php
@@ -398,14 +398,14 @@ if (!empty($userList)) {
         }
 
         $editUrl = null;
-        /*
+
         if (isset($sessionInfo['duration']) && !empty($sessionInfo['duration'])) {
             $editUrl = $codePath . 'session/session_user_edit.php?session_id=' . $sessionId . '&user_id=' . $userId;
             $editUrl = Display::url(
                 Display::return_icon('agenda.png', get_lang('SessionDurationEdit')),
                 $editUrl
             );
-        }*/
+        }
 
         $table->setCellContents($row, 0, $userLink);
         $link = $reportingLink.$courseUserLink.$removeLink.$addUserToUrlLink.$editUrl;


### PR DESCRIPTION
Issue #5638,  currently, sessions can be configured with a duration in days. Once a student enrolls in a session, they can access it from their first login date until the maximum duration configured for the session.

The issue we encountered is that it is not possible to 'extend' the duration for individual users. To do so, the student would have to be removed and re-added to the session, resulting in the loss of their progress.

While reviewing the code to confirm this limitation, we discovered unused code suggesting that this functionality existed in the past. For example, there are functions that seem to validate this possibility:

https://github.com/chamilo/chamilo-lms/blob/04c3e31cef55f168efa95a6ab1f1fd0763f9a89e/main/inc/lib/sessionmanager.lib.php#L7004-L7013


https://github.com/chamilo/chamilo-lms/blob/04c3e31cef55f168efa95a6ab1f1fd0763f9a89e/main/inc/lib/sessionmanager.lib.php#L7015-L7050


https://github.com/chamilo/chamilo-lms/blob/04c3e31cef55f168efa95a6ab1f1fd0763f9a89e/main/inc/lib/sessionmanager.lib.php#L7052-L7075

https://github.com/chamilo/chamilo-lms/blob/04c3e31cef55f168efa95a6ab1f1fd0763f9a89e/main/session/resume_session.php#L401-L408

This PR repurposes some of that unused code to enable the functionality of extending session durations for individual users