### PR TITLE
Security: SSRF via unprotected mPDF in legacy certificate generation (GHSA-mw74-xqfh-r8gj)

### DIFF
--- a/public/main/inc/lib/certificate.lib.php
+++ b/public/main/inc/lib/certificate.lib.php
@@ -2,6 +2,7 @@
 
 /* For licensing terms, see /license.txt */
 
+use Chamilo\CoreBundle\Component\Mpdf\SafeMpdfHttpClient;
 use Chamilo\CoreBundle\Entity\GradebookCategory;
 use Chamilo\CoreBundle\Entity\PersonalFile;
 use Chamilo\CoreBundle\Entity\ResourceFile;
@@ -1030,7 +1031,7 @@ class Certificate extends Model
             'margin_bottom'  => 0,
             'margin_header'  => 0,
             'margin_footer'  => 0,
-        ]);
+        ], SafeMpdfHttpClient::container());
         $mpdf->mirrorMargins = 0;
 
         // Safety: ensure HTML content is present; fetch from Resource if needed.


### PR DESCRIPTION
Refs advisory GHSA-mw74-xqfh-r8gj

## The fix

Route mPDF's asset fetches through `SafeMpdfHttpClient::container()`, exactly as the already-protected paths do (`CertificateController`, `AttendanceController`, `StudentPublicationController`, `pdf.lib.php`):

```php
$mpdf = new \Mpdf\Mpdf([... options ...], SafeMpdfHttpClient::container());
```

Two-line change: add the `use Chamilo\CoreBundle\Component\Mpdf\SafeMpdfHttpClient;` import and pass the container as the constructor's second argument.

## Invariant now enforced

Every remote asset mPDF fetches during legacy certificate rendering goes through `SafeMpdfHttpClient`, which delegates to `SafeHttpClientHelper` — applying private-network blocking and redirect filtering, and returning an empty response for blocked/unreachable URLs so mPDF silently skips the asset. The legacy path now matches the SSRF posture of the modern Symfony controllers.

## OWASP

A10:2021 — Server-Side Request Forgery (SSRF).

🤖 Generated with [Claude Code](https://claude.com/claude-code)