### PR TITLE
Security: Authenticated arbitrary resource file read via mismatched resourceFileId

### DIFF
--- a/src/CoreBundle/Controller/ResourceController.php
+++ b/src/CoreBundle/Controller/ResourceController.php
@@ -168,6 +168,14 @@ class ResourceController extends AbstractResourceController implements CourseCon
         $resourceFile = null;
         if ($resourceFileId) {
             $resourceFile = $this->resourceFileRepository->find($resourceFileId);
+
+            // The selected file must belong to the resource node in the path; otherwise the
+            // resourceFileId parameter is an IDOR oracle for arbitrary resource files.
+            if ($resourceFile instanceof ResourceFile
+                && $resourceFile->getResourceNode()?->getId() !== $resourceNode->getId()
+            ) {
+                throw new FileNotFoundException($this->trans('Resource file not found for the given resource node'));
+            }
         }
 
         $resourceFile ??= $resourceFileHelper->resolveResourceFileByAccessUrl($resourceNode);

--- a/src/CoreBundle/Entity/ResourceFile.php
+++ b/src/CoreBundle/Entity/ResourceFile.php
@@ -38,7 +38,7 @@ use Vich\UploaderBundle\Mapping\Attribute as Vich;
 #[ApiResource(
     types: ['http://schema.org/MediaObject'],
     operations: [
-        new Get(security: "is_granted('ROLE_USER')"),
+        new Get(security: "is_granted('VIEW', object)"),
         new Post(
             controller: CreateResourceFileAction::class,
             openapi: new Operation(


### PR DESCRIPTION
The `/r/{tool}/{type}/{uuid}/view` handler authorized the resource node in the path but returned the separate `ResourceFile` selected by the `resourceFileId` query parameter without checking the file belonged to that node — an IDOR that let a low-privileged user read other users' files by numeric id. The handler now rejects (404) any `resourceFileId` whose resource node does not match the path node. In addition, the individual `GET /api/resource_files/{id}` operation is tightened from `ROLE_USER` to object-level `is_granted('VIEW', object)` (via the existing `ResourceFileVoter`) to close the metadata/existence oracle.

Note: the fix does not add a per-access-URL/tenant check for variants belonging to the same node (advisory remediation point 3); the primary cross-user/cross-course read is closed by the node-match check. Flagging the multi-URL variant nuance as a possible follow-up.

Refs GHSA-2prx-vqcv-mv68