### PR TITLE
Security: Fix IDOR and mass-assignment in PushSubscription API resource

### DIFF
--- a/src/CoreBundle/Entity/PushSubscription.php
+++ b/src/CoreBundle/Entity/PushSubscription.php
@@ -6,7 +6,6 @@ declare(strict_types=1);
 
 namespace Chamilo\CoreBundle\Entity;
 
-use ApiPlatform\Doctrine\Orm\Filter\NumericFilter;
 use ApiPlatform\Doctrine\Orm\Filter\SearchFilter;
 use ApiPlatform\Metadata\ApiFilter;
 use ApiPlatform\Metadata\ApiResource;
@@ -15,6 +14,8 @@ use ApiPlatform\Metadata\Get;
 use ApiPlatform\Metadata\GetCollection;
 use ApiPlatform\Metadata\Post;
 use Chamilo\CoreBundle\Repository\PushSubscriptionRepository;
+use Chamilo\CoreBundle\State\PushSubscriptionStateProcessor;
+use Chamilo\CoreBundle\State\PushSubscriptionStateProvider;
 use DateTime;
 use Doctrine\ORM\Mapping as ORM;
 use Symfony\Component\Serializer\Attribute\Groups;
@@ -22,20 +23,27 @@ use Symfony\Component\Validator\Constraints as Assert;
 
 #[ApiResource(
     operations: [
-        new Get(security: "is_granted('ROLE_USER')"),
-        new Post(security: "is_granted('ROLE_USER')"),
-        new GetCollection(security: "is_granted('ROLE_USER')"),
-        new Delete(security: "is_granted('ROLE_USER')"),
+        new Get(
+            security: "is_granted('ROLE_USER')",
+        ),
+        new Post(
+            security: "is_granted('ROLE_USER')",
+        ),
+        new GetCollection(
+            security: "is_granted('ROLE_USER')",
+        ),
+        new Delete(
+            security: "is_granted('ROLE_USER')",
+        ),
     ],
     normalizationContext: ['groups' => ['pushsubscription:read']],
     denormalizationContext: ['groups' => ['pushsubscription:write']],
-    paginationClientEnabled: false
+    paginationClientEnabled: false,
+    provider: PushSubscriptionStateProvider::class,
+    processor: PushSubscriptionStateProcessor::class,
 )]
 #[ApiFilter(SearchFilter::class, properties: [
     'endpoint' => 'exact',
-])]
-#[ApiFilter(NumericFilter::class, properties: [
-    'user.id',
 ])]
 #[ORM\Table(name: 'push_subscription')]
 #[ORM\Index(columns: ['user_id'], name: 'idx_push_subscription_user')]
@@ -53,12 +61,12 @@ class PushSubscription
     #[ORM\Column(name: 'endpoint', type: 'text')]
     private string $endpoint;
 
-    #[Groups(['pushsubscription:read', 'pushsubscription:write'])]
+    #[Groups(['pushsubscription:write'])]
     #[Assert\NotBlank]
     #[ORM\Column(name: 'public_key', type: 'text')]
     private string $publicKey;
 
-    #[Groups(['pushsubscription:read', 'pushsubscription:write'])]
+    #[Groups(['pushsubscription:write'])]
     #[Assert\NotBlank]
     #[ORM\Column(name: 'auth_token', type: 'text')]
     private string $authToken;
@@ -79,7 +87,7 @@ class PushSubscription
     #[ORM\Column(name: 'updated_at', type: 'datetime')]
     private DateTime $updatedAt;
 
-    #[Groups(['pushsubscription:read', 'pushsubscription:write'])]
+    #[Groups(['pushsubscription:read'])]
     #[ORM\ManyToOne(targetEntity: User::class)]
     #[ORM\JoinColumn(name: 'user_id', referencedColumnName: 'id', onDelete: 'CASCADE')]
     private ?User $user = null;

