### PR TITLE
Internal: Fix language flipping between SPA and legacy pages + tests for CourseFromRequestHelper

### DIFF
--- a/assets/vue/App.vue
+++ b/assets/vue/App.vue
@@ -324,20 +324,16 @@ api.interceptors.response.use(
 
 platformConfigurationStore.initialize()
 
-// i18n sync
-watch(
-  () => route.params,
-  () => {
-    const { appLocale } = useLocale()
-    if (appLocale?.value && locale.value !== appLocale.value) setLocale(appLocale.value)
-  },
-  { immediate: true },
-)
+// i18n sync — single writer. appLocale mirrors the server-side locale chain
+// (see useLocale) and reacts to store changes (platform config, user profile,
+// course context set/cleared by the router guards) on client-side navigation.
+// The boot locale comes from <html data-lang>, already resolved by the server.
+const { appLocale } = useLocale()
 
 watch(
-  () => securityStore.user?.language,
-  (lang) => {
-    if (lang && locale.value !== lang) setLocale(lang)
+  appLocale,
+  (newLocale) => {
+    if (newLocale && locale.value !== newLocale) setLocale(newLocale)
   },
   { immediate: true },
 )

--- a/assets/vue/composables/locale.js
+++ b/assets/vue/composables/locale.js
@@ -17,6 +17,11 @@ export function useLocale() {
 
   const appLocale = ref(document.documentElement.dataset.lang)
 
+  // Client-side mirror of LocaleSubscriber::getCurrentLanguage() so that
+  // entering/leaving a course without a full page load resolves the same locale
+  // the server would. Browser Accept-Language and the ?_locale session override
+  // are server-side only: they are already baked into <html data-lang> at boot
+  // and self-correct on the next full page load.
   const localeList = computed(() => {
     const list = {}
 
@@ -25,14 +30,16 @@ export function useLocale() {
 
     let courseLang = null
 
-    if (
-      courseSettingsStore.getSetting("show_course_in_user_language") === "1" &&
-      securityStore.user &&
-      securityStore.user.locale
-    ) {
-      courseLang = securityStore.user.locale
-    } else if (cidReqStore.course) {
-      courseLang = cidReqStore.course.courseLanguage
+    if (cidReqStore.course) {
+      if (
+        courseSettingsStore.getSetting("show_course_in_user_language") === "1" &&
+        securityStore.user &&
+        securityStore.user.locale
+      ) {
+        courseLang = securityStore.user.locale
+      } else {
+        courseLang = cidReqStore.course.courseLanguage
+      }
     }
 
     list["course_lang"] = courseLang
@@ -43,6 +50,7 @@ export function useLocale() {
   watch(
     localeList,
     (newLocaleList) => {
+      // 1) Honor the configured language_priority_1..4 settings, like the server.
       const priorityList = ["language_priority_1", "language_priority_2", "language_priority_3", "language_priority_4"]
 
       for (const priority of priorityList) {
@@ -51,8 +59,23 @@ export function useLocale() {
         if (setting && newLocaleList[setting]) {
           appLocale.value = newLocaleList[setting]
 
-          break
+          return
         }
+      }
+
+      // 2) No priority matched: same fallback as the server — last non-empty
+      // wins, so course_lang > user_profil_lang > platform_lang. When nothing
+      // is known yet (stores still loading) keep the server-provided locale.
+      let candidate = null
+
+      for (const key of ["platform_lang", "user_profil_lang", "course_lang"]) {
+        if (newLocaleList[key]) {
+          candidate = newLocaleList[key]
+        }
+      }
+
+      if (candidate) {
+        appLocale.value = candidate
       }
     },
     { immediate: true },

--- a/assets/vue/i18n.js
+++ b/assets/vue/i18n.js
@@ -58,9 +58,13 @@ function buildFallbackChain(base, resolved, messages) {
 
 const messages = loadLocaleMessages()
 
-// Prefer previously chosen locale, otherwise <html lang>, otherwise "en"
-const stored = typeof localStorage !== "undefined" ? localStorage.getItem("app_locale") : null
-const initialHtmlLocale = stored || document.documentElement.dataset?.lang || "en_US"
+// The server (LocaleSubscriber) resolves the locale for every full page load and
+// prints it in <html data-lang>: it already factors platform/user/course settings,
+// the language priorities, the ?_locale override and the browser Accept-Language.
+// That answer is authoritative at boot. Client-side route changes are handled at
+// runtime by setLocale() (driven by the useLocale composable) — never persist the
+// locale on the client, a stored value can only disagree with the server.
+const initialHtmlLocale = document.documentElement.dataset?.lang || "en_US"
 const initial = resolveBestLocale(initialHtmlLocale, messages)
 
 // NOTE: do NOT create runtime aliases; use the resolved bundle directly
@@ -72,7 +76,12 @@ const i18n = createI18n({
   messages,
 })
 
-// Public API: switch locale at runtime (no page reload)
+/**
+ * Switches the interface locale at runtime (no page reload), e.g. when a
+ * client-side navigation enters or leaves a course with its own language.
+ *
+ * @param {string} code - requested locale code (e.g. "es", "en_US", "pt-BR")
+ */
 export function setLocale(code) {
   const target = resolveBestLocale(code, messages)
 
@@ -82,9 +91,6 @@ export function setLocale(code) {
 
   if (typeof document !== "undefined") {
     document.documentElement.dataset.lang = target.resolved
-  }
-  if (typeof localStorage !== "undefined") {
-    localStorage.setItem("app_locale", target.resolved)
   }
 }
 


### PR DESCRIPTION
## Problem

With a platform in Spanish, a user profile in English and courses in Spanish, navigating **course → administration → BuyCourses plugin → my courses → administration** kept flipping the interface language on every hop.

## Root cause

The Vue app resolved its locale independently from the backend and persisted it in `localStorage`:

- `i18n.js` booted from `localStorage.app_locale` **before** the server-provided `<html data-lang>`, so a stale value from a previous course visit overrode the locale `LocaleSubscriber` had just resolved for the current request. Legacy pages (BuyCourses) always follow the server, so SPA and legacy pages permanently disagreed.
- `useLocale()` only recomputed the locale when `language_priority_*` settings were configured — without them, leaving a course through client-side navigation kept the course language.
- `App.vue` had two competing locale watchers (one of them watching a non-existent `user.language` field — the entity exposes `locale`).

The initially suspected `$cidReset` guard in `LocaleSubscriber` was verified to be a no-op for this bug: BuyCourses URLs carry no `cid`/`cidReq`, so course resolution already returns null there.

## Fix

- **`assets/vue/i18n.js`**: boot from `<html data-lang>` — the server answer already factors platform/user/course settings, priorities, `?_locale` and `Accept-Language`. Drop `localStorage` persistence entirely (it can only agree with the server or be stale).
- **`assets/vue/composables/locale.js`**: `useLocale()` now mirrors `LocaleSubscriber::getCurrentLanguage()`: `language_priority_1..4` first, then the same last-non-empty fallback (course > user profile > platform). `course_lang` is only computed when a course is in context.
- **`assets/vue/App.vue`**: single locale writer — one `watch(appLocale) → setLocale()`.

Runtime language switching is preserved: entering a course through client-side navigation still switches the interface to the course language instantly.

Also includes the PHPUnit test for `CourseFromRequestHelper` (complements 35060708bf5, which introduced the helper without its test): locks the shared cid/sid/gid resolution contract — numeric id or course code, legacy 1.11.x `cidReq`/`id_session`/`gidReq` fallbacks, attribute-over-query precedence, zero/empty/non-scalar meaning “no context”.

## Testing

- Headless-Chrome (CDP) run of the reported cycle with user `en_US`, platform `es`, course `es`, BuyCourses enabled: every hop (full loads and client-side navigations) now shows the same language the server would render, and `localStorage` is never written. The same script against the previous code reproduces the reported flipping (stays in Spanish when leaving the course client-side, writes `app_locale=es` which poisons the next full load).
- `CourseFromRequestHelperTest`: 19 tests / 52 assertions, green.
- ESLint/Prettier: no new issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)