### PR TITLE
Security: Path traversal + arbitrary file write via sub-language admin panel

### DIFF
--- a/public/main/inc/lib/sub_language.class.php
+++ b/public/main/inc/lib/sub_language.class.php
@@ -626,6 +626,14 @@ class SubLanguageManager
      */
     public static function updateOrAddMsgid($filename, $msgid, $content): array
     {
+        // Strip any directory component and enforce the expected .po naming so a
+        // crafted filename (e.g. "../../public/shell.php") cannot escape the
+        // translations directory and overwrite an arbitrary file.
+        $filename = basename((string) $filename);
+        if (1 !== preg_match('/^messages\.[A-Za-z0-9_]+\.po$/', $filename)) {
+            return ['success' => false, 'error' => 'Invalid filename'];
+        }
+
         $filePath = api_get_path(SYS_PATH) . self::SUBLANGUAGE_TRANS_PATH .  $filename;
 
         if (!file_exists($filePath)) {


### PR DESCRIPTION
## Summary

`SubLanguageManager::updateOrAddMsgid()` (`public/main/inc/lib/sub_language.class.php`) built the destination path by concatenating the client-supplied `filename` straight onto the translations directory before calling `file_put_contents()`. A crafted `filename` could therefore traverse out of the translations directory and write attacker-controlled content to an arbitrary file.

Refs GHSA-rpp3-vpc9-w3h2

## Fix

Before any filesystem access, the filename is now:

- normalized with `basename()`, which strips every directory component (defeating `../` traversal), and
- validated against the canonical `messages.<code>.po` pattern; anything else is rejected with an `Invalid filename` error.

## Invariant now enforced

Writes from this endpoint can only ever target a legitimately-named `.po` file located **inside** the translations directory — never an attacker-chosen path. This matches the only filename the UI ever sends (`messages.$code.po`), so legitimate sub-language editing is unaffected.

## OWASP

A01 Broken Access Control / Path Traversal (CWE-22) and arbitrary file write (CWE-73). Although the endpoint is gated behind `api_protect_admin_script()`, the sink performed no path containment; this adds defense-in-depth and removes the file-write primitive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)