### PR TITLE
Fix: allow ROLE_ADMIN to POST /api/course_rel_users for other users

### DIFF
--- a/src/CoreBundle/Entity/CourseRelUser.php
+++ b/src/CoreBundle/Entity/CourseRelUser.php
@@ -39,7 +39,7 @@ use Symfony\Component\Validator\Constraints as Assert;
         ),
         new Post(
             security: "is_granted('ROLE_USER')",
-            securityPostDenormalize: 'object.getUser() == user',
+            securityPostDenormalize: "is_granted('ROLE_ADMIN') or object.getUser() == user",
             processor: CourseRelUserStateProcessor::class
         ),
         new GetCollection(


### PR DESCRIPTION
## Summary

- `securityPostDenormalize` on the POST operation lacked an admin bypass: admins received 403 when subscribing any user other than themselves
- The upstream security commit (2a9f060fa9) enforces self-enrollment but omitted `ROLE_ADMIN` from the post-denormalize check
- Mirrors the `ROLE_ADMIN` bypass already present in `CourseRelUserStateProcessor`

## Test plan

- [ ] POST /api/course_rel_users as ROLE_ADMIN with `user` = another user → HTTP 201
- [ ] POST /api/course_rel_users as regular user with `user` = self → HTTP 201
- [ ] POST /api/course_rel_users as regular user with `user` = other user → HTTP 403