### PR TITLE
Security: SQL Injection in ExtraField::get_where_clause() via unescaped array filter values

### DIFF
--- a/public/main/inc/lib/extra_field.lib.php
+++ b/public/main/inc/lib/extra_field.lib.php
@@ -2947,7 +2947,8 @@ class ExtraField extends Model
         }
         if ('cn' === $oper || 'nc' === $oper || 'in' === $oper || 'ni' === $oper) {
             if (is_array($val)) {
-                $result = '"%'.implode(';', $val).'%"';
+                $escaped = array_map(static fn ($item) => Database::escape_string(trim($item)), $val);
+                $result = '"%'.implode(';', $escaped).'%"';
                 foreach ($val as $item) {
                     $item = Database::escape_string(trim($item));
                     $result .= ' '.$conditionBetweenOptions.' '.$col.' LIKE "%'.$item.'%"';


### PR DESCRIPTION
Escapes array filter values with `Database::escape_string()` before they are imploded into the SQL string in `ExtraField::get_where_clause()`, closing the SQL injection reachable by DRH users through the reporting grid `filters` blob. Refs GHSA-7whw-8467-78jp