### PR TITLE
Security: Unauthenticated Template Deletion

### DIFF
--- a/src/CoreBundle/Controller/TemplateController.php
+++ b/src/CoreBundle/Controller/TemplateController.php
@@ -88,6 +88,13 @@ class TemplateController extends AbstractController
     #[Route('/document-templates/{documentId}/delete', methods: ['POST'])]
     public function deleteDocumentTemplate(int $documentId, EntityManagerInterface $entityManager): Response
     {
+        $document = $entityManager->getRepository(CDocument::class)->find($documentId);
+        if (!$document) {
+            return $this->json(['error' => 'Document not found.'], Response::HTTP_NOT_FOUND);
+        }
+
+        $this->denyAccessUnlessGranted('EDIT', $document->getResourceNode());
+
         $template = $entityManager->getRepository(Templates::class)->findOneBy(['refDoc' => $documentId]);
 
         if (!$template) {
@@ -96,13 +103,8 @@ class TemplateController extends AbstractController
 
         $entityManager->remove($template);
 
-        $document = $entityManager->getRepository(CDocument::class)->find($documentId);
-        if ($document) {
-            $document->setTemplate(false);
-            $entityManager->persist($document);
-        } else {
-            return $this->json(['error' => 'Document not found.'], Response::HTTP_NOT_FOUND);
-        }
+        $document->setTemplate(false);
+        $entityManager->persist($document);
 
         $entityManager->flush();
 

--- a/src/CoreBundle/Controller/TemplateController.php
+++ b/src/CoreBundle/Controller/TemplateController.php
@@ -14,6 +14,7 @@ use Chamilo\CoreBundle\Repository\AssetRepository;
 use Chamilo\CoreBundle\Repository\Node\CourseRepository;
 use Chamilo\CoreBundle\Repository\SystemTemplateRepository;
 use Chamilo\CoreBundle\Repository\TemplatesRepository;
+use Chamilo\CoreBundle\Security\Authorization\Voter\CourseVoter;
 use Chamilo\CoreBundle\Settings\SettingsManager;
 use Chamilo\CourseBundle\Entity\CDocument;
 use Chamilo\CourseBundle\Repository\CDocumentRepository;
@@ -93,7 +94,12 @@ class TemplateController extends AbstractController
             return $this->json(['error' => 'Document not found.'], Response::HTTP_NOT_FOUND);
         }
 
-        $this->denyAccessUnlessGranted('EDIT', $document->getResourceNode());
+        $course = $document->getFirstResourceLink()?->getCourse();
+        if (!$course instanceof Course) {
+            throw $this->createAccessDeniedException();
+        }
+
+        $this->denyAccessUnlessGranted(CourseVoter::EDIT, $course);
 
         $template = $entityManager->getRepository(Templates::class)->findOneBy(['refDoc' => $documentId]);
 


### PR DESCRIPTION
Requires the requester to be a teacher of the course that owns the referenced document (`CourseVoter::EDIT`, i.e. course teacher or admin) before deleting its document template, matching the `isCurrentTeacher` gate used in the frontend. The course is resolved from the document itself, so an attacker cannot bypass the check by supplying a different course context. Closes an endpoint that previously allowed any unauthenticated user to delete arbitrary templates.

Refs GHSA-37fh-r78h-9vvr