### PR TITLE
Course: add Delete operation to /api/courses/{id} (admin only)

### DIFF
--- a/src/CoreBundle/Entity/Course.php
+++ b/src/CoreBundle/Entity/Course.php
@@ -11,6 +11,7 @@ use ApiPlatform\Doctrine\Orm\Filter\SearchFilter;
 use ApiPlatform\Metadata\ApiFilter;
 use ApiPlatform\Metadata\ApiProperty;
 use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\Delete;
 use ApiPlatform\Metadata\Get;
 use ApiPlatform\Metadata\GetCollection;
 use ApiPlatform\Metadata\Post;
@@ -42,6 +43,7 @@ use const SORT_NATURAL;
     operations: [
         new Get(security: "is_granted('VIEW', object)"),
         new Post(security: "is_granted('ROLE_TEACHER') or is_granted('ROLE_ADMIN')"),
+        new Delete(security: "is_granted('ROLE_ADMIN')"),
         new GetCollection(
             paginationClientEnabled: true,
             security: "is_granted('ROLE_TEACHER') or is_granted('ROLE_ADMIN')"


### PR DESCRIPTION
## Summary

Adds `DELETE /api/courses/{id}` to the Course `#[ApiResource]`, restricted to `ROLE_ADMIN`.

- Uses API Platform's built-in remove processor (`EntityManager::remove()` + flush)
- The database-level `onDelete: CASCADE` on `resource_node_id` handles cleanup of the linked ResourceNode
- Mirrors the pattern used by other destructive operations on Course (`Patch`) and Session (`Delete`)

## Notes

`CourseVoter::DELETE` grants course teachers delete rights, which would be too permissive for a course-level delete. The explicit `is_granted('ROLE_ADMIN')` sidesteps the voter and restricts access correctly.

Physical files (e.g. course illustrations on disk) are not automatically removed on delete — this is a pre-existing limitation shared by the legacy `CourseRepository::deleteCourse()`.