### PR TITLE
Security: Unauthenticated Template Creation via /template/document-templates/create

### DIFF
--- a/src/CoreBundle/Controller/TemplateController.php
+++ b/src/CoreBundle/Controller/TemplateController.php
@@ -14,6 +14,7 @@ use Chamilo\CoreBundle\Repository\AssetRepository;
 use Chamilo\CoreBundle\Repository\Node\CourseRepository;
 use Chamilo\CoreBundle\Repository\SystemTemplateRepository;
 use Chamilo\CoreBundle\Repository\TemplatesRepository;
+use Chamilo\CoreBundle\Security\Authorization\Voter\CourseVoter;
 use Chamilo\CoreBundle\Settings\SettingsManager;
 use Chamilo\CourseBundle\Entity\CDocument;
 use Chamilo\CourseBundle\Repository\CDocumentRepository;
@@ -45,7 +46,12 @@ class TemplateController extends AbstractController
             return $this->json(['error' => 'Document not found.'], Response::HTTP_NOT_FOUND);
         }
 
-        $this->denyAccessUnlessGranted('EDIT', $document->getResourceNode());
+        $documentCourse = $document->getFirstResourceLink()?->getCourse();
+        if (!$documentCourse instanceof Course) {
+            throw $this->createAccessDeniedException();
+        }
+
+        $this->denyAccessUnlessGranted(CourseVoter::EDIT, $documentCourse);
 
         $user = $userHelper->getCurrent();
         $course = null;

--- a/src/CoreBundle/Controller/TemplateController.php
+++ b/src/CoreBundle/Controller/TemplateController.php
@@ -40,6 +40,13 @@ class TemplateController extends AbstractController
             return $this->json(['error' => 'No image provided.'], Response::HTTP_BAD_REQUEST);
         }
 
+        $document = $entityManager->getRepository(CDocument::class)->find($documentId);
+        if (!$document) {
+            return $this->json(['error' => 'Document not found.'], Response::HTTP_NOT_FOUND);
+        }
+
+        $this->denyAccessUnlessGranted('EDIT', $document->getResourceNode());
+
         $user = $userHelper->getCurrent();
         $course = null;
         if ($cid) {
@@ -62,13 +69,8 @@ class TemplateController extends AbstractController
         $template->setImage($asset);
         $entityManager->persist($template);
 
-        $document = $entityManager->getRepository(CDocument::class)->find($documentId);
-        if ($document) {
-            $document->setTemplate(true);
-            $entityManager->persist($document);
-        } else {
-            return $this->json(['error' => 'Document not found.'], Response::HTTP_NOT_FOUND);
-        }
+        $document->setTemplate(true);
+        $entityManager->persist($document);
 
         $entityManager->flush();
 


### PR DESCRIPTION
Requires the requester to be a teacher of the course that owns the referenced document (`CourseVoter::EDIT`, i.e. course teacher or admin) before creating a document template and flagging the document as a template, matching the `isCurrentTeacher` gate used in the frontend. The course is resolved from the document itself (via `refDoc`), so an attacker cannot authorize the action against an unrelated course supplied in `cid`. Closes an endpoint that previously accepted unauthenticated, attacker-controlled `refDoc`/`cid` values.

Refs GHSA-hg2v-955j-35c3