### PR TITLE
Enhancement - Scheduled session announcements new option by user progress

### DIFF
--- a/main/inc/lib/ScheduledAnnouncement.php
+++ b/main/inc/lib/ScheduledAnnouncement.php
@@ -112,6 +112,26 @@ class ScheduledAnnouncement extends Model
 
         $form->addHidden('session_id', $sessionInfo['id']);
         $form->addDateTimePicker('date', get_lang('Date'));
+
+        $useBaseProgress = api_get_configuration_value('scheduled_announcements_use_base_progress');
+        if ($useBaseProgress) {
+            $extraFieldValue = new ExtraFieldValue('scheduled_announcement');
+            $baseProgress = $extraFieldValue->get_values_by_handler_and_field_variable(
+                $id,
+                'use_base_progress'
+            );
+            $form->addNumeric ('progress',
+                get_lang('Progress'),
+                [
+                    'step' => 1,
+                    'min' => 1,
+                    'max' => 100,
+                    'value' => $baseProgress['value'],
+                ],
+                true
+            );
+        }
+
         $form->addText('subject', get_lang('Subject'));
         $form->addHtmlEditor('message', get_lang('Message'));
 
@@ -185,6 +205,11 @@ class ScheduledAnnouncement extends Model
             $typeOptions['base_date'] = get_lang('BaseDate');
         }
 
+        $useBaseProgress = api_get_configuration_value('scheduled_announcements_use_base_progress');
+        if ($useBaseProgress) {
+            $typeOptions['base_progress'] = get_lang('BaseProgress');
+        }
+
         $form->addSelect(
             'type',
             get_lang('Type'),
@@ -194,9 +219,15 @@ class ScheduledAnnouncement extends Model
                     if (this.options[this.selectedIndex].value == 'base_date') {
                         document.getElementById('options').style.display = 'block';
                         document.getElementById('specific_date').style.display = 'none';
-                    } else {
+                        document.getElementById('base_progress').style.display = 'none';
+                    } else if (this.options[this.selectedIndex].value == 'specific_date') {
                         document.getElementById('options').style.display = 'none';
                         document.getElementById('specific_date').style.display = 'block';
+                        document.getElementById('base_progress').style.display = 'none';
+                    } else {
+                        document.getElementById('options').style.display = 'block';
+                        document.getElementById('specific_date').style.display = 'none';
+                        document.getElementById('base_progress').style.display = 'block';
                     }
             ", ]
         );
@@ -204,6 +235,20 @@ class ScheduledAnnouncement extends Model
         $form->addHtml('<div id="specific_date">');
         $form->addDateTimePicker('date', get_lang('Date'));
         $form->addHtml('</div>');
+
+        $form->addHtml('<div id="base_progress" style="display:none">');
+        $form->addNumeric ('progress',
+            get_lang('Progress'),
+            [
+                'step' => 1,
+                'min' => 1,
+                'max' => 100,
+                'value' => 100,
+            ],
+            true
+        );
+        $form->addHtml('</div>');
+
         $form->addHtml('<div id="options" style="display:none">');
 
         $startDate = $sessionInfo['access_start_date'];
@@ -344,7 +389,19 @@ class ScheduledAnnouncement extends Model
                             $coachList = array_unique($coachList);
                         }
 
-                        $this->update(['id' => $result['id'], 'sent' => 1]);
+                        $useBaseProgress = api_get_configuration_value('scheduled_announcements_use_base_progress');
+                        if ($useBaseProgress) {
+                            $baseProgress = $extraFieldValue->get_values_by_handler_and_field_variable(
+                                $result['id'],
+                                'use_base_progress'
+                            );
+                            if (empty($baseProgress) || empty($baseProgress['value']) || $baseProgress['value'] < 1) {
+                                $this->update(['id' => $result['id'], 'sent' => 1]);
+                            }
+                        } else {
+                            $this->update(['id' => $result['id'], 'sent' => 1]);
+                        }
+
                         $attachments = $this->getAttachmentToString($result['id']);
                         $subject = $result['subject'];
 
@@ -369,6 +426,44 @@ class ScheduledAnnouncement extends Model
                                     [],
                                     $sessionId
                                 );
