### PR TITLE
Internals: keep soft-deleted users out of the user-to-URL list

### DIFF
--- a/public/main/admin/access_url_add_users_to_url.php
+++ b/public/main/admin/access_url_add_users_to_url.php
@@ -85,7 +85,7 @@ $first_letter_user_lower = Database::escape_string(api_strtolower($first_letter_
 $target_name = api_sort_by_first_name() ? 'firstname' : 'lastname';
 $target_name = 'lastname';
 $sql = "SELECT id, lastname, firstname, username FROM $tbl_user
-	    WHERE active <> ".USER_SOFT_DELETED." AND ".$target_name." LIKE '".$first_letter_user_lower."%' OR ".$target_name." LIKE '".$first_letter_user_lower."%'
+	    WHERE active <> ".USER_SOFT_DELETED." AND ".$target_name." LIKE '".$first_letter_user_lower."%'
 		ORDER BY ".(count($users) > 0 ? '(id IN('.implode(',', $users).')) DESC,' : '').' '.$target_name;
 $result = Database::query($sql);
 $db_users = Database::store_result($result);


### PR DESCRIPTION
## Problem

In `admin/access_url_add_users_to_url.php` the user-selection query combined `AND` and `OR` without parentheses:

```
WHERE active <> USER_SOFT_DELETED AND <name> LIKE '…%' OR <name> LIKE '…%'
```

Because `AND` binds tighter than `OR`, the engine evaluated it as `(active <> -2 AND name LIKE …) OR (name LIKE …)`, so the trailing `OR` clause matched users regardless of `active`, listing soft-deleted accounts in the admin user-to-URL assignment list.

## Root cause / fix

The `OR` was a **redundant leftover**, not a name search. Originally it matched the first letter in both original and lowercased form (`'A%' OR 'a%'`); a 2015 change (refs #7440) escaped the input into a single lowercased variable and used it on **both** sides of the `OR`, leaving two identical conditions. With Chamilo's case-insensitive collation a single lowercase `LIKE` already matches both cases.

So the `OR` is collapsed to a single `LIKE`:

```
WHERE active <> USER_SOFT_DELETED AND <name> LIKE '…%'
```

This removes the dead condition and the precedence ambiguity, so the `active`-status filter is always applied.

## Scope

Low-impact logic fix. The page is restricted to global platform administrators (`api_protect_global_admin_script()`), so this is a data-correctness issue (soft-deleted users shown in the picker), not a trust-boundary/security one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)