### PR TITLE
Fix: login-as crash 'Database Manager is not initialized' (backport #8661 to 2.0)

### DIFF
--- a/src/CoreBundle/Repository/Node/UserRepository.php
+++ b/src/CoreBundle/Repository/Node/UserRepository.php
@@ -616,6 +616,28 @@ class UserRepository extends ResourceRepository implements PasswordUpgraderInter
     }
 
     /**
+     * Whether $targetUserId is followed by the HR manager $drhId through the UserRelUser
+     * RRHH relation. Native replacement for UserManager::is_user_followed_by_drh().
+     */
+    public function isUserFollowedByDrh(int $targetUserId, int $drhId): bool
+    {
+        $count = (int) $this->getEntityManager()->createQueryBuilder()
+            ->select('COUNT(uru.id)')
+            ->from(UserRelUser::class, 'uru')
+            ->where('uru.user = :target')
+            ->andWhere('uru.friend = :drh')
+            ->andWhere('uru.relationType = :relationType')
+            ->setParameter('target', $targetUserId)
+            ->setParameter('drh', $drhId)
+            ->setParameter('relationType', UserRelUser::USER_RELATION_TYPE_RRHH)
+            ->getQuery()
+            ->getSingleScalarResult()
+        ;
+
+        return $count > 0;
+    }
+
+    /**
      * Get number of users in URL.
      *
      * @return int

--- a/src/CoreBundle/Security/Authorization/LoginAsAuthorizationChecker.php
+++ b/src/CoreBundle/Security/Authorization/LoginAsAuthorizationChecker.php
@@ -7,9 +7,9 @@ declare(strict_types=1);
 namespace Chamilo\CoreBundle\Security\Authorization;
 
 use Chamilo\CoreBundle\Entity\User;
+use Chamilo\CoreBundle\Repository\Node\UserRepository;
 use Chamilo\CoreBundle\Settings\SettingsManager;
-use SessionManager;
-use UserManager;
+use Symfony\Component\Security\Core\Role\RoleHierarchyInterface;
 
 /**
  * Centralized authorization policy for "login as" / Symfony switch_user impersonation.
@@ -24,16 +24,19 @@ use UserManager;
  *  4. Impersonator is a session administrator (ROLE_SESSION_MANAGER) -> may impersonate
  *     only users with status STUDENT, plus COURSEMANAGER when the setting
  *     session.allow_session_admin_login_as_teacher is enabled.
- *  5. Impersonator is a HR manager (ROLE_HR / DRH) -> may impersonate either
- *       a) users followed via the UserRelUser RRHH relation, or
- *       b) users belonging to one of their sessions when the setting
- *          drh_can_access_all_session_content is enabled.
+ *  5. Impersonator is a HR manager (ROLE_HR / DRH) -> may impersonate ONLY users they
+ *     follow directly via the UserRelUser RRHH relation, and only when the target holds no
+ *     privilege the DRH itself lacks. Merely belonging to a session the DRH coaches does
+ *     NOT grant impersonation rights, and a followed user with higher privileges (session
+ *     admin, platform admin, etc.) can never be impersonated.
  *  6. Default deny.
  */
 final class LoginAsAuthorizationChecker
 {
     public function __construct(
         private readonly SettingsManager $settingsManager,
+        private readonly UserRepository $userRepository,
+        private readonly RoleHierarchyInterface $roleHierarchy,
     ) {}
 
     /**
@@ -79,9 +82,13 @@ final class LoginAsAuthorizationChecker
     }
 
     /**
-     * Replicates api_is_global_platform_admin(): the user is a platform admin AND is
-     * registered on access URL #1 (the main installation). Falls back to the legacy
-     * helper to honor multi-URL setups.
+     * Replicates api_is_global_platform_admin(): a platform admin who is also a global
+     * (super) admin. Resolved directly from the already-loaded User entity instead of the
+     * legacy api_is_global_platform_admin() helper, which reloads the user through the
+     * legacy Container. That Container is only wired by LegacyListener (kernel.request,
+     * priority 7), but the Symfony firewall fires switch_user earlier (priority 8) — so
+     * during a "login as" attempt the legacy Container is still null and the legacy helper
+     * would fatal with "Call to a member function get() on null".
      */
     private function isGlobalPlatformAdmin(User $user): bool
     {
@@ -89,7 +96,7 @@ final class LoginAsAuthorizationChecker
             return false;
         }
 
-        return \api_is_global_platform_admin($user->getId());
+        return $user->isSuperAdmin();
     }
 
     /**
@@ -127,23 +134,34 @@ final class LoginAsAuthorizationChecker
     }
 
     /**
-     * HR manager (ROLE_HR / DRH) may login as:
-     *  - users they explicitly follow (UserRelUser RRHH relation), or
-     *  - users in one of their sessions when drh_can_access_all_session_content is enabled.
+     * HR manager (ROLE_HR / DRH) may login as a user only when BOTH hold:
+     *  - the user is followed directly via the UserRelUser RRHH relation (legacy parity:
+     *    belonging to a session the DRH coaches is intentionally NOT enough), and
+     *  - the user does not hold any privilege the DRH lacks, so impersonation can never be
+     *    used to escalate privileges (e.g. a followed session admin or admin is refused).
+     *
+     * The RRHH lookup goes through UserRepository (Doctrine) instead of the legacy
+     * UserManager helper, so the policy no longer depends on the legacy Container being
+     * bootstrapped — which the Symfony firewall has not yet done when switch_user fires.
      */
     private function canDrhLoginAs(User $impersonator, User $target): bool
     {
-        if ('true' === (string) $this->settingsManager->getSetting('drh_can_access_all_session_content')) {
-            $users = SessionManager::getAllUsersFromCoursesFromAllSessionFromStatus('drh_all', $impersonator->getId());
-            if (is_array($users)) {
-                foreach ($users as $row) {
-                    if (isset($row['id']) && (int) $row['id'] === $target->getId()) {
-                        return true;
-                    }
-                }
-            }
+        if (!$this->userRepository->isUserFollowedByDrh((int) $target->getId(), (int) $impersonator->getId())) {
+            return false;
         }
 
-        return UserManager::is_user_followed_by_drh($target->getId(), $impersonator->getId());
+        return !$this->targetHasHigherPrivileges($impersonator, $target);
+    }
+
+    /**
+     * Whether $target holds at least one (hierarchy-expanded) role that $impersonator does
+     * not have. Used as a privilege-escalation guard for non-admin impersonators.
+     */
+    private function targetHasHigherPrivileges(User $impersonator, User $target): bool
+    {
+        $impersonatorRoles = $this->roleHierarchy->getReachableRoleNames($impersonator->getRoles());
+        $targetRoles = $this->roleHierarchy->getReachableRoleNames($target->getRoles());
+
+        return [] !== array_diff($targetRoles, $impersonatorRoles);
     }
 }

