### PR TITLE
Security: Remove path-traversal-prone placeholder endpoints in FileManagerController

### DIFF
--- a/src/CoreBundle/Controller/FileManagerController.php
+++ b/src/CoreBundle/Controller/FileManagerController.php
@@ -106,6 +106,10 @@ class FileManagerController extends AbstractController
     #[Route('/download/{filename}', name: 'file_manager_download', methods: ['GET'])]
     public function download(string $filename): Response
     {
+        // Strip any directory component so the route parameter cannot be used to
+        // traverse outside the intended storage directory (e.g. "..%2F..%2Fetc%2Fpasswd").
+        $filename = basename($filename);
+
         // Implement logic to download files
         // Replace 'path/to/your/files' with the actual path where the files are stored
         $filePath = 'path/to/your/files/'.$filename;

--- a/src/CoreBundle/Controller/FileManagerController.php
+++ b/src/CoreBundle/Controller/FileManagerController.php
@@ -11,7 +11,6 @@ use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\EntityManagerInterface;
 use Exception;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
-use Symfony\Component\HttpFoundation\BinaryFileResponse;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -34,22 +33,6 @@ class FileManagerController extends AbstractController
         $this->baseResourceFileAction = $baseResourceFileAction;
         $this->personalFileRepository = $personalFileRepository;
         $this->entityManager = $entityManager;
-    }
-
-    #[Route('/list', name: 'file_manager_list', methods: ['GET'])]
-    public function list(): JsonResponse
-    {
-        // Implement logic to list files and folders
-        // This could be a call to your service or logic to retrieve files/folders
-        return $this->json(['files' => []]);
-    }
-
-    #[Route('/upload', name: 'file_manager_upload', methods: ['POST'])]
-    public function upload(): JsonResponse
-    {
-        // Implement logic to upload files
-        // This part will handle receiving and storing uploaded files
-        return $this->json(['message' => 'File(s) uploaded successfully']);
     }
 
     /**
@@ -80,40 +63,5 @@ class FileManagerController extends AbstractController
             'data' => $result,
             'location' => $this->personalFileRepository->getResourceFileUrl($resource),
         ]);
-    }
-
-    #[Route('/create-folder', name: 'file_manager_create_folder', methods: ['POST'])]
-    public function createFolder(): JsonResponse
-    {
-        // Implement logic to create new folders
-        return $this->json(['message' => 'Folder created successfully']);
-    }
-
-    #[Route('/rename', name: 'file_manager_rename', methods: ['POST'])]
-    public function rename(): JsonResponse
-    {
-        // Implement logic to rename files/folders
-        return $this->json(['message' => 'File/folder renamed successfully']);
-    }
-
-    #[Route('/delete', name: 'file_manager_delete', methods: ['DELETE'])]
-    public function delete(): JsonResponse
-    {
-        // Implement logic to delete files/folders
-        return $this->json(['message' => 'File/folder deleted successfully']);
-    }
-
-    #[Route('/download/{filename}', name: 'file_manager_download', methods: ['GET'])]
-    public function download(string $filename): Response
-    {
-        // Strip any directory component so the route parameter cannot be used to
-        // traverse outside the intended storage directory (e.g. "..%2F..%2Fetc%2Fpasswd").
-        $filename = basename($filename);
-
-        // Implement logic to download files
-        // Replace 'path/to/your/files' with the actual path where the files are stored
-        $filePath = 'path/to/your/files/'.$filename;
-
-        return new BinaryFileResponse($filePath);
     }
 }


### PR DESCRIPTION
## Summary

`FileManagerController` shipped a set of placeholder/scaffolding actions, none of which are referenced anywhere in the codebase (verified across `src/`, `public/`, `assets/`, `templates/`, `config/`, `tests/`, and route-name / URL / `generateUrl` lookups). One of them, `download()`, built the served file path directly from the `{filename}` route parameter and handed it to `BinaryFileResponse`, exposing a path-traversal sink reachable by any authenticated user.

Refs GHSA-7jqm-3829-36cm

## Fix

The unused placeholder actions — `download`, `list`, `upload`, `createFolder`, `rename`, `delete` — are removed, which deletes the path-traversal sink at the source rather than merely containing it. The now-unused `BinaryFileResponse` import is dropped.

Only `uploadImage` is kept: it has a real implementation backed by `PersonalFile` / `BaseResourceFileAction`.

## Invariant now enforced

There is no longer any route in this controller that turns client input into a filesystem path. The traversal primitive is gone, not just sanitized.

## Note

The remaining `uploadImage` action is also currently unreferenced; full removal of the controller is under internal review by the team and can follow separately if confirmed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)