### PR TITLE
Fix conditional check for quiz result validation

### DIFF
--- a/main/lp/learnpathItem.class.php
+++ b/main/lp/learnpathItem.class.php
@@ -2390,8 +2390,7 @@ class learnpathItem
 
                                                     if (isset($minScore) && isset($minScore)) {
                                                         // Taking min/max prerequisites values see BT#5776
-                                                        if ($quiz['exe_result'] >= $minScore &&
-                                                            $quiz['exe_result'] <= $maxScore
+                                                        if ($quiz['exe_result'] >= $minScore
                                                         ) {
                                                             $returnstatus = true;
                                                         } else {


### PR DESCRIPTION
Le contrôle de la valeur max n'a pas de sens si la valeur minimum est déjà atteinte.