### PR TITLE
Fix: show correct status label for all user types in user_information

### DIFF
--- a/public/main/admin/user_information.php
+++ b/public/main/admin/user_information.php
@@ -194,7 +194,7 @@ $data = [
     get_lang('Phone') => $user->getPhone(),
     get_lang('Course code') => $user->getOfficialCode(),
     //get_lang('Online') => !empty($user['user_is_online']) ? Display::return_icon('online.png') : Display::return_icon('offline.png'),
-    get_lang('Status') => 1 === $user->getStatus() ? get_lang('Trainer') : get_lang('Learner'),
+    get_lang('Status') => api_get_status_langvars()[$user->getStatus()] ?? get_lang('Learner'),
 ];
 
 $params = [];

--- a/src/CoreBundle/Resources/views/Macros/box.html.twig
+++ b/src/CoreBundle/Resources/views/Macros/box.html.twig
@@ -124,9 +124,19 @@
                     <dt class="w-1/3 font-semibold">{{ 'Status'|trans }}</dt>
                     <dd class="w-2/3">
                         {% if user.status == 1 %}
-                            {{ 'Trainer' | trans }}
+                            {{ 'Trainer'|trans }}
+                        {% elseif user.status == 3 %}
+                            {{ 'Sessions administrator'|trans }}
+                        {% elseif user.status == 4 %}
+                            {{ 'Human Resources Manager'|trans }}
+                        {% elseif user.status == 6 %}
+                            {{ 'Anonymous'|trans }}
+                        {% elseif user.status == 17 %}
+                            {{ 'Student boss'|trans }}
+                        {% elseif user.status == 20 %}
+                            {{ 'Invited'|trans }}
                         {% else %}
-                            {{ 'Learner' | trans }}
+                            {{ 'Learner'|trans }}
                         {% endif %}
                     </dd>
                 </div>
@@ -280,6 +290,16 @@
                         <dd class="text-sm font-semibold text-gray-900 text-right">
                             {% if user.status == 1 %}
                                 {{ 'Trainer'|trans }}
+                            {% elseif user.status == 3 %}
+                                {{ 'Sessions administrator'|trans }}
+                            {% elseif user.status == 4 %}
+                                {{ 'Human Resources Manager'|trans }}
+                            {% elseif user.status == 6 %}
+                                {{ 'Anonymous'|trans }}
+                            {% elseif user.status == 17 %}
+                                {{ 'Student boss'|trans }}
+                            {% elseif user.status == 20 %}
+                                {{ 'Invited'|trans }}
                             {% else %}
                                 {{ 'Learner'|trans }}
                             {% endif %}


### PR DESCRIPTION
## Summary

The status field on `/main/admin/user_information.php` used a binary check:

```php
// Before
get_lang('Status') => 1 === $user->getStatus() ? get_lang('Trainer') : get_lang('Learner'),
```

This caused users with status `DRH` (4), `SESSIONADMIN` (3), `STUDENT_BOSS` (17) and `INVITEE` (20) to incorrectly display as **Learner**, even when they held HR manager, session admin, or invitee roles.

The fix replaces the binary check with `api_get_status_langvars()`, which already provides the complete mapping for all status values and is used in other parts of the codebase.

```php
// After
get_lang('Status') => api_get_status_langvars()[$user->getStatus()] ?? get_lang('Learner'),
```

## Status values covered

| Constant | Value | Label |
|---|---|---|
| `COURSEMANAGER` | 1 | Teacher |
| `SESSIONADMIN` | 3 | Sessions administrator |
| `DRH` | 4 | Human Resources Manager |
| `STUDENT` | 5 | Learner |
| `ANONYMOUS` | 6 | Anonymous |
| `STUDENT_BOSS` | 17 | Student boss |
| `INVITEE` | 20 | Invited |

## Test plan

- Open `/main/admin/user_information.php?user_id=<id>` for users with each status type
- Verify the Status row shows the correct label for DRH, Session admin, Student boss and Invitee users
- Verify Teacher and Learner users still display correctly