--- a/src/CoreBundle/State/PushSubscriptionStateProcessor.php
+++ b/src/CoreBundle/State/PushSubscriptionStateProcessor.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+/* For licensing terms, see /license.txt */
+
+namespace Chamilo\CoreBundle\State;
+
+use ApiPlatform\Metadata\DeleteOperationInterface;
+use ApiPlatform\Metadata\Operation;
+use ApiPlatform\State\ProcessorInterface;
+use Chamilo\CoreBundle\Entity\PushSubscription;
+use Chamilo\CoreBundle\Helpers\UserHelper;
+use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
+
+/**
+ * Guards write operations on PushSubscription:
+ *  - on create, forces the owning `user` to the authenticated user, preventing
+ *    mass-assignment of the relation from the request body;
+ *  - on delete, validates that the caller owns the subscription (admins bypass)
+ *    before delegating to the remove processor.
+ *
+ * @implements ProcessorInterface<PushSubscription, PushSubscription|null>
+ */
+final readonly class PushSubscriptionStateProcessor implements ProcessorInterface
+{
+    public function __construct(
+        #[Autowire(service: 'api_platform.doctrine.orm.state.persist_processor')]
+        private ProcessorInterface $persistProcessor,
+        #[Autowire(service: 'api_platform.doctrine.orm.state.remove_processor')]
+        private ProcessorInterface $removeProcessor,
+        private UserHelper $userHelper,
+        private Security $security,
+    ) {}
+
+    public function process(mixed $data, Operation $operation, array $uriVariables = [], array $context = []): ?PushSubscription
+    {
+        $currentUser = $this->userHelper->getCurrent();
+        if (null === $currentUser) {
+            throw new AccessDeniedHttpException();
+        }
+
+        if ($operation instanceof DeleteOperationInterface) {
+            if ($data instanceof PushSubscription
+                && !$this->security->isGranted('ROLE_ADMIN')
+                && $data->getUser()?->getId() !== $currentUser->getId()
+            ) {
+                throw new AccessDeniedHttpException();
+            }
+
+            $this->removeProcessor->process($data, $operation, $uriVariables, $context);
+
+            return null;
+        }
+
+        if ($data instanceof PushSubscription) {
+            $data->setUser($currentUser);
+        }
+
+        return $this->persistProcessor->process($data, $operation, $uriVariables, $context);
+    }
+}

