### PR TITLE
Security: Skip unregistered roles in ResourceAclHelper instead of crashing

### DIFF
--- a/src/CoreBundle/Helpers/ResourceAclHelper.php
+++ b/src/CoreBundle/Helpers/ResourceAclHelper.php
@@ -97,6 +97,19 @@ readonly class ResourceAclHelper
         $roles = $user instanceof UserInterface ? $user->getRoles() : [];
 
         foreach ($roles as $role) {
+            // init() only ever registers a small fixed set of resource-permission
+            // roles (ROLE_USER, ROLE_STUDENT, ROLE_CURRENT_COURSE_TEACHER, ...).
+            // $user->getRoles() returns the user's FULL Symfony role set, which
+            // for an admin using "Login as" also includes roles like
+            // ROLE_SESSION_MANAGER, ROLE_PREVIOUS_ADMIN or ROLE_ALLOWED_TO_SWITCH -
+            // none of which the ACL knows about. Laminas throws
+            // InvalidArgumentException for any role it hasn't registered, so
+            // without this guard a single unrelated role crashes the whole
+            // permission check instead of just being irrelevant to it.
+            if (!$acl->hasRole($role)) {
+                continue;
+            }
+
             if ($acl->isAllowed($role, $resourceLink->getId(), $askedMask)) {
                 return true;
             }

--- a/tests/CoreBundle/Helpers/ResourceAclHelperTest.php
+++ b/tests/CoreBundle/Helpers/ResourceAclHelperTest.php
@@ -1,0 +1,55 @@
+<?php
+
+/* For licensing terms, see /license.txt */
+
+declare(strict_types=1);
+
+namespace Chamilo\Tests\CoreBundle\Helpers;
+
+use Chamilo\CoreBundle\Entity\ResourceLink;
+use Chamilo\CoreBundle\Entity\User;
+use Chamilo\CoreBundle\Helpers\ResourceAclHelper;
+use PHPUnit\Framework\TestCase;
+use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+
+final class ResourceAclHelperTest extends TestCase
+{
+    /**
+     * Reproduces the "Login as" / session-manager smoke-test crash: the
+     * current user's Symfony role set can contain roles the ACL never
+     * registers (ROLE_SESSION_MANAGER, ROLE_PREVIOUS_ADMIN,
+     * ROLE_ALLOWED_TO_SWITCH, ...), because ResourceAclHelper::init() only
+     * ever registers a small fixed set of resource-permission roles.
+     * isAllowed() iterates ALL of $user->getRoles() - without a
+     * $acl->hasRole() guard, Laminas throws
+     * Acl\Exception\InvalidArgumentException for the first unregistered
+     * role instead of just skipping it, turning every resource permission
+     * check into a 500 for such a user.
+     */
+    public function testDoesNotThrowWhenUserHasRoleNotRegisteredInAcl(): void
+    {
+        $user = $this->createMock(User::class);
+        $user->method('getRoles')->willReturn([
+            'ROLE_SESSION_MANAGER',
+            'ROLE_PREVIOUS_ADMIN',
+            'ROLE_ALLOWED_TO_SWITCH',
+            'ROLE_CURRENT_COURSE_STUDENT',
+            'ROLE_STUDENT',
+        ]);
+
+        $token = $this->createMock(TokenInterface::class);
+
+        $security = $this->createMock(Security::class);
+        $security->method('getToken')->willReturn($token);
+        $security->method('getUser')->willReturn($user);
+
+        $helper = new ResourceAclHelper($security);
+
+        $resourceLink = new ResourceLink();
+
+        $result = $helper->isAllowed('VIEW', $resourceLink, []);
+
+        $this->assertFalse($result);
+    }
+}


### PR DESCRIPTION
## Summary
- `ResourceAclHelper::isAllowed()` iterates every role in `$user->getRoles()` and calls `Acl::isAllowed($role, ...)` for each, but the Laminas ACL registry (built in `init()`) only ever registers a small fixed set of resource-permission roles (`ROLE_USER`, `ROLE_STUDENT`, `ROLE_CURRENT_COURSE_TEACHER`, ...).
- Any other role the user happens to carry - e.g. `ROLE_SESSION_MANAGER`, `ROLE_PREVIOUS_ADMIN` or `ROLE_ALLOWED_TO_SWITCH`, all present on an admin's token while using "Login as" - makes Laminas throw `Acl\Exception\InvalidArgumentException("Role '...' not found")`, crashing the whole request with a 500 instead of just being irrelevant to the resource-level permission check.
- This affects any `AbstractResource`-backed resource (documents, forums, etc.) whenever the current user's Symfony role set contains a role the ACL never registered - most commonly while impersonating another user via "Login as".
- Fix: skip roles the ACL hasn't registered via `Acl::hasRole()` instead of asking it about them.

## Test plan
- [x] Added `tests/CoreBundle/Helpers/ResourceAclHelperTest.php`, reproducing the crash with a mocked user carrying `ROLE_SESSION_MANAGER`/`ROLE_PREVIOUS_ADMIN`/`ROLE_ALLOWED_TO_SWITCH` - fails before the fix, passes after.
- [x] `vendor/bin/phpstan analyse` clean on the changed file (pre-existing unrelated findings on lines untouched by this change were verified present before this diff too).