### PR TITLE
Security: Backport Moodle import Zip Slip + hardening to 2.0 (GHSA-94h4-9vrp-v3cv)

### DIFF
--- a/public/main/inc/lib/MoodleImport.php
+++ b/public/main/inc/lib/MoodleImport.php
@@ -201,6 +201,11 @@ class MoodleImport
                 error_log('moduleName: '.$moduleName);
             }
 
+            // Guard against path traversal: <directory> comes from the untrusted backup XML
+            if (isset($currentItem['directory'])) {
+                $this->assertSafeEntryPath($currentItem['directory']);
+            }
+
             switch ($moduleName) {
                 case 'forum':
                     $catForumValues = [];

--- a/public/main/inc/lib/MoodleImport.php
+++ b/public/main/inc/lib/MoodleImport.php
@@ -57,9 +57,7 @@ class MoodleImport
                     $entryPath = str_replace('\\', '/', $pharEntry->getPathname());
                     $pharPath = str_replace('\\', '/', $filePath);
                     $relative = ltrim(substr($entryPath, strlen($pharPath)), '/');
-                    if (str_contains($relative, '../') || str_starts_with($relative, '/')) {
-                        throw new Exception(get_lang('Error importing file'));
-                    }
+                    $this->assertSafeEntryPath($relative);
                 }
 
                 if (false === $backUpFile->extractTo($destinationDir)) {
@@ -87,6 +85,11 @@ class MoodleImport
 
                 if (!$mainFileKey) {
                     throw new Exception(get_lang("Failed to import: this doesn't seem to be a Moodle course backup file (.mbz)"));
+                }
+
+                // Guard against ZIP Slip: validate all entry paths before extraction
+                foreach ($packageContent as $value) {
+                    $this->assertSafeEntryPath($value['filename']);
                 }
 
                 $package->extract(PCLZIP_OPT_PATH, $destinationDir);
@@ -391,6 +394,26 @@ class MoodleImport
         unlink($filePath);
 
         return true;
+    }
+
+    /**
+     * Reject a path entry that could escape the extraction directory (Zip Slip / path traversal).
+     *
+     * The path may come from an archive entry name or from an untrusted value inside the
+     * backup XML. Any entry containing a "../" sequence or an absolute path is rejected.
+     *
+     * @param string $path
+     *
+     * @throws Exception
+     *
+     * @return void
+     */
+    private function assertSafeEntryPath($path)
+    {
+        $normalized = str_replace('\\', '/', (string) $path);
+        if (str_contains($normalized, '../') || str_starts_with($normalized, '/')) {
+            throw new Exception(get_lang('Error importing file'));
+        }
     }
 
     /**

--- a/public/main/inc/lib/MoodleImport.php
+++ b/public/main/inc/lib/MoodleImport.php
@@ -174,7 +174,7 @@ class MoodleImport
 
         $xml = @file_get_contents($destinationDir.'/moodle_backup.xml');
         $doc = new DOMDocument();
-        $res = @$doc->loadXML($xml);
+        $res = @$doc->loadXML($xml, LIBXML_NONET);
 
         if (empty($res)) {
             removeDir($destinationDir);
@@ -433,7 +433,7 @@ class MoodleImport
     public function readForumModule($moduleXml)
     {
         $moduleDoc = new DOMDocument();
-        $moduleRes = @$moduleDoc->loadXML($moduleXml);
+        $moduleRes = @$moduleDoc->loadXML($moduleXml, LIBXML_NONET);
         if (empty($moduleRes)) {
             return false;
         }
@@ -460,7 +460,7 @@ class MoodleImport
     public function readResourceModule($moduleXml)
     {
         $moduleDoc = new DOMDocument();
-        $moduleRes = @$moduleDoc->loadXML($moduleXml);
+        $moduleRes = @$moduleDoc->loadXML($moduleXml, LIBXML_NONET);
         if (empty($moduleRes)) {
             return false;
         }
@@ -491,7 +491,7 @@ class MoodleImport
     public function readUrlModule($moduleXml)
     {
         $moduleDoc = new DOMDocument();
-        $moduleRes = @$moduleDoc->loadXML($moduleXml);
+        $moduleRes = @$moduleDoc->loadXML($moduleXml, LIBXML_NONET);
         if (empty($moduleRes)) {
             return false;
         }
@@ -518,7 +518,7 @@ class MoodleImport
     public function readQuizModule($moduleXml)
     {
         $moduleDoc = new DOMDocument();
-        $moduleRes = @$moduleDoc->loadXML($moduleXml);
+        $moduleRes = @$moduleDoc->loadXML($moduleXml, LIBXML_NONET);
         if (empty($moduleRes)) {
             return false;
         }
@@ -560,7 +560,7 @@ class MoodleImport
     public function readMainFilesXml($filesXml, $contextId)
     {
         $moduleDoc = new DOMDocument();
-        $moduleRes = @$moduleDoc->loadXML($filesXml);
+        $moduleRes = @$moduleDoc->loadXML($filesXml, LIBXML_NONET);
 
         if (empty($moduleRes)) {
             return false;
@@ -622,7 +622,7 @@ class MoodleImport
     public function readMainQuestionsXml($questionsXml, $questionId)
     {
         $moduleDoc = new DOMDocument();
-        $moduleRes = @$moduleDoc->loadXML($questionsXml);
+        $moduleRes = @$moduleDoc->loadXML($questionsXml, LIBXML_NONET);
         if (empty($moduleRes)) {
             return false;
         }
@@ -1160,7 +1160,7 @@ class MoodleImport
     public function getAllQuestionFiles($filesXml)
     {
         $moduleDoc = new DOMDocument();
-        $moduleRes = @$moduleDoc->loadXML($filesXml);
+        $moduleRes = @$moduleDoc->loadXML($filesXml, LIBXML_NONET);
 
         if (empty($moduleRes)) {
             return [];

--- a/public/main/inc/lib/MoodleImport.php
+++ b/public/main/inc/lib/MoodleImport.php
@@ -97,6 +97,12 @@ class MoodleImport
                 $package->extract(PCLZIP_OPT_PATH, $destinationDir);
 
                 break;
+            default:
+                // Reject anything that is not a recognised Moodle backup archive (gzip/zip)
+                removeDir($destinationDir);
+                unlink($filePath);
+
+                throw new Exception(get_lang("Failed to import: this doesn't seem to be a Moodle course backup file (.mbz)"));
         }
 
         $courseInfo = api_get_course_info();

--- a/public/main/inc/lib/MoodleImport.php
+++ b/public/main/inc/lib/MoodleImport.php
@@ -382,8 +382,13 @@ class MoodleImport
                     $moduleDir = $currentItem['directory'];
                     $moduleXml = @file_get_contents($destinationDir.'/'.$moduleDir.'/'.$moduleName.'.xml');
                     $moduleValues = $this->readUrlModule($moduleXml);
+                    $externalUrl = isset($moduleValues['externalurl']) ? (string) $moduleValues['externalurl'] : '';
+                    // Only import http(s) links; reject dangerous schemes (javascript:, data:, etc.)
+                    if (!preg_match('#^https?://#i', $externalUrl)) {
+                        break;
+                    }
                     $_POST['title'] = $moduleValues['name'];
-                    $_POST['url'] = $moduleValues['externalurl'];
+                    $_POST['url'] = $externalUrl;
                     $_POST['description'] = $moduleValues['intro'];
                     $_POST['category_id'] = 0;
                     $_POST['target'] = '_blank';

--- a/public/main/inc/lib/MoodleImport.php
+++ b/public/main/inc/lib/MoodleImport.php
@@ -29,8 +29,10 @@ class MoodleImport
         $cachePath = api_get_path(SYS_ARCHIVE_PATH);
         $tempPath = $uploadedFile['tmp_name'];
         $nameParts = explode('.', $uploadedFile['name']);
-        $extension = array_pop($nameParts);
-        $name = basename($tempPath).".$extension";
+        // Keep only alphanumerics from the user-supplied extension to prevent path separators
+        // or traversal sequences leaking into the stored filename.
+        $extension = preg_replace('/[^a-z0-9]/i', '', (string) array_pop($nameParts));
+        $name = basename($tempPath).('' !== $extension ? ".$extension" : '');
 
         if (!move_uploaded_file($tempPath, api_get_path(SYS_ARCHIVE_PATH).$name)) {
             throw new Exception(get_lang('Upload failed, please check maximum file size limits and folder rights.'));


### PR DESCRIPTION
Backport to the `2.0` branch of the security fixes merged to `master` in #8574.

Addresses **GHSA-94h4-9vrp-v3cv** (Zip Slip path traversal → RCE in Moodle course import) plus related hardening found while reviewing `MoodleImport.php`:

- Zip Slip path traversal in the `application/zip` branch (advisory) — validate every archive entry before extraction (shared `assertSafeEntryPath()` helper).
- Path traversal in module file reads via the untrusted `<directory>` node.
- Sanitization of the user-supplied upload file extension.
- `LIBXML_NONET` on all `loadXML()` calls (XXE hardening).
- URL scheme allowlist (`http(s)://`) for imported `url` resources (stored XSS).
- Deny-by-default rejection of unrecognised MIME types.

Cherry-pick of the 6 commits from #8574; the resulting `MoodleImport.php` is byte-identical to `master`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)