### PR TITLE
Fix: auto-retry OAuth2 flow on invalid state instead of showing error

### DIFF
--- a/src/CoreBundle/Security/Authenticator/OAuth2/AbstractAuthenticator.php
+++ b/src/CoreBundle/Security/Authenticator/OAuth2/AbstractAuthenticator.php
@@ -14,6 +14,7 @@ use Doctrine\ORM\EntityManagerInterface;
 use KnpU\OAuth2ClientBundle\Client\ClientRegistry;
 use KnpU\OAuth2ClientBundle\Client\OAuth2ClientInterface;
 use KnpU\OAuth2ClientBundle\Security\Authenticator\OAuth2Authenticator;
+use KnpU\OAuth2ClientBundle\Security\Exception\InvalidStateAuthenticationException;
 use League\OAuth2\Client\Token\AccessToken;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -81,6 +82,23 @@ abstract class AbstractAuthenticator extends OAuth2Authenticator implements Auth
 
     public function onAuthenticationFailure(Request $request, AuthenticationException $exception): ?Response
     {
+        // On invalid OAuth2 state (session lost between redirect and callback), restart the
+        // auth flow silently. One auto-retry per provider; a second failure falls through to
+        // the normal error path so a broken session can't loop indefinitely.
+        if ($exception instanceof InvalidStateAuthenticationException && $request->hasSession()) {
+            $session = $request->getSession();
+            $retryKey = '_oauth2_state_retry_'.$this->providerName;
+
+            if (!$session->get($retryKey, false)) {
+                $session->set($retryKey, true);
+                $startRoute = 'chamilo.oauth2_'.$this->providerName.'_start';
+
+                return new RedirectResponse($this->router->generate($startRoute));
+            }
+
+            $session->remove($retryKey);
+        }
+
         $message = strtr($exception->getMessageKey(), $exception->getMessageData());
 
         if ($request->hasSession()) {


### PR DESCRIPTION
## Problem

When the OAuth2 state stored in the PHP session is lost between the
`/connect/{provider}` redirect and the `/connect/{provider}/check`
callback, the `KnpU\OAuth2ClientBundle` throws an
`InvalidStateAuthenticationException`. The user sees a confusing red
flash message — *"Invalid state parameter passed in callback URL."* —
and is redirected to the home page, where they must manually navigate
back to the login page and click the SSO button again.

This can happen due to:
- Session garbage-collection between the two requests
- A stale Symfony cache that serialises session services incorrectly
- Concurrent background requests competing for the session lock

The scenario we observed: admin logs in via SSO → uses "Login as" to
impersonate another user → logs out → tries to re-authenticate via SSO →
hits the invalid-state error because the session was invalidated during
logout and the new session state was lost.

## Solution

Catch `InvalidStateAuthenticationException` in
`AbstractAuthenticator::onAuthenticationFailure()` and transparently
restart the auth flow by redirecting to the provider's start URL
(`/connect/{provider}`). A session flag (`_oauth2_state_retry_{provider}`)
limits this to **one automatic retry** per provider; a second consecutive
failure still shows the error, preventing an infinite redirect loop.

The change is a one-file patch affecting all OAuth2 providers
(generic, Facebook, Keycloak, Azure) equally.

## Test plan

- [ ] Log in via SSO → works normally (no regression)
- [ ] Simulate invalid state: open `/connect/{provider}`, clear the session cookie, follow the callback URL → should transparently retry and land on the login page (or complete auth), not show an error
- [ ] Verify the retry flag prevents looping: if auth still fails on retry, the flash error appears as before