### PR TITLE
Fix: Eliminar inyección duplicada del script hljs.initHighlightingOnLoad() en CkEditor

### DIFF
--- a/plugin/customcertificate/src/export_pdf_all_in_one.php
+++ b/plugin/customcertificate/src/export_pdf_all_in_one.php
@@ -376,6 +376,8 @@ foreach ($userList as $userInfo) {
                 style="max-height: 150px; max-width: '.(2 * $widthCell).'mm;"
                 src="'.$path.$infoCertificate['logo_right'].'" />';
     }
+    
+    $myContentHtml = preg_replace('#<script(.*?)>(.*?)</script>#is', '', $myContentHtml);
 
     $htmlText .= '<table
         width="'.$workSpace.'mm"

--- a/plugin/customcertificate/src/print_certificate.php
+++ b/plugin/customcertificate/src/print_certificate.php
@@ -266,6 +266,8 @@ foreach ($userList as $userInfo) {
         $dateExpediction,
         $myContentHtml
     );
+    
+    $myContentHtml = preg_replace('#<script(.*?)>(.*?)</script>#is', '', $myContentHtml);
 
     $myContentHtml = strip_tags(
         $myContentHtml,

--- a/src/Chamilo/CoreBundle/Component/Editor/CkEditor/CkEditor.php
+++ b/src/Chamilo/CoreBundle/Component/Editor/CkEditor/CkEditor.php
@@ -74,6 +74,7 @@ class CkEditor extends Editor
             $style .= api_get_css(ChamiloApi::getEditorDocStylePath());
             $style .= api_get_css_asset('ckeditor/plugins/codesnippet/lib/highlight/styles/default.css');
             $style .= api_get_asset('ckeditor/plugins/codesnippet/lib/highlight/highlight.pack.js');
+            $style .= '<script>hljs.initHighlightingOnLoad();</script>';
         }
 
         $html = '<textarea id="'.$this->getTextareaId().'" name="'.$this->getName().'" class="ckeditor">


### PR DESCRIPTION
Al generar vistas previas de certificados (y potencialmente otro contenido que utiliza CkEditor), se está inyectando el script hljs.initHighlightingOnLoad(); en la salida HTML, causando problemas de visualización.

En el archivo src/Chamilo/CoreBundle/Component/Editor/CkEditor/CkEditor.php, la siguiente línea está añadiendo la etiqueta script:

`$style .= '<script>hljs.initHighlightingOnLoad();</script>';`

Esto parece ser redundante o estar incorrectamente ubicado, ya que highlight.js debería inicializarse a través de una gestión adecuada de assets en lugar de inyección de scripts inline.