### PR TITLE
Añadido filtro en user_move_stats.php

### DIFF
--- a/main/lang/spanish/trad4all.inc.php
+++ b/main/lang/spanish/trad4all.inc.php
@@ -3039,6 +3039,7 @@ $CurrentCourse = "Curso actual";
 $Back = "Volver";
 $Info = "Información";
 $Search = "Buscar";
+$Clear = "Limpiar";
 $AdvancedSearch = "Búsqueda avanzada";
 $Open = "Abierto";
 $Import = "Importar";


### PR DESCRIPTION
Este PR añade un campo de búsqueda en main/admin/user_move_stats.php para filtrar el listado de usuarios por nombre, apellidos, usuario, email o código oficial, manteniendo la funcionalidad existente de comparación y movimiento de estadísticas entre sesiones.

Además, se asegura la disponibilidad de la cadena Clear en el fichero de idioma en español.

Relacionado: https://tareas.contidosdixitais.com/issues/2428