--- a/src/CoreBundle/State/PushSubscriptionStateProvider.php
+++ b/src/CoreBundle/State/PushSubscriptionStateProvider.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types=1);
+
+/* For licensing terms, see /license.txt */
+
+namespace Chamilo\CoreBundle\State;
+
+use ApiPlatform\Doctrine\Orm\Extension\FilterExtension;
+use ApiPlatform\Doctrine\Orm\Extension\OrderExtension;
+use ApiPlatform\Doctrine\Orm\Extension\PaginationExtension;
+use ApiPlatform\Doctrine\Orm\Extension\QueryResultCollectionExtensionInterface;
+use ApiPlatform\Doctrine\Orm\Util\QueryNameGenerator;
+use ApiPlatform\Metadata\CollectionOperationInterface;
+use ApiPlatform\Metadata\Operation;
+use ApiPlatform\State\ProviderInterface;
+use Chamilo\CoreBundle\Entity\PushSubscription;
+use Chamilo\CoreBundle\Helpers\UserHelper;
+use Chamilo\CoreBundle\Repository\PushSubscriptionRepository;
+use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+
+/**
+ * Restricts every read on push_subscriptions (item and collection) to the rows
+ * owned by the authenticated user. Platform administrators bypass the ownership
+ * scope and may read any subscription. Filtering (e.g. by `endpoint`), ordering
+ * and pagination on the collection are delegated to API Platform's Doctrine
+ * extensions.
+ *
+ * @implements ProviderInterface<PushSubscription>
+ */
+readonly class PushSubscriptionStateProvider implements ProviderInterface
+{
+    private array $extensions;
+
+    public function __construct(
+        FilterExtension $filterExtension,
+        OrderExtension $orderExtension,
+        PaginationExtension $paginationExtension,
+        #[Autowire(service: 'api_platform.doctrine.orm.state.item_provider')]
+        private ProviderInterface $itemProvider,
+        private PushSubscriptionRepository $repository,
+        private UserHelper $userHelper,
+        private Security $security,
+    ) {
+        $this->extensions = [
+            $filterExtension,
+            $orderExtension,
+            $paginationExtension,
+        ];
+    }
+
+    public function provide(Operation $operation, array $uriVariables = [], array $context = []): array|object|null
+    {
+        $currentUser = $this->userHelper->getCurrent();
+        if (null === $currentUser) {
+            return $operation instanceof CollectionOperationInterface ? [] : null;
+        }
+
+        $isAdmin = $this->security->isGranted('ROLE_ADMIN');
+
+        if ($operation instanceof CollectionOperationInterface) {
+            return $this->provideCollection($operation, $context, $isAdmin ? null : (int) $currentUser->getId());
+        }
+
+        $subscription = $this->itemProvider->provide($operation, $uriVariables, $context);
+
+        // Hide the item from non-owners (admins bypass the ownership scope) so a
+        // foreign id returns 404 instead of leaking its existence.
+        if ($subscription instanceof PushSubscription
+            && !$isAdmin
+            && $subscription->getUser()?->getId() !== $currentUser->getId()
+        ) {
+            return null;
+        }
+
+        return $subscription;
+    }
+
+    private function provideCollection(Operation $operation, array $context, ?int $userId): array|object
+    {
+        $queryNameGenerator = new QueryNameGenerator();
+        $queryBuilder = $this->repository->createQueryBuilder('p');
+
+        // Admins (null $userId) see every subscription; everyone else is scoped.
+        if (null !== $userId) {
+            $userParam = $queryNameGenerator->generateParameterName('user');
+            $queryBuilder
+                ->andWhere('p.user = :'.$userParam)
+                ->setParameter($userParam, $userId)
+            ;
+        }
+
+        foreach ($this->extensions as $extension) {
+            $extension->applyToCollection($queryBuilder, $queryNameGenerator, PushSubscription::class, $operation, $context);
+
+            if ($extension instanceof QueryResultCollectionExtensionInterface
+                && $extension->supportsResult(PushSubscription::class, $operation, $context)
+            ) {
+                return $extension->getResult($queryBuilder, PushSubscription::class, $operation, $context);
+            }
+        }
+
+        return $queryBuilder->getQuery()->getResult();
+    }
+}

