### PR TITLE
Quiz: reimplement export all result functionnality from 1.11.x - refs #6837

### DIFF
--- a/src/CoreBundle/Framework/Container.php
+++ b/src/CoreBundle/Framework/Container.php
@@ -631,11 +631,6 @@ class Container
         return self::$container->get('form.factory');
     }
 
-    public static function getCQuizRepository(): CQuizRepository
-    {
-        return self::$container->get(CQuizRepository::class);
-    }
-
     public static function addFlash(string $message, string $type = 'success'): void
     {
         $type = match ($type) {


### PR DESCRIPTION
Hi!

I reimplemented the old file `export_exercise_results.php` for Chamilo v2.
I'm using repositories to find exercises, courses, etc. Hope that's fine.
In the old version, the queries were not dynamic, so I stuck with the same logic, except for the fact that I'm using Select2 instead of Selectpicker (I didn’t manage to use it properly — it seems it's not implemented yet in Chamilo v2).

You also can't select a course if you haven’t selected a session first, and you need a course selected to choose an exercise.

I’m not sure if I’ve tested every possible case, so feel free to do so and let me know if you need any readjustments.

**Issue: https://github.com/chamilo/chamilo-lms/issues/6837**

**Screens:**
<img width="1200" height="500" alt="Capture d’écran du 2025-10-17 09-47-56" src="https://github.com/user-attachments/assets/1d89564a-fc4d-4c1d-8679-e3b8aa8af596" />

<img width="1200" height="400" alt="Capture d’écran du 2025-10-16 16-38-34" src="https://github.com/user-attachments/assets/72f1f560-498d-426b-a04c-6acb1e585aa7" /> <img width="1200" height="400" alt="Capture d’écran du 2025-10-16 16-38-27" src="https://github.com/user-attachments/assets/8938c6ed-1916-4739-8e8b-137e4d4cf71d" />

**:warning: PDF result :**
<img width="700" height="600" alt="Capture d’écran du 2025-10-16 15-22-42" src="https://github.com/user-attachments/assets/d881a13b-7a82-4ede-84d3-77a21338028e" />

(I figure it should be fixed in another PR.)