### PR TITLE
Internal: Move cache clearing to post-install/update-cmd to avoid deleting the whole var/cache folder

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -231,15 +231,16 @@
     },
     "scripts": {
         "auto-scripts": {
-            "cache:clear": "symfony-cmd",
             "assets:install %PUBLIC_DIR%": "symfony-cmd",
             "requirements-checker": "script"
         },
         "post-install-cmd": [
-            "@auto-scripts"
+            "@auto-scripts",
+            "find var/cache -mindepth 1 -delete 2>/dev/null || true"
         ],
         "post-update-cmd": [
-            "@auto-scripts"
+            "@auto-scripts",
+            "find var/cache -mindepth 1 -delete 2>/dev/null || true"
         ],
         "pre-install-cmd": [
             "Chamilo\\CoreBundle\\Component\\Composer\\ScriptHandler::deleteOldFilesFrom19x"


### PR DESCRIPTION
… and just delete its contents. Cache warmup is left out of composer install/update. Launch manually if necessary with php bin/console cache:warmup