--- a/tests/CoreBundle/Security/Authorization/LoginAsAuthorizationCheckerTest.php
+++ b/tests/CoreBundle/Security/Authorization/LoginAsAuthorizationCheckerTest.php
@@ -1,0 +1,173 @@
+<?php
+
+declare(strict_types=1);
+
+/* For licensing terms, see /license.txt */
+
+namespace Chamilo\Tests\CoreBundle\Security\Authorization;
+
+use Chamilo\CoreBundle\Entity\Session;
+use Chamilo\CoreBundle\Entity\User;
+use Chamilo\CoreBundle\Entity\UserRelUser;
+use Chamilo\CoreBundle\Framework\Container;
+use Chamilo\CoreBundle\Repository\SessionRepository;
+use Chamilo\CoreBundle\Security\Authorization\LoginAsAuthorizationChecker;
+use Chamilo\Tests\AbstractApiTest;
+use Chamilo\Tests\ChamiloTestTrait;
+
+/**
+ * Authorization policy coverage for "login as" (switch_user).
+ *
+ * Every decision below is taken with the legacy Container forced to null, reproducing the
+ * request ordering in production: the Symfony firewall fires switch_user on kernel.request
+ * (priority 8) before LegacyListener (priority 7) wires the legacy Container. The checker
+ * must therefore resolve every path natively (User entity + injected repositories), never
+ * through legacy helpers that would fatal with "Call to a member function get() on null".
+ */
+class LoginAsAuthorizationCheckerTest extends AbstractApiTest
+{
+    use ChamiloTestTrait;
+
+    // --- Platform admin paths ---------------------------------------------------------
+
+    public function testGlobalAdminCanImpersonateAdmin(): void
+    {
+        $impersonator = $this->createUser('login_as_global_admin', '', '', 'ROLE_GLOBAL_ADMIN');
+        $target = $this->createUser('login_as_target_admin', '', '', 'ROLE_ADMIN');
+
+        $this->assertTrue($this->decide($impersonator, $target));
+    }
+
+    public function testPlainAdminCanImpersonateAdmin(): void
+    {
+        $impersonator = $this->createUser('login_as_plain_admin', '', '', 'ROLE_ADMIN');
+        $target = $this->createUser('login_as_other_admin', '', '', 'ROLE_ADMIN');
+
+        $this->assertTrue($this->decide($impersonator, $target));
+    }
+
+    public function testPlainAdminCannotImpersonateGlobalAdmin(): void
+    {
+        $impersonator = $this->createUser('login_as_plain_admin_2', '', '', 'ROLE_ADMIN');
+        $target = $this->createUser('login_as_global_admin_target', '', '', 'ROLE_GLOBAL_ADMIN');
+
+        $this->assertFalse($this->decide($impersonator, $target));
+    }
+
+    // --- HR manager (DRH) paths -------------------------------------------------------
+
+    public function testHrManagerCanImpersonateRrhhFollowedStudent(): void
+    {
+        $drh = $this->createUser('login_as_drh', '', '', 'ROLE_HR');
+        $student = $this->createUser('login_as_drh_student');
+        $this->linkRrhh($student, $drh);
+
+        $this->assertTrue($this->decide($drh, $student));
+    }
+
+    public function testHrManagerCannotImpersonateUnfollowedStudent(): void
+    {
+        $drh = $this->createUser('login_as_drh_2', '', '', 'ROLE_HR');
+        $student = $this->createUser('login_as_unrelated_student');
+
+        $this->assertFalse($this->decide($drh, $student));
+    }
+
+    /**
+     * Legacy parity: belonging to a session the DRH coaches must NOT grant impersonation
+     * rights — only the direct RRHH relation does.
+     */
+    public function testHrManagerCannotImpersonateUserInCoachedSession(): void
+    {
+        $drh = $this->createUser('login_as_drh_3', '', '', 'ROLE_HR');
+        $student = $this->createUser('login_as_session_student');
+        // DRH coaches the session and the student is enrolled, but there is no RRHH relation.
+        $this->enrolStudentInDrhSession($student, $drh);
+
+        $this->assertFalse($this->decide($drh, $student));
+    }
+
+    /**
+     * Privilege-escalation guard: a followed user holding a role the DRH lacks
+     * (here ROLE_SESSION_MANAGER) must never be impersonable.
+     */
+    public function testHrManagerCannotImpersonateFollowedSessionAdmin(): void
+    {
+        $drh = $this->createUser('login_as_drh_4', '', '', 'ROLE_HR');
+        $sessionAdmin = $this->createUser('login_as_followed_session_admin', '', '', 'ROLE_SESSION_MANAGER');
+        $this->linkRrhh($sessionAdmin, $drh);
+
+        $this->assertFalse($this->decide($drh, $sessionAdmin));
+    }
+
+    public function testHrManagerCannotImpersonateFollowedAdmin(): void
+    {
+        $drh = $this->createUser('login_as_drh_5', '', '', 'ROLE_HR');
+        $admin = $this->createUser('login_as_followed_admin', '', '', 'ROLE_ADMIN');
+        $this->linkRrhh($admin, $drh);
+
+        $this->assertFalse($this->decide($drh, $admin));
+    }
+
+    /**
+     * A teacher is not "higher" than a DRH: ROLE_HR already reaches ROLE_TEACHER through the
+     * role hierarchy, so impersonating a followed teacher is not an escalation.
+     */
+    public function testHrManagerCanImpersonateFollowedTeacher(): void
+    {
+        $drh = $this->createUser('login_as_drh_6', '', '', 'ROLE_HR');
+        $teacher = $this->createUser('login_as_followed_teacher', '', '', 'ROLE_TEACHER');
+        $this->linkRrhh($teacher, $drh);
+
+        $this->assertTrue($this->decide($drh, $teacher));
+    }
+
+    // --- Helpers ----------------------------------------------------------------------
+
+    /**
+     * Runs canLoginAs() with the legacy Container forced to null, proving the decision is
+     * free of any legacy-Container dependency.
+     */
+    private function decide(User $impersonator, User $target): bool
+    {
+        /** @var LoginAsAuthorizationChecker $checker */
+        $checker = self::getContainer()->get(LoginAsAuthorizationChecker::class);
+
+        $previous = Container::$container;
+        Container::$container = null;
+
+        try {
+            return $checker->canLoginAs($impersonator, $target);
+        } finally {
+            Container::$container = $previous;
+        }
+    }
+
+    private function linkRrhh(User $student, User $drh): void
+    {
+        $em = $this->getEntityManager();
+        $em->persist(
+            (new UserRelUser())
+                ->setUser($student)
+                ->setFriend($drh)
+                ->setRelationType(UserRelUser::USER_RELATION_TYPE_RRHH)
+        );
+        $em->flush();
+    }
+
+    private function enrolStudentInDrhSession(User $student, User $drh): void
+    {
+        $sessionRepo = self::getContainer()->get(SessionRepository::class);
+
+        $course = $this->createCourse('LoginAs DRH course');
+        $session = $this->createSession('LoginAs DRH session');
+        $session
+            ->addCourse($course)
+            ->addUserInSession(Session::DRH, $drh)
+        ;
+        $sessionRepo->update($session);
+
+        $sessionRepo->addUserInCourse(Session::STUDENT, $student, $course, $session);
+        $sessionRepo->update($session);
+    }
+}


