### PR TITLE
Fix Symfony container validation errors

### DIFF
--- a/config/packages/api_platform.yaml
+++ b/config/packages/api_platform.yaml
@@ -56,10 +56,7 @@ api_platform:
         hydra_prefix: true
 
     graphql:
-        graphiql:
-            enabled: false
-        graphql_playground:
-            enabled: false
+        enabled: false
 
 #    mercure:
 #        hub_url: '%env(MERCURE_SUBSCRIBE_URL)%'

--- a/src/CoreBundle/Resources/config/services.yml
+++ b/src/CoreBundle/Resources/config/services.yml
@@ -66,11 +66,6 @@ services:
           driver: 'gd'
         $filters: [ ]
 
-    Chamilo\CoreBundle\Helpers\GlideAssetUtil:
-        arguments:
-            - {source: '@oneup_flysystem.asset_filesystem', cache: '@oneup_flysystem.asset_cache_filesystem'}
-            - '%glide_media_filters%'
-
     # Check if users are online
 #    chamilo_core.listener.online:
 #        class: Chamilo\CoreBundle\EventListener\OnlineListener

--- a/src/CoreBundle/Storage/Factory/AwsS3ClientFactory.php
+++ b/src/CoreBundle/Storage/Factory/AwsS3ClientFactory.php
@@ -24,9 +24,12 @@ class AwsS3ClientFactory
         string $region,
         string $key,
         string $secret,
-        string $endpoint = '',
-        string $usePathStyle = '',
+        ?string $endpoint = null,
+        ?string $usePathStyle = null,
     ): S3Client {
+        $endpoint ??= '';
+        $usePathStyle ??= '';
+
         $config = [
             'version' => $version,
             'region' => $region,


### PR DESCRIPTION
Fix container validation errors exposed after the Symfony 7.4 upgrade:

- Remove the stale GlideAssetUtil service declaration.
- Allow nullable optional S3 endpoint configuration.
- Disable GraphQL because its runtime dependency is not installed and Chamilo does not currently expose GraphQL operations.

Validation:
- cache:clear passes
- lint:container passes
- No database changes