### PR TITLE
Security: Restrict allowed classes in Sequence::getUnSerializeGraph()

### DIFF
--- a/src/CoreBundle/Entity/Sequence.php
+++ b/src/CoreBundle/Entity/Sequence.php
@@ -11,6 +11,7 @@ use Doctrine\ORM\Mapping as ORM;
 use Fhaculty\Graph\Graph;
 use Gedmo\Timestampable\Traits\TimestampableEntity;
 use Stringable;
+use UnserializeApi;
 
 #[ORM\Table(name: 'sequence')]
 #[ORM\Entity(repositoryClass: SequenceRepository::class)]
@@ -82,7 +83,7 @@ class Sequence implements Stringable
      */
     public function getUnSerializeGraph()
     {
-        return unserialize($this->graph);
+        return UnserializeApi::unserialize('sequence_graph', $this->graph);
     }
 
     public function setGraphAndSerialize(Graph $graph): self


### PR DESCRIPTION
## Summary

`Sequence::getUnSerializeGraph()` (`src/CoreBundle/Entity/Sequence.php`) called bare `unserialize()` on the `sequence.graph` column with no class restriction, allowing any autoloadable PHP class to be instantiated during deserialization — a PHP Object Injection sink (CWE-502).

Refs GHSA-2c5g-hrhg-44vg

## Fix

Route the call through the codebase's canonical helper `UnserializeApi::unserialize()` (`public/main/inc/lib/UnserializeApi.php`) using the existing `'sequence_graph'` type, which already defines the allowlist for serialized sequence graphs:

- `Graph`, `VerticesMap`, `Vertices`, `Edges`, `Vertex`, `Edge\Base`, `Directed`, `Undirected`

This reuses the same allowlisted-deserialization mechanism applied elsewhere in the project (course backups, LP, `ExternalTool`) instead of inlining a per-call allowlist, keeping the policy centralized.

## Invariant now enforced

Deserializing `sequence.graph` can only instantiate the whitelisted `Fhaculty\Graph` classes. Any other serialized class (e.g. a gadget-chain payload) is decoded to `__PHP_Incomplete_Class` and its `__destruct`/`__wakeup` never runs — closing the object-injection path regardless of how the column was written.

## OWASP control

A08:2021 — Software and Data Integrity Failures (insecure deserialization).

🤖 Generated with [Claude Code](https://claude.com/claude-code)