### PR TITLE
Security: Exposed test token generation endpoint enables privilege escalation

### DIFF
--- a/src/CoreBundle/Controller/ValidationTokenController.php
+++ b/src/CoreBundle/Controller/ValidationTokenController.php
@@ -19,7 +19,6 @@ use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Attribute\Route;
-use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 
 #[Route('/validate')]
@@ -69,21 +68,6 @@ class ValidationTokenController extends AbstractController
         return $this->render('@ChamiloCore/Validation/success.html.twig', [
             'type' => $type,
         ]);
-    }
-
-    #[Route('/test/generate-token/{type}/{resourceId}', name: 'test_generate_token')]
-    public function testGenerateToken(string $type, int $resourceId): Response
-    {
-        $typeId = $this->validationTokenHelper->getTypeId($type);
-        $token = new ValidationToken($typeId, $resourceId);
-        $this->tokenRepository->save($token, true);
-
-        $validationLink = $this->generateUrl('validate_token', [
-            'type' => $type,
-            'hash' => $token->getHash(),
-        ], UrlGeneratorInterface::ABSOLUTE_URL);
-
-        return new Response("Generated token: {$token->getHash()}<br>Validation link: <a href='{$validationLink}'>{$validationLink}</a>");
     }
 
     /**


### PR DESCRIPTION
## Summary

`ValidationTokenController` (`src/CoreBundle/Controller/ValidationTokenController.php`) exposed a `test_generate_token` route that created a valid `ValidationToken` for an arbitrary resource id without any authorization check. Because validation tokens gate privileged actions (such as unsubscribing a user from a ticket), any caller able to reach the route could forge a token and drive those actions against resources they do not own.

Refs GHSA-9g35-w847-rpp8

## Fix

The `testGenerateToken()` method and its route are removed. It was a test-only helper, referenced nowhere in the codebase and generating its link with a route name that no longer exists, so it served no production purpose. Gating it would have left a token-minting primitive in place for no benefit; deletion removes it cleanly. The now-unused `UrlGeneratorInterface` import is dropped as well.

## Invariant now enforced

`ValidationToken` instances can only be issued through the authorized `ValidationTokenHelper` flow. There is no longer any route that mints tokens for arbitrary resources without an authorization check.

## OWASP

A01 Broken Access Control / Improper Privilege Management (CWE-269). The missing authorization on a security-token generation endpoint allowed privilege escalation; removing the endpoint closes it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)