### PR TITLE
Fix total courses progress calculation in mystudent.php

### DIFF
--- a/main/mySpace/myStudents.php
+++ b/main/mySpace/myStudents.php
@@ -1339,7 +1339,7 @@ if (empty($details)) {
             $totalScore = 0;
             $totalProgress = 0;
             $gradeBookTotal = [0, 0];
-            $totalCourses = count($courses);
+            $totalCourses = 0;
             $scoreDisplay = ScoreDisplay::instance();
             $theoreticalTime = 0;
             $totalTheoreticalTime = 0;
@@ -1364,6 +1364,7 @@ if (empty($details)) {
                 }
 
                 if ($isSubscribed) {
+                    $totalCourses++;
                     $timeInSeconds = Tracking::get_time_spent_on_the_course(
                         $student_id,
                         $courseId,


### PR DESCRIPTION
Currently on the page mystudent.php, the calculation of the total progression in a session is based on the number of courses contained in this session with the formula: (total progressions/total number of courses in the session)x100. However, when a user is unenrolled from a course in the session using /main/session/session_course_user_list.php, the formula does not change, whereas the calculation should be made based on the number of courses the user is enrolled in this session with the formula: (total progressions/total number of courses where the user is enrolled in this session)x100.