### PR TITLE
Security: stored XSS via language name in admin panel

### DIFF
--- a/public/main/admin/languages.php
+++ b/public/main/admin/languages.php
@@ -282,15 +282,16 @@ while ($row = Database::fetch_array($result_select)) {
             $checked = ' checked="checked" ';
         }
 
+        $originalName = htmlspecialchars($row['original_name'], ENT_QUOTES, 'UTF-8');
         $row_td[] = '
             <input type="hidden" name="edit_id" value="'.$id.'" />
-            <input type="text" name="txt_name" value="'.$row['original_name'].'" />
+            <input type="text" name="txt_name" value="'.$originalName.'" />
             <input type="checkbox" '.$checked.' name="platformlanguage" id="platformlanguage" value="'.$row['isocode'].'" />
-            <label for="platformlanguage">'.sprintf(get_lang('%s as platform language'), $row['original_name']).'</label>
+            <label for="platformlanguage">'.sprintf(get_lang('%s as platform language'), $originalName).'</label>
             <input class="btn btn--primary" type="submit" name="Submit" value="'.get_lang('Validate').'" />
             <a name="value" />';
     } else {
-        $row_td[] = $row['original_name'];
+        $row_td[] = htmlspecialchars($row['original_name'], ENT_QUOTES, 'UTF-8');
     }
 
     $row_td[] = $row['english_name'].' ('.$row['isocode'].')';


### PR DESCRIPTION
## Problem

The admin language management list rendered the stored `original_name` of a language directly inside an HTML `value="..."` attribute (and also in a `<label>` and a table cell) without HTML-attribute encoding. A language name containing a double quote could break out of the attribute and inject an event handler, executing arbitrary JavaScript in the browser of any other administrator who opened the language list/edit form — an admin-to-admin stored XSS.

## Fix

Encode `original_name` with `htmlspecialchars($value, ENT_QUOTES, 'UTF-8')` at every point where it is rendered (the text input value, the platform-language label, and the read-only table cell). `ENT_QUOTES` neutralizes the double-quote attribute breakout.

## Invariant now enforced

The stored language name is always emitted as inert, attribute-safe text; it can no longer terminate the `value` attribute or inject markup/handlers.

## OWASP control

A03:2021 – Injection (Stored Cross-Site Scripting).

Refs GHSA-j9jg-h6cw-jj7v

🤖 Generated with [Claude Code](https://claude.com/claude-code)