### PR TITLE
Bug : when reload page on quiz attempt, radio checked input are not displayed has checked.

### DIFF
--- a/public/main/exercise/exercise_submit.php
+++ b/public/main/exercise/exercise_submit.php
@@ -1781,6 +1781,12 @@ echo '<script>
             // Save attempt duration
             addExerciseEvent(window, \'unload\', updateDuration , false);
             addExerciseEvent(window, \'beforeunload\', updateDuration , false);
+
+            // Fix: restore visual checked state on page reload
+            $("input[type=\'radio\']:checked").each(function () {
+                $(this).closest(".p-radiobutton").addClass("p-radiobutton-checked");
+            });
+
         });
 
         function previous_question(question_num) {


### PR DESCRIPTION
When reload page on quiz attempt, checked input are not displayed has checked.

To reproduce bug :
- start a test with a type 1 question (Unique Answer Question)
- click on a radio answer input, it is displayed has checked
- even reload page or click on [next question] then [previous question]
-> the radio answer input gots the ckecked attribut but is not displayed has checked, because of css

Correction :
add 
```
$("input[type=\'radio\']:checked").each(function () {  
    $(this).closest(".p-radiobutton").addClass("p-radiobutton-checked");
});
```
after page loaded