--- a/tests/CoreBundle/Api/PushSubscriptionApiSecurityTest.php
+++ b/tests/CoreBundle/Api/PushSubscriptionApiSecurityTest.php
@@ -1,0 +1,230 @@
+<?php
+
+declare(strict_types=1);
+
+/* For licensing terms, see /license.txt */
+
+namespace Chamilo\Tests\CoreBundle\Api;
+
+use Chamilo\CoreBundle\Entity\PushSubscription;
+use Chamilo\CoreBundle\Entity\User;
+use Chamilo\CoreBundle\Repository\PushSubscriptionRepository;
+use Chamilo\Tests\AbstractApiTest;
+use Chamilo\Tests\ChamiloTestTrait;
+use Doctrine\ORM\EntityManagerInterface;
+
+/**
+ * Regression tests for the PushSubscription IDOR / mass-assignment advisory.
+ *
+ * The advisory (reporter: Nguyen Manh Thuan, 2026-05-20) reported that every
+ * operation on /api/push_subscriptions was gated only by is_granted('ROLE_USER'),
+ * with the `user` relation in the write group and the cryptographic `authToken`
+ * in the read group. As a result any authenticated low-privileged user could:
+ *
+ *   1. Read the Web Push secrets (endpoint, publicKey, authToken) of every user.
+ *   2. Create a subscription owned by another user (mass-assignment of `user`)
+ *      to hijack server-initiated push notifications.
+ *   3. Delete any user's subscription.
+ *
+ * These tests assert the expected post-fix behaviour:
+ *   - a user may only read/delete their own subscription (object.user == user);
+ *   - the collection only ever returns the caller's own rows, even when the
+ *     `user.id`/`endpoint` filters target a victim;
+ *   - the `authToken`/`publicKey` secrets are never serialized in responses;
+ *   - the owning `user` cannot be mass-assigned on POST — the persisted row is
+ *     always owned by the authenticated caller.
+ */
+final class PushSubscriptionApiSecurityTest extends AbstractApiTest
+{
+    use ChamiloTestTrait;
+
+    /**
+     * Persists one PushSubscription owned by the given user and returns it.
+     */
+    private function seedSubscription(User $owner, string $suffix): PushSubscription
+    {
+        /** @var EntityManagerInterface $em */
+        $em = self::getContainer()->get(EntityManagerInterface::class);
+
+        $subscription = (new PushSubscription())
+            ->setEndpoint('https://push.example/endpoint-'.$suffix)
+            ->setPublicKey('public-key-'.$suffix)
+            ->setAuthToken('secret-auth-token-'.$suffix)
+            ->setContentEncoding('aesgcm')
+            ->setUserAgent('PHPUnit')
+            ->setUser($owner)
+        ;
+
+        $em->persist($subscription);
+        $em->flush();
+
+        return $subscription;
+    }
+
+    public function testForeignUserCannotReadOthersSubscription(): void
+    {
+        $victim = $this->createUser('push_sec_victim_read');
+        $attacker = $this->createUser('push_sec_attacker_read');
+        $subscription = $this->seedSubscription($victim, 'read');
+
+        $token = $this->getUserTokenFromUser($attacker);
+        $this->createClientWithCredentials($token)->request(
+            'GET',
+            '/api/push_subscriptions/'.$subscription->getId(),
+        );
+
+        // The provider scopes items to the caller, so a foreign id is not found
+        // rather than forbidden — its existence is never disclosed.
+        $this->assertResponseStatusCodeSame(404);
+    }
+
+    public function testOwnerCanReadOwnSubscription(): void
+    {
+        $owner = $this->createUser('push_sec_owner_read');
+        $subscription = $this->seedSubscription($owner, 'owner');
+
+        $token = $this->getUserTokenFromUser($owner);
+        $this->createClientWithCredentials($token)->request(
+            'GET',
+            '/api/push_subscriptions/'.$subscription->getId(),
+        );
+
+        $this->assertResponseStatusCodeSame(200);
+    }
+
+    public function testAdminCanReadAnyUsersSubscription(): void
+    {
+        $victim = $this->createUser('push_sec_victim_admin_read');
+        $admin = $this->createUser('push_sec_admin_read', '', '', 'ROLE_ADMIN');
+        $subscription = $this->seedSubscription($victim, 'admin_read');
+
+        $token = $this->getUserTokenFromUser($admin);
+        $this->createClientWithCredentials($token)->request(
+            'GET',
+            '/api/push_subscriptions/'.$subscription->getId(),
+        );
+
+        $this->assertResponseStatusCodeSame(200);
+    }
+
+    public function testAdminCollectionSeesOtherUsersSubscriptions(): void
+    {
+        $victim = $this->createUser('push_sec_victim_admin_list');
+        $admin = $this->createUser('push_sec_admin_list', '', '', 'ROLE_ADMIN');
+        $victimSub = $this->seedSubscription($victim, 'admin_list');
+
+        $token = $this->getUserTokenFromUser($admin);
+        $response = $this->createClientWithCredentials($token)->request(
+            'GET',
+            '/api/push_subscriptions?user.id='.$victim->getId(),
+        );
+
+        $this->assertResponseStatusCodeSame(200);
+
+        $userIris = array_column($response->toArray()['hydra:member'] ?? [], 'user');
+        $this->assertContains(
+            '/api/users/'.$victim->getId(),
+            $userIris,
+            'An admin must be able to list subscriptions owned by other users.'
+        );
+        $this->assertNotNull($victimSub->getId());
+    }
+
+    public function testCollectionOnlyReturnsOwnSubscriptionsEvenWhenFilteringVictim(): void
+    {
+        $victim = $this->createUser('push_sec_victim_list');
+        $attacker = $this->createUser('push_sec_attacker_list');
+        $victimSub = $this->seedSubscription($victim, 'list_victim');
+        $this->seedSubscription($attacker, 'list_attacker');
+
+        $token = $this->getUserTokenFromUser($attacker);
+
+        // Even targeting the victim directly via the legacy filters must not leak.
+        $response = $this->createClientWithCredentials($token)->request(
+            'GET',
+            '/api/push_subscriptions?user.id='.$victim->getId().'&endpoint='.urlencode($victimSub->getEndpoint()),
+        );
+
+        $this->assertResponseStatusCodeSame(200);
+
+        $members = $response->toArray()['hydra:member'] ?? [];
+        foreach ($members as $member) {
+            $this->assertSame(
+                '/api/users/'.$attacker->getId(),
+                $member['user'] ?? null,
+                'The push_subscriptions collection must only return rows owned by the caller.'
+            );
+        }
+    }
+
+    public function testCollectionDoesNotExposeWebPushSecrets(): void
+    {
+        $owner = $this->createUser('push_sec_owner_secrets');
+        $this->seedSubscription($owner, 'secrets');
+
+        $token = $this->getUserTokenFromUser($owner);
+        $response = $this->createClientWithCredentials($token)->request('GET', '/api/push_subscriptions');
+
+        $this->assertResponseStatusCodeSame(200);
+
+        $members = $response->toArray()['hydra:member'] ?? [];
+        $this->assertNotEmpty($members);
+        foreach ($members as $member) {
+            $this->assertArrayNotHasKey('authToken', $member, 'The RFC 8291 authToken secret must never be serialized.');
+            $this->assertArrayNotHasKey('publicKey', $member, 'The publicKey must never be serialized.');
+        }
+    }
+
+    public function testCannotMassAssignUserOnPost(): void
+    {
+        $victim = $this->createUser('push_sec_victim_post');
+        $attacker = $this->createUser('push_sec_attacker_post');
+
+        $token = $this->getUserTokenFromUser($attacker);
+        $response = $this->createClientWithCredentials($token)->request(
+            'POST',
+            '/api/push_subscriptions',
+            [
+                'json' => [
+                    'endpoint' => 'https://attacker.example/collector',
+                    'publicKey' => 'attacker-public-key',
+                    'authToken' => 'attacker-auth-token',
+                    'contentEncoding' => 'aesgcm',
+                    'user' => '/api/users/'.$victim->getId(),
+                ],
+            ],
+        );
+
+        $this->assertResponseStatusCodeSame(201);
+
+        // The owning user must be forced to the authenticated caller, never the victim.
+        $this->assertSame('/api/users/'.$attacker->getId(), $response->toArray()['user'] ?? null);
+
+        /** @var PushSubscriptionRepository $repository */
+        $repository = self::getContainer()->get(PushSubscriptionRepository::class);
+        $persisted = $repository->findOneByEndpoint('https://attacker.example/collector');
+        $this->assertNotNull($persisted);
+        $this->assertSame(
+            $attacker->getId(),
+            $persisted->getUser()?->getId(),
+            'The persisted subscription must be owned by the caller, not the mass-assigned victim.'
+        );
+    }
+
+    public function testForeignUserCannotDeleteOthersSubscription(): void
+    {
+        $victim = $this->createUser('push_sec_victim_del');
+        $attacker = $this->createUser('push_sec_attacker_del');
+        $subscription = $this->seedSubscription($victim, 'del');
+        $id = $subscription->getId();
+
+        $token = $this->getUserTokenFromUser($attacker);
+        $this->createClientWithCredentials($token)->request('DELETE', '/api/push_subscriptions/'.$id);
+
+        $this->assertResponseStatusCodeSame(404);
+
+        /** @var PushSubscriptionRepository $repository */
+        $repository = self::getContainer()->get(PushSubscriptionRepository::class);
+        $this->assertNotNull($repository->find($id), 'The victim subscription must survive a foreign delete attempt.');
+    }
+}


