### PR TITLE
Fix: orphaned documents/folders when SPA loses ?cid= in URL — non-admin teachers can't upload

### DIFF
--- a/assets/vue/services/documents.js
+++ b/assets/vue/services/documents.js
@@ -1,6 +1,9 @@
 import makeService, { asResponse, toServiceError } from "./api"
 import baseService from "./baseService"
 import prettyBytes from "pretty-bytes"
+import api from "../config/api"
+import { useCidReqStore } from "../store/cidReq"
+import { getCourseContext } from "../utils/courseContext"
 
 const oldService = makeService("documents")
 
@@ -220,11 +223,52 @@ export default {
 
   /**
    * Override createWithFormData only for documents to avoid breaking other modules.
-   * This keeps api.js untouched and prevents sending searchFieldValues as "[object Object]".
+   * Two reasons:
+   * 1. Flattens searchFieldValues so FormData does not serialize them as "[object Object]".
+   * 2. Forces the current course/session/group context (cid/sid/gid) onto the POST URL.
+   *    The shared axios interceptor in config/api.js reads getRawCourseContext() from
+   *    window.location.search, which is empty when the SPA navigates without preserving
+   *    ?cid=. Without cid in the request, CidReqListener wipes the session course;
+   *    CreateDocumentFileAction then builds a resource_link with no cid, and the new
+   *    document hangs orphaned (not visible in the course documents list). Reading the
+   *    Pinia cidReq store directly here is the canonical source maintained by the
+   *    router guards and survives URL changes.
    */
-  createWithFormData(payload) {
+  async createWithFormData(payload) {
     const prepared = flattenSearchFieldValues(payload)
-    return oldService.createWithFormData(prepared)
+    const formData = buildFormData(prepared)
+
+    // Course context: Pinia store is authoritative; getCourseContext() (URL-based)
+    // is the fallback for early init before the store is hydrated.
+    let cid = 0
+    let sid = 0
+    let gid = 0
+    try {
+      const store = useCidReqStore()
+      cid = Number(store.course?.id ?? 0) || 0
+      sid = Number(store.session?.id ?? 0) || 0
+      gid = Number(store.group?.id ?? 0) || 0
+    } catch {
+      // Pinia not active (test or pre-mount) — fall through to URL parse.
+    }
+    if (!cid) {
+      const fromUrl = getCourseContext()
+      cid = fromUrl.cid
+      sid = fromUrl.sid
+      gid = fromUrl.gid
+    }
+
+    const params = {}
+    if (cid > 0) params.cid = cid
+    if (sid > 0) params.sid = sid
+    if (gid > 0) params.gid = gid
+
+    try {
+      const response = await api.post("/api/documents", formData, { params })
+      return asResponse(response)
+    } catch (error) {
+      throw toServiceError(error)
+    }
   },
 
   /**


### PR DESCRIPTION
## Summary

Folders and documents created via the SPA can end up **orphaned** — created in the database but invisible in the course documents list — when the URL is missing `?cid=…`. This happens because:

- The shared axios request interceptor in `assets/vue/config/api.js` reads `getRawCourseContext()` from `window.location.search` and injects `cid/sid/gid` into `config.params`. When the SPA navigates inside a course without preserving `?cid=…` in the URL (e.g. after entering a sub-folder), that read returns `null`s, no params are injected, and the POST goes out as plain `/api/documents` with no query.
- Server-side, `CidReqListener` sees an empty `cid` and calls `cleanSessionHandler()`, wiping `session.course`.
- `CreateDocumentFileAction` then runs `buildResourceLinkListFromContext()` which finds no course in session and no `cid` in the query, so the `resource_link` is built without `cid`.
- The new document is created but has no `resource_link` binding it to the course, so it disappears from the documents list right after creation.

The security check still passes because admins inherit `ROLE_CURRENT_COURSE_TEACHER` via Symfony's `role_hierarchy` (`config/packages/security.yaml`), which **masks the bug for everyone with `ROLE_ADMIN`**. Teachers without admin role hit it.

Affected: every `/api/documents` POST going through `makeService("documents").createWithFormData` — i.e. folder creation and any flow using `store.dispatch("documents/createWithFormData", …)`. The chunked uploader at `DocumentsUpload.vue:609` was already constructing its own URL with explicit `cid/sid/gid` and is unaffected.

## Fix

Surgical override in `assets/vue/services/documents.js`:

- Override `createWithFormData` to construct its own POST request.
- Read `cid/sid/gid` from the Pinia `cidReq` store first (authoritative — maintained by router guards, survives URL changes) and fall back to `getCourseContext()` (URL-based) only when the store is not yet active (early bootstrap / tests).
- Append them as query parameters on `/api/documents`.

No backend changes; no impact on other modules.

## Test plan

- [ ] Log in as a non-admin teacher of a course
- [ ] Navigate to the course documents tool via the SPA navigation (no `?cid=` in URL after a few clicks)
- [ ] Create a new folder → folder appears in the list and is bound to the course
- [ ] Upload a single document via the standard (non-chunked) path → document appears in the list
- [ ] Verify the resulting `resource_link` row has the expected `course_id` populated
- [ ] Regression: log in as global admin and repeat — behaviour unchanged (this path was already silently broken but masked by `ROLE_CURRENT_COURSE_TEACHER` inheritance)