+                            }
+
+                            if ($useBaseProgress) {
+                                $baseProgress = $extraFieldValue->get_values_by_handler_and_field_variable(
+                                    $result['id'],
+                                    'use_base_progress'
+                                );
+                                if (!empty($baseProgress) && !empty($baseProgress['value']) && $baseProgress['value'] >= 1) {
+                                    if ((is_numeric($progress) && $progress > $baseProgress['value']) || !is_numeric($progress)) {
+                                        continue;
+                                    } else {
+                                        $comment = json_decode($baseProgress['comment'], true);
+                                        if ($comment !== null && is_array($comment)) {
+                                            if (isset($comment['sended']) && is_array($comment['sended'])) {
+                                                $userFound = false;
+                                                foreach ($comment['sended'] as $item) {
+                                                    if (isset($item['user']) && $item['user'] === $user['user_id']) {
+                                                        $userFound = true;
+                                                        break;
+                                                    }
+                                                }
+                                                if ($userFound) {
+                                                    continue;
+                                                } else {
+                                                    $comment['sended'][] = ['user' => $user['user_id'], 'send_date' => time(), 'progress_user' => $progress, 'progress_mark' => $baseProgress['value']];
+                                                    $newExtraFieldParams = $baseProgress;
+                                                    $newExtraFieldParams['comment'] = json_encode($comment);
+                                                    $extraFieldValue->save($newExtraFieldParams);
+                                                }
+                                            }
+                                        } else {
+                                            $comment['sended'][] = ['user' => $user['user_id'], 'send_date' => time(), 'progress_user' => $progress, 'progress_mark' => $baseProgress['value']];
+                                            $newExtraFieldParams = $baseProgress;
+                                            $newExtraFieldParams['comment'] = json_encode($comment);
+                                            $extraFieldValue->save($newExtraFieldParams);
+                                        }
+                                    }
+                                }
                             }
 
                             if (is_numeric($progress)) {

--- a/main/install/configuration.dist.php
+++ b/main/install/configuration.dist.php
@@ -698,6 +698,9 @@ $_configuration['send_all_emails_to'] = [
         'admin2@example.com',
     ]
 ];*/
+// Add a new type of scheduled announcement, based on user course session progress
+// Requires a "use_base_progress" extra field in: main/admin/extra_fields.php?type=scheduled_announcement&action=add
+//$_configuration['scheduled_announcements_use_base_progress'] = false;
 // Allow ticket projects to be access by specific chamilo roles
 /*$_configuration['ticket_project_user_roles'] = [
     'permissions' => [

--- a/main/session/scheduled_announcement.php
+++ b/main/session/scheduled_announcement.php
@@ -62,6 +62,7 @@ switch ($action) {
             $values = $form->getSubmitValues();
             switch ($values['type']) {
                 case 'base_date':
+                case 'base_progress':
                     $numberDays = (int) $values['days'];
                     switch ($values['base_date']) {
                         case 'start_date':
@@ -81,6 +82,11 @@ switch ($action) {
                             break;
                     }
                     $values['date'] = $newDate->format('Y-m-d h:i:s');
+
+                    if ($values['type'] == 'base_progress') {
+                        $values['extra_use_base_progress'] = $values['progress'];
+                    }
+
                     break;
                 case 'specific_date':
                     $values['date'] = api_get_utc_datetime($values['date']);
@@ -131,7 +137,14 @@ switch ($action) {
             $values['date'] = api_get_utc_datetime($values['date']);
             $res = $object->update($values);
 
+            $values['extra_use_base_progress'] = $values['progress'];
             $extraFieldValue = new ExtraFieldValue('scheduled_announcement');
+            $baseProgress = $extraFieldValue->get_values_by_handler_and_field_variable(
+                $id,
+                'use_base_progress'
+            );
+            $values['extra_use_base_progress_comment'] = $baseProgress["comment"];
+
             $values['item_id'] = $id;
             $extraFieldValue->saveFieldValues($values);
 


### PR DESCRIPTION
This pull request introduces a new option for the scheduled session announcemetns "Send announcement Based on Course Progress".

1. Configuration: "Send Based on Course Progress."
* Users must specify the progress threshold (default: 100).

2. Date Configuration:
* Specify the number of days before or after the start dates, similar to the existing "Send Based on Session Start/End Date" option.
* When editing, the date can be configured directly without needing to specify days before/after the start date (similar to the "Send Based on Session Start/End Date" option).

3. Progress Verification:
* When the date requirement is met, the system will verify up to the session's end access date whether there are students whose progress value is less than or equal to the specified threshold.

4. Logging:
* A record is saved for each student, including their ID, the sending date, their progress at the time of sending, and the configured progress threshold.
* This ensures that messages are not resent to the same students and provides a way to monitor activity. Access to this log is only available via the database.