### PR TITLE
Fix: /sessions give error 500

### DIFF
--- a/src/CoreBundle/State/UserSessionSubscriptionsStateProvider.php
+++ b/src/CoreBundle/State/UserSessionSubscriptionsStateProvider.php
@@ -7,6 +7,7 @@ declare(strict_types=1);
 namespace Chamilo\CoreBundle\State;
 
 use ApiPlatform\Doctrine\Orm\Extension\PaginationExtension;
+use ApiPlatform\Doctrine\Orm\Paginator;
 use ApiPlatform\Doctrine\Orm\Util\QueryNameGenerator;
 use ApiPlatform\Metadata\Operation;
 use ApiPlatform\State\ProviderInterface;
@@ -75,6 +76,20 @@ class UserSessionSubscriptionsStateProvider implements ProviderInterface
             $context
         );
 
-        return $this->paginationExtension->getResult($qb, Session::class, $operation, $context);
+        $paginator = $this->paginationExtension->getResult($qb, Session::class, $operation, $context);
+
+        // Convert paginator to array since paginationEnabled is false
+        $result = $paginator;
+
+        if ($result instanceof Paginator) {
+            return iterator_to_array($result);
+        }
+
+        // If it's already an array or collection, convert to array
+        if (is_iterable($result)) {
+            return \is_array($result) ? $result : iterator_to_array($result);
+        }
+
+        return [];
     }
 }


### PR DESCRIPTION
Hi ! 

While running tests for the chart documents, I noticed that the page `/sessions` throws a 500 error.

**Screens** : 
<img width="1473" height="101" alt="Capture d’écran du 2025-10-10 15-56-43" src="https://github.com/user-attachments/assets/90bc5ecb-f1ac-45bc-9769-a41aa9db5fbc" />
<img width="659" height="101" alt="Capture d’écran du 2025-10-10 15-56-32" src="https://github.com/user-attachments/assets/46b656a7-2fd0-4aa1-8c36-e2442b5872ca" />


I applied a small fix for it.


**Screen after fix :** 
<img width="565" height="809" alt="Capture d’écran du 2025-10-10 15-57-05" src="https://github.com/user-attachments/assets/1143da76-7ef2-4c12-a0bc-cd9238055cb7" />
