### PR TITLE
Security: enforce CSRF token validation on gradebook evaluation forms

### DIFF
--- a/public/main/gradebook/gradebook_add_eval.php
+++ b/public/main/gradebook/gradebook_add_eval.php
@@ -31,6 +31,10 @@ $form = new EvalForm(
 );
 
 if ($form->validate()) {
+    if (!Security::check_token('post')) {
+        api_not_allowed(true);
+    }
+    Security::clear_token();
     $values = $form->exportValues();
     $entityManager = Database::getManager();
     $course = $entityManager->getRepository(Course::class)->find(api_get_course_int_id());
@@ -165,6 +169,10 @@ echo Display::url(
 echo '</div>';
 
 echo '</div>';
+
+$token = Security::get_token();
+$form->addElement('hidden', 'sec_token');
+$form->setConstants(['sec_token' => $token]);
 
 $form->display();
 Display::display_footer();

--- a/public/main/gradebook/gradebook_edit_eval.php
+++ b/public/main/gradebook/gradebook_edit_eval.php
@@ -36,6 +36,10 @@ $form = new EvalForm(
     api_get_self().'?editeval='.intval($_GET['editeval']).'&'.api_get_cidreq()
 );
 if ($form->validate()) {
+    if (!Security::check_token('post')) {
+        api_not_allowed(true);
+    }
+    Security::clear_token();
     $values = $form->exportValues();
 
     $entityManager = Database::getManager();
@@ -106,5 +110,10 @@ $(function() {
 </script>';
 
 Display::display_header(get_lang('Edit evaluation'));
+
+$token = Security::get_token();
+$form->addElement('hidden', 'sec_token');
+$form->setConstants(['sec_token' => $token]);
+
 $form->display();
 Display::display_footer();


### PR DESCRIPTION
## Problem

The gradebook evaluation **add** (`gradebook_add_eval.php`) and **edit** (`gradebook_edit_eval.php`) endpoints are state-changing POST forms built on `EvalForm`/`FormValidator`. `FormValidator` does not inject or verify an anti-CSRF token by itself, so these forms processed forged cross-site submissions using only the victim's session cookie.

## Fix

Apply the standard Chamilo legacy CSRF idiom (the same one already used in `exercise/tests_category.php` and `group/settings.php`):

- On submit, validate `Security::check_token('post')` before any persistence; reject with `api_not_allowed(true)` if the token is missing/invalid, and `Security::clear_token()` on success.
- On the display path, emit a fresh token via `Security::get_token()` + a hidden `sec_token` element (`$form->addElement('hidden', 'sec_token')` + `setConstants`). `get_token()` is only called on the display path, never before `check_token()` on the processing request, so it never overwrites the session token being verified.

## Invariant now enforced

A gradebook evaluation can only be created or modified by a request that carries the per-session `sec_token` issued when the form was rendered; cross-site forged POSTs are rejected.

## OWASP control

A01:2021 – Broken Access Control (CWE-352, Cross-Site Request Forgery).

## ⚠ Scope / follow-up

The advisory describes the gradebook module's add/edit/**delete** endpoints generally. This PR covers the two evaluation form endpoints that are concretely named and share the identical `EvalForm` pattern. The same missing-CSRF pattern very likely affects sibling gradebook endpoints (`gradebook_edit_result.php`, `gradebook_add_result.php`, `gradebook_add_user.php`, `gradebook_edit_all.php`) and the deletion actions dispatched through `gradebook/index.php` action parameters. Those were left out of this minimal change because they have heterogeneous structures and deserve individual review; they should receive the same token idiom as a follow-up.

Refs GHSA-vjmr-7vxh-wpg2

🤖 Generated with [Claude Code](https://claude.com/claude-code)