### PR TITLE
Update sortable_table.class.php

### DIFF
--- a/main/inc/lib/sortable_table.class.php
+++ b/main/inc/lib/sortable_table.class.php
@@ -728,7 +728,7 @@ class SortableTable extends HTML_Table
         $nav = $pager_links['first'].' '.$pager_links['back'];
         $nav .= ' '.$pager->getCurrentPageId().' / '.$pager->numPages().' ';
         $nav .= $pager_links['next'].' '.$pager_links['last'];
-
+        $nav = str_replace('&amp;', '&', $nav);
         return $nav;
     }
 


### PR DESCRIPTION
Depuis la mise à jour 1.11.32, lorsque l'on veut naviguer à travers les différentes pages de document de cours grâce aux flèches présentes dans le coin supérieur droit de l'interface. Ce code corrige le probleme.