### PR DESCRIPTION
## Problem

When a platform admin uses the switch-user feature (`/?_switch_user=...`), a fatal error occurs:

> Call to a member function get() on null (Database Manager is not initialized)

## Root cause

The Symfony firewall fires the `switch_user` event at **priority 8**, before `LegacyListener` initialises the legacy Container at **priority 7**. The call chain:

`SwitchUserListener` → `SwitchUserSubscriber` → `LoginAsAuthorizationChecker::isGlobalPlatformAdmin()` → `api_is_global_platform_admin()` → `Database::getManager()` → **fatal**

## Fix

Backport of upstream/master commit `8432203a14` ("Internal: Fix 'login as' admin/hrm - refs #8661"):

1. **`LoginAsAuthorizationChecker::isGlobalPlatformAdmin()`** — replace `api_is_global_platform_admin()` with `User::isSuperAdmin()`, which reads directly from the already-loaded Doctrine entity and needs no legacy Container.

2. **`LoginAsAuthorizationChecker::canDrhLoginAs()`** — replace the `SessionManager`/`UserManager` legacy helpers with a clean Doctrine `UserRepository::isUserFollowedByDrh()` call, eliminating the remaining legacy Container dependency from this service.

3. **`UserRepository::isUserFollowedByDrh()`** — new Doctrine method, native replacement for `UserManager::is_user_followed_by_drh()`.

4. **`LoginAsAuthorizationCheckerTest`** — unit test for all impersonation policy paths (also from the original commit).

The fix on upstream/master was not backported to the `2.0` branch; this PR does exactly that.