### PR TITLE
Add clear documentation for creating custom themes (fixes #3106)

### DIFF
--- a/THEME_GUIDE.md
+++ b/THEME_GUIDE.md
@@ -1,0 +1,20 @@
+# Creating a Custom Theme in Chamilo LMS
+
+This guide explains how to properly create your own theme for Chamilo.
+
+## Folder Structure
+
+CSS files must be placed in both locations to work correctly (as of version 1.9+):
+
+1. `app/Resources/public/css/themes/{your_theme}/`
+2. `web/css/{your_theme}/`
+
+> Replace `{your_theme}` with your theme name, in lowercase.
+
+## Naming Rules
+- CSS files **must be lowercase** and use the `.css` extension.
+- Example: `default.css`, `learnpath.css`
+
+## Notes
+Currently, Chamilo duplicates CSS files in both locations, but one location may be removed in future versions.  
+Refer to the [Chamilo Developer Documentation](https://docs.chamilo.org/en/) for future updates.


### PR DESCRIPTION
This update adds a new THEME_GUIDE.md file to clearly explain how to create and structure custom themes in Chamilo LMS.

Changes made:

Added clear folder structure for CSS placement (app/Resources/public/css/themes/{theme}/ and web/css/{theme}/).

Mentioned naming conventions and duplication note for Chamilo 1.9+.

Linked to official Chamilo developer documentation for further details.

Related to issue #3106.