### PR TITLE
Session: add Patch operation to /api/sessions/{id}

### DIFF
--- a/src/CoreBundle/Entity/Session.php
+++ b/src/CoreBundle/Entity/Session.php
@@ -11,6 +11,7 @@ use ApiPlatform\Metadata\Delete;
 use ApiPlatform\Metadata\Get;
 use ApiPlatform\Metadata\GetCollection;
 use ApiPlatform\Metadata\Link;
+use ApiPlatform\Metadata\Patch;
 use ApiPlatform\Metadata\Post;
 use ApiPlatform\Metadata\Put;
 use ApiPlatform\OpenApi\Model\Operation;
@@ -45,6 +46,7 @@ use Symfony\Component\Validator\Constraints as Assert;
             security: "is_granted('ROLE_ADMIN') or is_granted('VIEW', object)"
         ),
         new Put(security: "is_granted('ROLE_ADMIN')"),
+        new Patch(security: "is_granted('ROLE_ADMIN')"),
         new GetCollection(
             security: "is_granted('ROLE_ADMIN')",
             filters: [


### PR DESCRIPTION
## Summary

- Adds `PATCH /api/sessions/{id}` alongside the existing `PUT`, restricted to `ROLE_ADMIN`
- Fixes a false 422 "title already used" on `PUT`: API Platform 3 can create a new entity object during PUT denormalization (id=null), causing `UniqueEntity` to flag the existing title as a conflict with itself
- `PATCH` correctly preserves `object_to_populate` and avoids this issue
- Enables partial updates without resending the full resource

## Test plan

- [ ] PATCH /api/sessions/{id} with unchanged title → HTTP 200
- [ ] PATCH /api/sessions/{id} with changed title → HTTP 200
- [ ] PATCH /api/sessions/{id} with title already used by another session → HTTP 422
- [ ] PUT /api/sessions/{id} still works