### PR DESCRIPTION
## Summary

The `PushSubscription` API Platform resource (`/api/push_subscriptions`) gated all four operations (`Get`, `GetCollection`, `Post`, `Delete`) with only `is_granted('ROLE_USER')`, exposed the `user` relation in the write serialization group and the RFC 8291 `authToken` secret in the read group. As a result, any authenticated low-privileged user could:

1. **Read every user's Web Push secrets** (`endpoint`, `publicKey`, `authToken`) via `GET /api/push_subscriptions` (or targeted via the `user.id` filter).
2. **Hijack another user's push notifications** by creating a subscription owned by the victim (`"user": "/api/users/{victimId}"` in the POST body) — re-routing the plaintext of server-initiated notifications to an attacker-controlled endpoint.
3. **Delete any user's subscription**, silencing notifications.

`authToken` is a cryptographic secret (RFC 8291 / RFC 8188) that must stay confidential, and the mass-assignable `user` lets confidential message plaintext escape the LMS trust boundary.

**Vulnerability classes:** CWE-639 (IDOR), CWE-915 (Mass Assignment), CWE-200 (Sensitive Information Exposure), CWE-285 (Improper Authorization).

## Changes

- **`Get` / `GetCollection` / `Delete`** now use a new `PushSubscriptionStateProvider` (declared at resource level), which scopes items and collections to the authenticated user. Platform admins (`is_granted('ROLE_ADMIN')`) bypass the scope. The item operation delegates to the default `item_provider` and hides foreign rows, so a non-owned id returns **404** (no existence disclosure) instead of leaking data. Collection filtering/ordering/pagination are delegated to API Platform's Doctrine extensions.
- **`Post` / `Delete`** now use a new `PushSubscriptionStateProcessor` (declared at resource level): on create it forces the owning `user` to the authenticated caller before persisting (preventing mass-assignment); on delete it validates ownership (admins bypass) before delegating to the remove processor.
- **Serialization groups hardened:** `user` is now read-only; `publicKey` and `authToken` are write-only and never serialized back (the browser already holds them via `PushManager.getSubscription()`).
- **Removed the `NumericFilter` on `user.id`** (the targeted-lookup aggravator, now redundant).
- **Added `PushSubscriptionApiSecurityTest`** — regression coverage for owner-only read/delete (foreign → 404), no mass-assignment of `user`, secrets never serialized, and admin access.

The Vue frontend (`usePushSubscription.js`) is unaffected: it only ever operates on the current user's own subscriptions, sends its own `user.id`, and does not consume the secrets from API responses.

## OWASP control

**A01 – Broken Access Control:** object-level authorization enforced server-side in a single place (the provider/processor), never trusting the client-supplied `user`. Reinforced with **A02 – Cryptographic Failures** by no longer echoing the `authToken` secret.

## Test plan

- [x] `php bin/phpunit tests/CoreBundle/Api/PushSubscriptionApiSecurityTest.php` → 8 tests, 25 assertions, green
- [x] ECS clean on all touched `src/` files
- [x] Psalm clean on the new State classes

## Credits

- Reporter: Nguyen Manh Thuan (manhthuan.2902@gmail.com) — Discovery date: 2026-05-20

🤖 Generated with [Claude Code](https://claude.com/claude-code)
