### PR TITLE
Add error message if creating a course with existing course code to warn user why course not created.

### DIFF
--- a/public/main/admin/course_list.php
+++ b/public/main/admin/course_list.php
@@ -16,6 +16,8 @@ use Chamilo\CoreBundle\Enums\StateIcon;
 use Chamilo\CoreBundle\Enums\ToolIcon;
 use Chamilo\CoreBundle\Framework\Container;
 use Chamilo\CoreBundle\Repository\CatalogueCourseRelAccessUrlRelUsergroupRepository;
+use ChamiloSession as Session;
+
 
 $cidReset = true;
 
@@ -24,6 +26,12 @@ require_once __DIR__.'/../inc/global.inc.php';
 $this_section = SECTION_PLATFORM_ADMIN;
 api_protect_admin_script();
 $sessionId = $_GET['session_id'] ?? null;
+
+// if course code already exists
+// should be remplaced with Container::getSession()->getFlashBag(); when symfonisation
+if ($msg = Session::read('error_message')) {
+    Display::addFlash(Display::return_message($msg, 'error'));
+}
 
 /**
  * Get the number of courses which will be displayed.

--- a/public/main/inc/lib/course.lib.php
+++ b/public/main/inc/lib/course.lib.php
@@ -101,6 +101,8 @@ class CourseManager
 
                     return $course;
                 }
+            } else {
+                Session::write('error_message', get_lang('Sorry, but that course code already exists. Please choose another one.'));
             }
         }
 


### PR DESCRIPTION
Hi,

when creating a new course, if course code already exists, course isnt created.

There where no error message.

I add an existing error message : 'Sorry, but that course code already exists. Please choose another one.'

<img width="1902" height="523" alt="image" src="https://github.com/user-attachments/assets/043c6c30-d546-4ee4-b197-d350d13436b2" />
