### PR TITLE
Security: Restrict Course Maintenance to teachers of the current course

### DIFF
--- a/assets/vue/router/coursemaintenance.js
+++ b/assets/vue/router/coursemaintenance.js
@@ -1,3 +1,42 @@
+import { useCidReqStore } from "../store/cidReq"
+import { checkIsAllowedToEdit } from "../composables/userPermissions"
+
+/**
+ * Course Maintenance is a teacher-only course tool (admin category): students
+ * and teachers of other courses must not reach any of its pages.
+ *
+ * Runs as beforeEnter (before beforeResolve), so the course context is loaded
+ * here first, then edit permission is resolved for the current cid/sid. Mirrors
+ * the backend gate (ROLE_CURRENT_COURSE_TEACHER / platform admin), so course
+ * teachers and admins pass while everyone else is redirected away.
+ *
+ * @param {import('vue-router').RouteLocationNormalized} to
+ * @returns {Promise<boolean|import('vue-router').RouteLocationRaw>}
+ */
+async function courseMaintenanceBeforeEnter(to) {
+  const courseId = parseInt(to.query?.cid ?? 0)
+  const sessionId = parseInt(to.query?.sid ?? 0)
+
+  if (!courseId) {
+    return { name: "Home", replace: true }
+  }
+
+  const cidReqStore = useCidReqStore()
+  await cidReqStore.setCourseAndSessionById(courseId, sessionId)
+
+  if (!cidReqStore.course) {
+    return { name: "Home", replace: true }
+  }
+
+  const isAllowedToEdit = await checkIsAllowedToEdit()
+
+  if (!isAllowedToEdit) {
+    return { name: "CourseHome", params: { id: courseId }, query: sessionId ? { sid: sessionId } : {} }
+  }
+
+  return true
+}
+
 export default {
   path: "/resources/course_maintenance/:node(\\d+)",
   meta: { requiresAuth: true, showBreadcrumb: true, breadcrumb: "Course maintenance" },
@@ -8,36 +47,42 @@ export default {
     {
       name: "CMImportBackup",
       path: "import",
+      beforeEnter: courseMaintenanceBeforeEnter,
       component: () => import("../views/coursemaintenance/ImportBackup.vue"),
       meta: { breadcrumb: "Import backup" },
     },
     {
       name: "CMCreateBackup",
       path: "create",
+      beforeEnter: courseMaintenanceBeforeEnter,
       component: () => import("../views/coursemaintenance/CreateBackup.vue"),
       meta: { breadcrumb: "Create backup" },
     },
     {
       name: "CMCopyCourse",
       path: "copy",
+      beforeEnter: courseMaintenanceBeforeEnter,
       component: () => import("../views/coursemaintenance/CopyCourse.vue"),
       meta: { breadcrumb: "Copy course" },
     },
     {
       name: "CMCc13",
       path: "cc13",
+      beforeEnter: courseMaintenanceBeforeEnter,
       component: () => import("../views/coursemaintenance/Cc13.vue"),
       meta: { breadcrumb: "IMS CC 1.3" },
     },
     {
       name: "CMRecycle",
       path: "recycle",
+      beforeEnter: courseMaintenanceBeforeEnter,
       component: () => import("../views/coursemaintenance/RecycleCourse.vue"),
       meta: { breadcrumb: "Recycle course" },
     },
     {
       name: "CMDelete",
       path: "delete",
+      beforeEnter: courseMaintenanceBeforeEnter,
       component: () => import("../views/coursemaintenance/DeleteCourse.vue"),
       meta: { breadcrumb: "Delete course" },
     },

--- a/src/CoreBundle/Controller/CourseMaintenanceController.php
+++ b/src/CoreBundle/Controller/CourseMaintenanceController.php
@@ -22,6 +22,7 @@ use Chamilo\CourseBundle\Component\CourseCopy\Moodle\Builder\MoodleImport;
 use CourseManager;
 use Doctrine\ORM\EntityManagerInterface;
 use RuntimeException;
+use Symfony\Component\ExpressionLanguage\Expression;
 use Symfony\Component\HttpFoundation\BinaryFileResponse;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -38,7 +39,7 @@ use const DIRECTORY_SEPARATOR;
 use const FILTER_VALIDATE_BOOL;
 use const PATHINFO_EXTENSION;
 
-#[IsGranted('ROLE_TEACHER')]
+#[IsGranted(new Expression('is_granted("ROLE_CURRENT_COURSE_TEACHER")'))]
 #[Route('/course_maintenance/{node}', name: 'cm_', requirements: ['node' => '\d+'])]
 class CourseMaintenanceController extends AbstractCourseMaintenanceController
 {


### PR DESCRIPTION
The Course Maintenance feature (import, copy, recycle, delete, Moodle/CC export) was only gated by the global `ROLE_TEACHER`, so any teacher — or, on the SPA side, any authenticated user reaching the route — could target a course they do not manage via its `cid`.

Two layers, both aligned with the criterion `CToolStateProvider` already uses to hide this `admin`-category tool from non-editors:

- **Backend** (`CourseMaintenanceController`): class-level access control now requires `ROLE_CURRENT_COURSE_TEACHER` (admins inherit it via the role hierarchy) instead of the global `ROLE_TEACHER`.
- **Frontend** (`router/coursemaintenance.js`): a `beforeEnter` guard on every child route loads the course context and verifies edit permission for the current `cid`/`sid`, redirecting students and teachers of other courses away. This is UX defense-in-depth; the backend remains the security boundary.