### PR TITLE
bugfix attendance tool: group id not present

### DIFF
--- a/main/attendance/attendance_sheet.php
+++ b/main/attendance/attendance_sheet.php
@@ -286,7 +286,7 @@ if (api_is_allowed_to_edit(null, true) ||
                 if ($allowSignature) {
                     $iconFullScreen = Display::url(
                         Display::return_icon('view_fullscreen.png', get_lang('SeeForTablet'), [], ICON_SIZE_SMALL),
-                        api_get_self().'?'.api_get_cidreq().'&action=attendance_sheet_list&func=fullscreen&attendance_id='.$attendance_id.'&calendar_id='.$calendar['id']
+                        api_get_self().'?'.api_get_cidreq().'&action=attendance_sheet_list&func=fullscreen&attendance_id='.$attendance_id.'&calendar_id='.$calendar['id'] . (!empty($groupId) ? '&group_id=' . $groupId : '')
                     );
                     $isBlocked = 0;
                     $iconBlockName = 'eyes.png';


### PR DESCRIPTION
The selected group-ID was not present in the parameters send to the full-screen, "tablet" view of the attendance tool. 
(ps.: only applicable if signature-functionality is active on attendance tool)