### PR TITLE
Allow category managers to view all tickets in his category

### DIFF
--- a/main/ticket/ticket_details.php
+++ b/main/ticket/ticket_details.php
@@ -134,10 +134,14 @@ $userIsAllowInProject = TicketManager::userIsAllowInProject($userInfo, $projectI
 $allowEdition = $ticket['ticket']['assigned_last_user'] == $user_id ||
     $ticket['ticket']['sys_insert_user_id'] == $user_id ||
     $isAdmin;
+$allowCategory = TicketManager::userIsAssignedToCategory(
+    $user_id,
+    $ticket['ticket']['category_id']
+);
 
 if (false === $userIsAllowInProject) {
-    // make sure it's either a user assigned to this ticket, or the reporter, or and admin
-    if (false === $allowEdition) {
+    // make sure it's either a user assigned to this ticket, the reporter, an admin or the category manager
+    if (false === $allowEdition && false === $allowCategory) {
         api_not_allowed(true);
     }
 }


### PR DESCRIPTION
Currently, the person in charge of a ticket category has no visibility into the tickets created in that category and cannot view the content of the tickets. This change allows the person in charge of a ticket category to access the list of tickets created in that category and to view their contents. They cannot modify anything in the ticket. It is only for consultation.