### PR TITLE
Security: Stored XSS in course chat (sanitizer ran before Markdown)

### DIFF
--- a/public/main/inc/lib/CourseChatUtils.php
+++ b/public/main/inc/lib/CourseChatUtils.php
@@ -187,7 +187,6 @@ class CourseChatUtils
 
         $message = trim($message);
         $message = nl2br($message);
-        $message = Security::remove_XSS($message);
 
         // url -> anchor
         $message = preg_replace(
@@ -203,6 +202,10 @@ class CourseChatUtils
         );
 
         $message = MarkdownExtra::defaultTransform($message);
+
+        // Sanitize last, after Markdown produced the final HTML, so HTMLPurifier
+        // strips javascript: links and other payloads Markdown may have generated.
+        $message = Security::remove_XSS($message);
 
         return $message;
     }


### PR DESCRIPTION
In `CourseChatUtils::prepareMessage()` the message was sanitized with `Security::remove_XSS()` while it was still raw Markdown, so HTMLPurifier never saw the HTML that `MarkdownExtra::defaultTransform()` produced afterwards (e.g. `[x](javascript:...)` became a live `javascript:` anchor). The sanitization now runs last, after Markdown rendering, matching the correct order already used elsewhere in the codebase.

Refs GHSA-rrjh-7f5h-8w96