### PR TITLE
Security: stored XSS via social group discussion thread title

### DIFF
--- a/assets/vue/components/usergroup/GroupDiscussions.vue
+++ b/assets/vue/components/usergroup/GroupDiscussions.vue
@@ -18,10 +18,7 @@
         @click="selectDiscussion(discussion)"
       >
         <div class="discussion-content">
-          <div
-            class="discussion-title"
-            v-html="discussion.title"
-          ></div>
+          <div class="discussion-title">{{ discussion.title }}</div>
           <div class="discussion-details">
             <i class="mdi mdi-message-reply-text icon"></i>
             <span>{{ discussion.repliesCount }} {{ t("Replies") }}</span>


### PR DESCRIPTION
## Problem

The discussion thread title in a social group was rendered as raw HTML (`v-html="discussion.title"`) in `usergroup/GroupDiscussions.vue`. Any group member (a regular student account suffices) could create a thread whose title contained an XSS payload that executed in every group member's browser — including teachers/admins sharing the group — on page load, with no victim interaction.

## Fix

Render the thread title as auto-escaped text (`{{ discussion.title }}`) instead of `v-html`. A discussion title is plain text and carries no legitimate markup, so escaping it fully neutralizes the sink while preserving the displayed title.

## Invariant now enforced

Group discussion titles can no longer inject markup or script into the group page; they are always displayed as inert text.

## OWASP control

A03:2021 – Injection (Stored Cross-Site Scripting).

Refs GHSA-9mpp-78g5-c22m

🤖 Generated with [Claude Code](https://claude.com/claude-code)