### PR TITLE
Resource file deletion via delete_variant

### DIFF
--- a/src/CoreBundle/Controller/ResourceController.php
+++ b/src/CoreBundle/Controller/ResourceController.php
@@ -575,6 +575,23 @@ class ResourceController extends AbstractResourceController implements CourseCon
             return $this->json(['error' => 'Variant not found'], Response::HTTP_NOT_FOUND);
         }
 
+        $resourceNode = $variant->getResourceNode();
+        if (null === $resourceNode) {
+            throw new NotFoundHttpException();
+        }
+
+        // Require edit permission on the owning resource node (admins pass via ROLE_ADMIN).
+        $this->denyAccessUnlessGranted(
+            ResourceNodeVoter::EDIT,
+            $resourceNode,
+            $this->trans('Unauthorised access to resource')
+        );
+
+        // Only genuine access-URL variants may be removed here, never a primary resource file.
+        if (null === $variant->getAccessUrl()) {
+            throw new NotFoundHttpException();
+        }
+
         $em->remove($variant);
         $em->flush();
 


### PR DESCRIPTION
Adds authorization to the `DELETE /r/resource_files/{id}/delete_variant` endpoint, which previously deleted `ResourceFile` by numeric id. The handler now requires `EDIT` permission on the owning `ResourceNode` (admins pass via `ROLE_ADMIN`) and only allows removal of genuine access-URL variants (`accessUrl !== null`), returning 404 otherwise.

Note: CSRF token validation was not added — the endpoint is consumed by the SPA over JWT bearer auth and adding a token would require a coordinated frontend change; the authorization check already eliminates the unauthenticated/cross-privilege vector. Flagging in case a CSRF layer is desired as defense-in-depth.

Refs GHSA-4j89-qjx2-3wcr