### PR TITLE
Adding responsive style to the Learning Path - refs #6609

### DIFF
--- a/assets/css/scss/layout/_breadcrumb.scss
+++ b/assets/css/scss/layout/_breadcrumb.scss
@@ -1,5 +1,5 @@
 .app-breadcrumb {
-  @apply bg-white mb-3 text-tiny font-semibold leading-4 space-y-1;
+  @apply bg-white mb-3 md:px-6 px-4 text-tiny font-semibold leading-4 space-y-1;
 
   .p-breadcrumb-item-link {
     @apply text-tiny font-semibold;

--- a/assets/css/scss/layout/_main_container.scss
+++ b/assets/css/scss/layout/_main_container.scss
@@ -1,5 +1,5 @@
 .app-main {
-  @apply flex flex-col min-h-screen pb-8 px-8 transition-[margin-left] duration-150;
+  @apply flex flex-col min-h-screen md:pb-8 md:px-8 transition-[margin-left] duration-150;
   padding-top: calc(4.5rem + 1rem + 1px);
 
   &:not(.app-main--no-sidebar) {

--- a/assets/vue/components/StudentViewButton.vue
+++ b/assets/vue/components/StudentViewButton.vue
@@ -6,12 +6,13 @@
     :on-label="t('Switch to teacher view')"
     off-icon="eye-off"
     on-icon="eye-on"
+    :onlyIcon="isOnlyIcon"
   />
 </template>
 
 <script setup>
 import BaseToggleButton from "./basecomponents/BaseToggleButton.vue"
-import { computed } from "vue"
+import { ref, computed, onMounted, onBeforeUnmount } from "vue"
 import { useI18n } from "vue-i18n"
 import { usePlatformConfig } from "../store/platformConfig"
 import { useCidReqStore } from "../store/cidReq"
@@ -54,4 +55,19 @@ const showButton = computed(() =>
   (securityStore.isCourseAdmin || securityStore.isAdmin || isCoach.value) &&
   platformConfigStore.getSetting("course.student_view_enabled") === "true"
 )
+
+const windowSize = ref(window.innerWidth)
+
+function updateSize() {
+  windowSize.value = window.innerWidth
+}
+
+onMounted(() => {
+  window.addEventListener("resize", updateSize)
+})
+onBeforeUnmount(() => {
+  window.removeEventListener("resize", updateSize)
+})
+
+const isOnlyIcon = computed(() => windowSize.value <= 768)
 </script>

--- a/assets/vue/components/lp/LpCardItem.vue
+++ b/assets/vue/components/lp/LpCardItem.vue
@@ -90,7 +90,7 @@ const progressTextClass = computed(() => {
               </span>
             </template>
             <template #menu>
-              <div class="absolute right-0 w-44 bg-white border border-gray-25 rounded-xl shadow-xl p-1 z-10 mb-2" style="bottom: calc(-100% + 2.5rem)">
+              <div class="absolute right-0 w-44 bg-white border border-gray-25 rounded-xl shadow-xl p-1 z-40 mb-2" style="bottom: calc(-100% + 2.5rem)">
                   <button class="w-full text-left px-3 py-2 rounded hover:bg-gray-15" @click="emit('open', lp)">{{ t('Open') }}</button>
                   <button class="w-full text-left px-3 py-2 rounded hover:bg-gray-15" @click="emit('toggle-publish', lp)">{{ t('Publish / Hide') }}</button>
                   <button class="w-full text-left px-3 py-2 rounded hover:bg-gray-15" @click="emit('build', lp)">{{ t('Edit learnpath') }}</button>
@@ -183,7 +183,7 @@ const progressTextClass = computed(() => {
               </span>
             </template>
             <template #menu>
-              <div class="absolute right-0 w-44 bg-white border border-gray-25 rounded-xl shadow-xl p-1 z-10 mb-2" style="bottom: calc(-100% + 2.5rem)">
+              <div class="absolute right-0 w-44 bg-white border border-gray-25 rounded-xl shadow-xl p-1 z-40 mb-2" style="bottom: calc(-100% + 2.5rem)">
                   <button class="w-full text-left px-3 py-2 rounded hover:bg-gray-15" @click="emit('open', lp)">{{ t('Open') }}</button>
                   <button class="w-full text-left px-3 py-2 rounded hover:bg-gray-15" @click="emit('toggle-publish', lp)">{{ t('Publish / Hide') }}</button>
                   <button class="w-full text-left px-3 py-2 rounded hover:bg-gray-15" @click="emit('build', lp)">{{ t('Edit learnpath') }}</button>

--- a/assets/vue/components/lp/LpCardItem.vue
+++ b/assets/vue/components/lp/LpCardItem.vue
@@ -33,10 +33,10 @@ const progressTextClass = computed(() => {
 </script>
 
 <template>
-  <div class="relative rounded-2xl border border-gray-25 bg-white px-4 pt-3 pb-4 min-h-[220px] flex flex-col">
+  <div class="relative rounded-2xl border border-gray-25 bg-white px-2 sm:px-4 pt-3 pb-4 min-h-[220px] flex flex-col">
     <button
       v-if="canEdit"
-      class="drag-handle2 absolute left-3 top-3 w-8 h-8 grid place-content-center rounded-lg text-gray-50 hover:text-gray-90 hover:bg-gray-15 cursor-move"
+      class="drag-handle2 absolute left-0 sm:left-3 top-3 w-8 h-8 grid place-content-center rounded-lg text-gray-50 hover:text-gray-90 hover:bg-gray-15 cursor-move"
       :title="t('Drag to reorder')" :aria-label="t('Drag to reorder')"
     >
       <svg width="14" height="14" viewBox="0 0 14 14" fill="currentColor" aria-hidden>
@@ -45,8 +45,8 @@ const progressTextClass = computed(() => {
       </svg>
     </button>
 
-    <div class="mt-2 grid grid-cols-[80px_1fr] gap-3 items-start pr-10 pl-8">
-      <div class="w-20 h-20 rounded-xl overflow-hidden ring-1 ring-gray-25 bg-gray-15 shrink-0">
+    <div class="mt-2 grid grid-cols-[80px_1fr] gap-3 items-start md:pr-10 sm:ml-8 ml-5 mr-2 md:mr-0">
+      <div class="w-20 h-20 rounded-xl overflow-hidden ring-1 ring-gray-25 bg-gray-15 shrink-0 ml-2 sm:ml-0">
         <img v-if="lp.coverUrl" :src="lp.coverUrl" alt="" class="w-full h-full object-cover" />
         <div v-else class="w-full h-full grid place-content-center text-gray-40">
           <svg width="26" height="26" viewBox="0 0 24 24" fill="none" stroke="currentColor" class="opacity-70">
@@ -57,32 +57,56 @@ const progressTextClass = computed(() => {
         </div>
       </div>
 
-      <div class="min-w-0">
-        <h3 class="font-semibold text-gray-90 leading-snug">
-          <button
-            class="underline-offset-2 hover:underline focus:underline text-left"
-            @click="emit('open', lp)"
-            :title="t('Open')"
+      <div class="min-w-0 flex ml-2 md:ml-0">
+        <div class="flex-1">
+          <h3 class="font-semibold text-gray-90 leading-none md:truncate text-lg md:text-xl leading-none md:leading-4">
+            <button
+              class="underline-offset-2 hover:underline focus:underline text-left"
+              @click="emit('open', lp)"
+              :title="t('Open')"
+            >
+              {{ lp.title || t('Learning path title here') }}
+            </button>
+          </h3>
+          <div v-if="lp.prerequisiteName" class="mt-1 text-caption text-support-5 flex items-center gap-1.5">
+            <svg class="w-4 h-4" viewBox="0 0 24 24" fill="currentColor" aria-hidden>
+              <circle cx="12" cy="12" r="3"/>
+            </svg>
+            <span class="font-medium">{{ t('Prerequisites') }}</span>
+            <span class="text-support-5">{{ lp.prerequisiteName }}</span>
+          </div>
+        </div>
+        <div class="relative w-8 h-8 block md:hidden">
+          <BaseDropdownMenu v-if="canEdit"
+          :dropdown-id="`card-${lp.iid}`"
+          class="absolute"
           >
-            {{ lp.title || t('Learning path title here') }}
-          </button>
-        </h3>
-
-        <div v-if="lp.prerequisiteName" class="mt-1 text-caption text-support-5 flex items-center gap-1.5">
-          <svg class="w-4 h-4" viewBox="0 0 24 24" fill="currentColor" aria-hidden>
-            <circle cx="12" cy="12" r="3"/>
-          </svg>
-          <span class="font-medium">{{ t('Prerequisites') }}</span>
-          <span class="text-support-5">{{ lp.prerequisiteName }}</span>
+            <template #button>
+              <span
+                class="w-8 h-8 grid place-content-center rounded-lg border border-gray-25 hover:bg-gray-15 cursor-pointer"
+                :title="t('More')" :aria-label="t('More')"
+              >
+                <i class="mdi mdi-dots-vertical text-lg" aria-hidden></i>
+              </span>
+            </template>
+            <template #menu>
+              <div class="absolute right-0 w-44 bg-white border border-gray-25 rounded-xl shadow-xl p-1 z-10 mb-2" style="bottom: calc(-100% + 2.5rem)">
+                  <button class="w-full text-left px-3 py-2 rounded hover:bg-gray-15" @click="emit('open', lp)">{{ t('Open') }}</button>
+                  <button class="w-full text-left px-3 py-2 rounded hover:bg-gray-15" @click="emit('toggle-publish', lp)">{{ t('Publish / Hide') }}</button>
+                  <button class="w-full text-left px-3 py-2 rounded hover:bg-gray-15" @click="emit('build', lp)">{{ t('Edit learnpath') }}</button>
+                  <button class="w-full text-left px-3 py-2 rounded hover:bg-gray-15 text-danger" @click="emit('delete', lp)">{{ t('Delete') }}</button>
+              </div>
+            </template>
+          </BaseDropdownMenu>
         </div>
       </div>
 
-      <p class="col-span-2 mt-3 text-caption text-gray-50">
+      <p class="col-span-2 md:mt-3 text-caption text-gray-50 ml-2 md:ml-0">
         {{ dateText }}
       </p>
     </div>
 
-    <div class="mt-auto pt-3 flex items-center pl-8">
+    <div class="mt-auto pt-3 flex items-center ml-5 pl-2 sm:ml-8 sm:pl-0 mr-2 md:mr-0">
       <div class="flex items-center gap-2">
         <div class="relative w-10 h-10">
           <svg viewBox="0 0 37 37" class="w-10 h-10">
@@ -129,7 +153,7 @@ const progressTextClass = computed(() => {
         </button>
         <button
           v-if="canExportScorm"
-          class="row-start-1 col-start-4 opacity-70 hover:opacity-100"
+          class="row-start-1 col-start-4 opacity-70 hover:opacity-100 md:block hidden"
           :title="t('Export as SCORM')"
           :aria-label="t('Export as SCORM')"
           @click="emit('export-scorm', lp)"
@@ -138,14 +162,14 @@ const progressTextClass = computed(() => {
         </button>
         <button
           v-if="canExportPdf"
-          class="row-start-1 col-start-5 opacity-70 hover:opacity-100"
+          class="row-start-1 col-start-5 opacity-70 hover:opacity-100 md:block hidden"
           :title="t('Export to PDF')"
           :aria-label="t('Export to PDF')"
           @click="emit('export-pdf', lp)"
         >
           <i class="mdi mdi-file-pdf-box text-xl" />
         </button>
-        <div class="relative w-8 h-8">
+        <div class="relative w-8 h-8 hidden md:block">
           <BaseDropdownMenu v-if="canEdit"
           :dropdown-id="`card-${lp.iid}`"
           class="absolute"

--- a/assets/vue/components/lp/LpCardItem.vue
+++ b/assets/vue/components/lp/LpCardItem.vue
@@ -95,6 +95,8 @@ const progressTextClass = computed(() => {
                   <button class="w-full text-left px-3 py-2 rounded hover:bg-gray-15" @click="emit('toggle-publish', lp)">{{ t('Publish / Hide') }}</button>
                   <button class="w-full text-left px-3 py-2 rounded hover:bg-gray-15" @click="emit('build', lp)">{{ t('Edit learnpath') }}</button>
                   <button class="w-full text-left px-3 py-2 rounded hover:bg-gray-15 text-danger" @click="emit('delete', lp)">{{ t('Delete') }}</button>
+                  <button v-if="canExportScorm" class="w-full text-left px-3 py-2 rounded hover:bg-gray-15 md:hidden" @click="emit('export-scorm', lp)">{{ t('Export as SCORM') }}</button>
+                  <button class="w-full text-left px-3 py-2 rounded hover:bg-gray-15 md:hidden" @click="emit('settings', lp)">{{ t('Settings') }}</button>
               </div>
             </template>
           </BaseDropdownMenu>

--- a/assets/vue/components/lp/LpCategorySection.vue
+++ b/assets/vue/components/lp/LpCategorySection.vue
@@ -167,7 +167,7 @@ function onChangeCat() {
         handle=".drag-handle2"
         :animation="180"
         tag="div"
-        class="grid gap-4 md:grid-cols-2 xl:grid-cols-3 mt-5"
+        class="grid gap-4 lg:grid-cols-2 xl:grid-cols-3 mt-5"
         ghost-class="ghosting"
         chosen-class="chosen"
         drag-class="dragging"

--- a/assets/vue/components/lp/LpCategorySection.vue
+++ b/assets/vue/components/lp/LpCategorySection.vue
@@ -91,7 +91,7 @@ function onChangeCat() {
 </script>
 
 <template>
-  <section class="relative ml-2 rounded-2xl shadow-[0_1px_8px_rgba(0,0,0,.04)]">
+  <section class="relative ml-2 rounded-2xl shadow-lg">
     <header class="relative bg-support-6 rounded-t-2xl flex items-center justify-between pl-0 pr-4 py-3">
       <span class="pointer-events-none absolute inset-y-0 -left-1.5 w-1.5 bg-support-5 rounded-l-2xl" aria-hidden />
       <div class="flex items-center gap-3">
@@ -159,7 +159,7 @@ function onChangeCat() {
       </div>
     </header>
 
-    <div v-if="isOpen && localList.length" :id="panelId" class="px-4 pb-4 bg-white rounded-b-2xl">
+    <div v-if="isOpen && localList.length" :id="panelId" class="sm:px-4 sm:pb-4 px-2 pb-2 bg-white rounded-b-2xl">
       <Draggable
         v-model="localList"
         item-key="iid"

--- a/assets/vue/components/lp/LpRowItem.vue
+++ b/assets/vue/components/lp/LpRowItem.vue
@@ -101,6 +101,8 @@ const progressTextClass = computed(() => {
             <button class="w-full text-left px-3 py-2 rounded hover:bg-gray-15" @click="emit('toggle-publish', lp)">{{ t('Publish / Hide') }}</button>
             <button class="w-full text-left px-3 py-2 rounded hover:bg-gray-15" @click="emit('build', lp)">{{ t('Edit learnpath') }}</button>
             <button class="w-full text-left px-3 py-2 rounded hover:bg-gray-15 text-danger" @click="emit('delete', lp)">{{ t('Delete') }}</button>
+            <button v-if="canExportScorm" class="w-full text-left px-3 py-2 rounded hover:bg-gray-15 md:hidden" @click="emit('export-scorm', lp)">{{ t('Export as SCORM') }}</button>
+            <button class="w-full text-left px-3 py-2 rounded hover:bg-gray-15 md:hidden" @click="emit('settings', lp)">{{ t('Settings') }}</button>
           </div>
         </template>
       </BaseDropdownMenu>

--- a/assets/vue/components/lp/LpRowItem.vue
+++ b/assets/vue/components/lp/LpRowItem.vue
@@ -37,7 +37,7 @@ const progressTextClass = computed(() => {
 </script>
 
 <template>
-  <article class="relative md:flex items-center gap-4 pl-5 pr-4 py-3 rounded-2xl border border-gray-25 bg-support-6 shadow-[0_1px_8px_rgba(0,0,0,0.04)]">
+  <article class="relative md:flex items-center gap-4 pl-5 pr-4 py-3 rounded-2xl border border-gray-25 bg-support-6 shadow-[0_1px_8px_rgba(0,0,0,0.04)] w-full">
     <span class="absolute left-0 top-0 bottom-0 w-1.5 bg-support-5" aria-hidden />
     <button
       v-if="canEdit"
@@ -55,7 +55,7 @@ const progressTextClass = computed(() => {
       </svg>
     </button>
 
-    <div class="flex gap-4">
+    <div class="flex gap-4 w-full">
       <div class="ml-5 w-20 h-20 md:w-24 md:h-24 rounded-xl overflow-hidden ring-1 ring-gray-25 bg-gray-15 shrink-0">
         <img v-if="lp.coverUrl" :src="lp.coverUrl" alt="" class="w-full h-full object-cover" />
         <div v-else class="w-full h-full grid place-content-center text-gray-40">
@@ -67,7 +67,7 @@ const progressTextClass = computed(() => {
         </div>
       </div>
       <div class="flex-1 min-w-0">
-        <h3 class="font-semibold text-gray-90 md:truncate text-lg md:text-xl leading-none md:leading-[inherit]">
+        <h3 class="font-semibold text-gray-90 md:truncate text-lg md:text-xl leading-none md:leading-4">
           <button
             class="text-left hover:underline focus:underline underline-offset-2"
             @click="emit('open', lp)"

--- a/assets/vue/components/lp/LpRowItem.vue
+++ b/assets/vue/components/lp/LpRowItem.vue
@@ -37,7 +37,7 @@ const progressTextClass = computed(() => {
 </script>
 
 <template>
-  <article class="relative flex items-center gap-4 pl-5 pr-4 py-3 rounded-2xl border border-gray-25 bg-support-6 shadow-[0_1px_8px_rgba(0,0,0,0.04)]">
+  <article class="relative md:flex items-center gap-4 pl-5 pr-4 py-3 rounded-2xl border border-gray-25 bg-support-6 shadow-[0_1px_8px_rgba(0,0,0,0.04)]">
     <span class="absolute left-0 top-0 bottom-0 w-1.5 bg-support-5" aria-hidden />
     <button
       v-if="canEdit"
@@ -55,39 +55,65 @@ const progressTextClass = computed(() => {
       </svg>
     </button>
 
-    <div class="ml-5 w-24 h-24 rounded-xl overflow-hidden ring-1 ring-gray-25 bg-gray-15 shrink-0">
-      <img v-if="lp.coverUrl" :src="lp.coverUrl" alt="" class="w-full h-full object-cover" />
-      <div v-else class="w-full h-full grid place-content-center text-gray-40">
-        <svg width="30" height="30" viewBox="0 0 24 24" fill="none" stroke="currentColor" class="opacity-70">
-          <rect x="3" y="3" width="18" height="18" rx="3" stroke-width="1.5" />
-          <path d="M3 16l4-4 3 3 5-5 6 6" stroke-width="1.5" />
-          <circle cx="9" cy="8" r="1.3" stroke-width="1.2" />
-        </svg>
+    <div class="flex gap-4">
+      <div class="ml-5 w-20 h-20 md:w-24 md:h-24 rounded-xl overflow-hidden ring-1 ring-gray-25 bg-gray-15 shrink-0">
+        <img v-if="lp.coverUrl" :src="lp.coverUrl" alt="" class="w-full h-full object-cover" />
+        <div v-else class="w-full h-full grid place-content-center text-gray-40">
+          <svg width="30" height="30" viewBox="0 0 24 24" fill="none" stroke="currentColor" class="opacity-70">
+            <rect x="3" y="3" width="18" height="18" rx="3" stroke-width="1.5" />
+            <path d="M3 16l4-4 3 3 5-5 6 6" stroke-width="1.5" />
+            <circle cx="9" cy="8" r="1.3" stroke-width="1.2" />
+          </svg>
+        </div>
       </div>
+      <div class="flex-1 min-w-0">
+        <h3 class="font-semibold text-gray-90 md:truncate text-lg md:text-xl leading-none md:leading-[inherit]">
+          <button
+            class="text-left hover:underline focus:underline underline-offset-2"
+            @click="emit('open', lp)"
+            :title="t('Open')"
+          >
+            {{ lp.title || t('Learning path title here') }}
+          </button>
+        </h3>
+        <p v-if="dateText" class="text-caption text-gray-50 mt-8 hidden md:block">{{ dateText }}</p>
+        <div v-if="lp.prerequisiteName" class="mt-1 text-caption hidden md:block">
+          <span class="text-support-5 font-medium">{{ t('Prerequisites') }}</span>
+          <span class="text-support-5">{{ lp.prerequisiteName }}</span>
+        </div>
+      </div>
+      <BaseDropdownMenu
+        :dropdown-id="`row-${lp.iid}`"
+        class="row-start-1 col-start-5 relative block md:hidden h-fit"
+      >
+        <template #button>
+          <span
+            class="list-none w-8 h-8 rounded-lg border border-gray-25 grid place-content-center hover:bg-gray-15 cursor-pointer"
+            :title="t('More')"
+            :aria-label="t('More')"
+          >
+            <i class="mdi mdi-dots-vertical text-lg" aria-hidden></i>
+          </span>
+        </template>
+        <template #menu>
+          <div class="absolute right-0 z-50 w-52 bg-white border border-gray-25 rounded-xl shadow-xl p-1">
+            <button class="w-full text-left px-3 py-2 rounded hover:bg-gray-15" @click="emit('open', lp)">{{ t('Open') }}</button>
+            <button class="w-full text-left px-3 py-2 rounded hover:bg-gray-15" @click="emit('toggle-publish', lp)">{{ t('Publish / Hide') }}</button>
+            <button class="w-full text-left px-3 py-2 rounded hover:bg-gray-15" @click="emit('build', lp)">{{ t('Edit learnpath') }}</button>
+            <button class="w-full text-left px-3 py-2 rounded hover:bg-gray-15 text-danger" @click="emit('delete', lp)">{{ t('Delete') }}</button>
+          </div>
+        </template>
+      </BaseDropdownMenu>
     </div>
-
-    <div class="flex-1 min-w-0">
-      <h3 class="font-semibold text-gray-90 truncate">
-        <button
-          class="text-left hover:underline focus:underline underline-offset-2"
-          @click="emit('open', lp)"
-          :title="t('Open')"
-        >
-          {{ lp.title || t('Learning path title here') }}
-        </button>
-      </h3>
-
-      <p v-if="dateText" class="text-caption text-gray-50 mt-8">{{ dateText }}</p>
-
-      <div v-if="lp.prerequisiteName" class="mt-1 text-caption">
-        <span class="text-support-5 font-medium">{{ t('Prerequisites') }}</span>
-        <span class="text-support-5">{{ lp.prerequisiteName }}</span>
-      </div>
+    <p v-if="dateText" class="text-caption text-gray-50 mt-4 block md:hidden ml-5">{{ dateText }}</p>
+    <div v-if="lp.prerequisiteName" class="mt-1 text-caption">
+      <span class="text-support-5 font-medium">{{ t('Prerequisites') }}</span>
+      <span class="text-support-5">{{ lp.prerequisiteName }}</span>
     </div>
 
     <template v-if="canEdit">
-      <div class="ml-auto flex-column items-center">
-        <div class="flex  gap-x-3">
+      <div class="ml-5 md:ml-auto md:flex-col flex items-center justify-between md:justify-start">
+        <div class="flex gap-x-3 order-2 md:order1 mt-5 md:mt-0">
           <button class="row-start-1 col-start-1 opacity-70 hover:opacity-100" :title="t('Reports')" :aria-label="t('Reports')" @click="emit('report', lp)">
             <i class="mdi mdi-chart-box-outline text-xl" />
           </button>
@@ -104,7 +130,7 @@ const progressTextClass = computed(() => {
           </button>
             <button
             v-if="canExportScorm"
-            class="row-start-1 col-start-4 opacity-70 hover:opacity-100"
+            class="row-start-1 col-start-4 opacity-70 hover:opacity-100 hidden md:block"
             :title="t('Export as SCORM')"
             :aria-label="t('Export as SCORM')"
             @click="emit('export-scorm', lp)"
@@ -113,7 +139,7 @@ const progressTextClass = computed(() => {
           </button>
           <button
             v-if="canExportPdf"
-            class="row-start-1 col-start-5 opacity-70 hover:opacity-100"
+            class="row-start-1 col-start-5 opacity-70 hover:opacity-100 hidden md:block"
             :title="t('Export to PDF')"
             :aria-label="t('Export to PDF')"
             @click="emit('export-pdf', lp)"
@@ -134,7 +160,7 @@ const progressTextClass = computed(() => {
           </button>
           <BaseDropdownMenu
             :dropdown-id="`row-${lp.iid}`"
-            class="row-start-1 col-start-5 relative"
+            class="row-start-1 col-start-5 relative hidden md:block"
           >
             <template #button>
               <span
@@ -156,11 +182,11 @@ const progressTextClass = computed(() => {
           </BaseDropdownMenu>
         </div>
 
-        <div class="row-start-2 col-start-1 col-end-5 flex items-center gap-2 justify-self-end mt-5">
-          <span class="text-caption text-gray-50">
+        <div class="row-start-2 col-start-1 col-end-5 flex items-center gap-2 justify-self-end mt-5 order-1 md:order-2">
+          <span class="text-caption text-gray-50 order-2 md:order-1">
             {{ ringValue(lp.progress) === 100 ? t('Completed') : t('Progress') }}
           </span>
-          <div class="relative w-10 h-10">
+          <div class="relative w-10 h-10 order-1 md:order-2">
             <svg viewBox="0 0 37 37" class="w-10 h-10">
               <circle cx="18.5" cy="19" r="16" stroke-width="3.5" class="text-gray-25" fill="none" stroke="currentColor" />
               <circle

--- a/assets/vue/components/lp/LpRowItem.vue
+++ b/assets/vue/components/lp/LpRowItem.vue
@@ -112,7 +112,7 @@ const progressTextClass = computed(() => {
     </div>
 
     <template v-if="canEdit">
-      <div class="ml-5 md:ml-auto md:flex-col flex items-center justify-between md:justify-start">
+      <div class="ml-5 md:ml-auto md:flex-col flex items-end justify-between md:justify-start">
         <div class="flex gap-x-3 order-2 md:order1 mt-5 md:mt-0">
           <button class="row-start-1 col-start-1 opacity-70 hover:opacity-100" :title="t('Reports')" :aria-label="t('Reports')" @click="emit('report', lp)">
             <i class="mdi mdi-chart-box-outline text-xl" />


### PR DESCRIPTION
Hi there, it's me again.

In [#6609](https://github.com/chamilo/chamilo-lms/pull/6628) I proposed to help with the responsive part and you kindly gave me the design.

**Demo :** 
[Capture vidéo du 2025-09-26 17-00-54.webm](https://github.com/user-attachments/assets/629a229b-4726-452f-b417-e3d06b69de70)
<img width="287" height="614" alt="Capture d’écran du 2025-09-26 17-01-24" src="https://github.com/user-attachments/assets/7be34da5-4e54-4af4-8f78-8a1530ad2bbb" />

Hope you like it and that I didn’t forget anything.
I took some liberties, like reducing padding and margins in the category, because it didn’t quite fit in 320px.

It’s still missing a few links in the menu because I don’t have them yet ("Export to Chamilo format" and "Replace Score").

:warning: Date Issue: The date doesn’t show up under the categories. I’ll open an issue for that.
