### PR TITLE
MCP: add course authoring and review workflow

### DIFF
--- a/assets/vue/components/social/UserProfileCard.vue
+++ b/assets/vue/components/social/UserProfileCard.vue
@@ -285,6 +285,30 @@
               aria-hidden="true"
             ></i>
           </button>
+
+          <button
+            type="button"
+            class="group flex min-h-[56px] w-full items-center rounded-xl bg-secondary px-4 py-3 text-left text-secondary-button-text shadow-sm transition hover:opacity-95 hover:shadow-xl"
+            @click="manageMcpApiKey"
+          >
+            <span
+              class="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-white text-secondary shadow-sm"
+            >
+              <i
+                class="mdi mdi-lock-outline text-lg"
+                aria-hidden="true"
+              ></i>
+            </span>
+
+            <span class="ml-3 min-w-0 flex-1 text-body-2 font-semibold leading-snug">
+              {{ t("MCP API key") }}
+            </span>
+
+            <i
+              class="mdi mdi-chevron-right ml-2 text-lg opacity-80 transition group-hover:translate-x-0.5"
+              aria-hidden="true"
+            ></i>
+          </button>
         </div>
       </div>
     </div>
@@ -352,6 +376,10 @@ function editProfile() {
 
 function changePassword() {
   window.location.href = "/account/change-password"
+}
+
+function manageMcpApiKey() {
+  window.location.href = "/resources/users/mcp_api_key"
 }
 
 async function fetchUserProfile(userId) {

--- a/assets/vue/router/user.js
+++ b/assets/vue/router/user.js
@@ -17,5 +17,11 @@ export default {
       meta: { breadcrumb: "Personal data" },
       component: () => import("../views/user/PersonalData.vue"),
     },
+    {
+      name: "McpApiKey",
+      path: "mcp_api_key",
+      meta: { breadcrumb: "MCP API key" },
+      component: () => import("../views/user/McpApiKey.vue"),
+    },
   ],
 }

--- a/assets/vue/services/mcpApiKeyService.js
+++ b/assets/vue/services/mcpApiKeyService.js
@@ -1,0 +1,21 @@
+import baseService from "./baseService"
+
+const ENDPOINT = "/api/mcp_api_key"
+
+async function getCurrent() {
+  return baseService.get(ENDPOINT)
+}
+
+async function generate() {
+  return baseService.post(ENDPOINT, {})
+}
+
+async function revoke() {
+  return baseService.delete(ENDPOINT)
+}
+
+export default {
+  getCurrent,
+  generate,
+  revoke,
+}

--- a/assets/vue/views/user/McpApiKey.vue
+++ b/assets/vue/views/user/McpApiKey.vue
@@ -1,0 +1,286 @@
+<template>
+  <div class="flex flex-col gap-4">
+    <BaseCard
+      class="bg-white"
+      plain
+    >
+      <template #header>
+        <div class="px-4 py-2 -mb-2 bg-gray-15">
+          <h2 class="text-h5">{{ t("MCP API key") }}</h2>
+        </div>
+      </template>
+
+      <hr class="-mt-2 mb-4 -mx-4" />
+
+      <div class="space-y-4">
+        <p>
+          {{
+            t(
+              "Use this personal key to connect a remote MCP client to Chamilo with your own account and permissions.",
+            )
+          }}
+        </p>
+
+        <div class="rounded-xl border border-amber-200 bg-amber-50 p-4 text-sm text-amber-900">
+          {{
+            t(
+              "The complete key is displayed only once. Store it securely. Generating a new key immediately invalidates the previous one.",
+            )
+          }}
+        </div>
+
+        <div
+          v-if="isLoading"
+          class="text-sm text-gray-50"
+        >
+          {{ t("Loading...") }}
+        </div>
+
+        <template v-else>
+          <dl class="grid grid-cols-1 gap-3 md:grid-cols-[12rem_1fr]">
+            <dt class="font-semibold">{{ t("Status") }}</dt>
+            <dd>
+              <span
+                v-if="apiKey.active"
+                class="inline-flex rounded-full bg-success px-3 py-1 text-sm text-success-button-text"
+              >
+                {{ t("Active") }}
+              </span>
+              <span
+                v-else
+                class="inline-flex rounded-full bg-gray-20 px-3 py-1 text-sm text-gray-90"
+              >
+                {{ t("Inactive") }}
+              </span>
+            </dd>
+
+            <dt class="font-semibold">{{ t("MCP endpoint") }}</dt>
+            <dd class="break-all font-mono text-sm">{{ apiKey.endpoint || "-" }}</dd>
+
+            <template v-if="apiKey.maskedKey">
+              <dt class="font-semibold">{{ t("API key") }}</dt>
+              <dd class="break-all font-mono text-sm">{{ apiKey.maskedKey }}</dd>
+            </template>
+
+            <template v-if="apiKey.createdAt">
+              <dt class="font-semibold">{{ t("Created at") }}</dt>
+              <dd>{{ formatDate(apiKey.createdAt) }}</dd>
+            </template>
+
+            <template v-if="apiKey.lastUsedAt">
+              <dt class="font-semibold">{{ t("Last used at") }}</dt>
+              <dd>{{ formatDate(apiKey.lastUsedAt) }}</dd>
+            </template>
+          </dl>
+
+          <div
+            v-if="plainKey"
+            class="rounded-xl border border-success bg-support-2 p-4"
+          >
+            <p class="mb-3 font-semibold">
+              {{ t("Copy this key now. It will not be shown again.") }}
+            </p>
+
+            <div class="flex flex-col gap-2 md:flex-row">
+              <input
+                name="mcp_api_key"
+                class="min-w-0 flex-1 rounded-lg border border-gray-25 bg-white px-3 py-2 font-mono text-sm"
+                :value="plainKey"
+                readonly
+                type="text"
+                @focus="$event.target.select()"
+              />
+              <BaseButton
+                :label="t('Copy')"
+                icon="copy"
+                type="primary"
+                @click="copyKey"
+              />
+            </div>
+          </div>
+
+          <div class="flex flex-wrap gap-2">
+            <BaseButton
+              :disabled="isSaving"
+              :is-loading="isSaving"
+              :label="apiKey.active ? t('Rotate API key') : t('Generate API key')"
+              icon="refresh"
+              type="primary"
+              @click="confirmGenerate"
+            />
+            <BaseButton
+              v-if="apiKey.active"
+              :disabled="isSaving"
+              :label="t('Revoke API key')"
+              icon="delete"
+              type="danger"
+              @click="confirmRevoke"
+            />
+          </div>
+        </template>
+      </div>
+    </BaseCard>
+
+    <BaseCard
+      class="bg-white"
+      plain
+    >
+      <template #header>
+        <div class="px-4 py-2 -mb-2 bg-gray-15">
+          <h2 class="text-h5">{{ t("Remote MCP connection") }}</h2>
+        </div>
+      </template>
+
+      <hr class="-mt-2 mb-4 -mx-4" />
+
+      <div class="space-y-3 text-sm">
+        <p>{{ t("Configure your MCP client with the following values:") }}</p>
+        <pre class="overflow-x-auto rounded-xl bg-gray-90 p-4 text-white">URL: {{ apiKey.endpoint || "https://your-chamilo.example/mcp" }}
+Authorization: Bearer &lt;your MCP API key&gt;</pre>
+        <p>
+          {{
+            t(
+              "The key authenticates the client as your Chamilo account. It does not grant permissions that your account does not already have.",
+            )
+          }}
+        </p>
+      </div>
+    </BaseCard>
+  </div>
+</template>
+
+<script setup>
+import { onMounted, reactive, ref } from "vue"
+import { useI18n } from "vue-i18n"
+import BaseButton from "../../components/basecomponents/BaseButton.vue"
+import BaseCard from "../../components/basecomponents/BaseCard.vue"
+import { useConfirmation } from "../../composables/useConfirmation"
+import { useNotification } from "../../composables/notification"
+import mcpApiKeyService from "../../services/mcpApiKeyService"
+
+const { t } = useI18n()
+const { requireConfirmation } = useConfirmation()
+const notifications = useNotification()
+
+const isLoading = ref(false)
+const isSaving = ref(false)
+const plainKey = ref("")
+const apiKey = reactive(createEmptyApiKey())
+
+function createEmptyApiKey() {
+  return {
+    active: false,
+    maskedKey: null,
+    endpoint: "",
+    createdAt: null,
+    lastUsedAt: null,
+    revokedAt: null,
+  }
+}
+
+function applyApiKey(data = {}) {
+  Object.assign(apiKey, createEmptyApiKey(), data)
+}
+
+function getErrorMessage(error) {
+  return (
+    error?.response?.data?.detail ||
+    error?.response?.data?.["hydra:description"] ||
+    error?.response?.data?.message ||
+    t("The MCP API key operation could not be completed.")
+  )
+}
+
+function formatDate(value) {
+  if (!value) {
+    return "-"
+  }
+
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) {
+    return value
+  }
+
+  return new Intl.DateTimeFormat(undefined, { dateStyle: "medium", timeStyle: "short" }).format(date)
+}
+
+async function loadApiKey() {
+  isLoading.value = true
+
+  try {
+    applyApiKey(await mcpApiKeyService.getCurrent())
+  } catch (error) {
+    console.error("Error loading MCP API key metadata", error)
+    notifications.showErrorNotification(getErrorMessage(error))
+  } finally {
+    isLoading.value = false
+  }
+}
+
+function confirmGenerate() {
+  requireConfirmation({
+    title: apiKey.active ? t("Rotate API key") : t("Generate API key"),
+    message: apiKey.active
+      ? t("The current key will stop working immediately. Continue?")
+      : t("A new personal MCP API key will be generated. Continue?"),
+    accept: generateKey,
+  })
+}
+
+async function generateKey() {
+  isSaving.value = true
+  plainKey.value = ""
+
+  try {
+    const response = await mcpApiKeyService.generate()
+    applyApiKey(response)
+    plainKey.value = response.plainKey || ""
+    notifications.showSuccessNotification(t("MCP API key generated"))
+  } catch (error) {
+    console.error("Error generating MCP API key", error)
+    notifications.showErrorNotification(getErrorMessage(error))
+  } finally {
+    isSaving.value = false
+  }
+}
+
+function confirmRevoke() {
+  requireConfirmation({
+    title: t("Revoke API key"),
+    message: t("Connected MCP clients using this key will stop working immediately. Continue?"),
+    accept: revokeKey,
+  })
+}
+
+async function revokeKey() {
+  isSaving.value = true
+  plainKey.value = ""
+
+  try {
+    await mcpApiKeyService.revoke()
+    await loadApiKey()
+    notifications.showSuccessNotification(t("MCP API key revoked"))
+  } catch (error) {
+    console.error("Error revoking MCP API key", error)
+    notifications.showErrorNotification(getErrorMessage(error))
+  } finally {
+    isSaving.value = false
+  }
+}
+
+async function copyKey() {
+  if (!plainKey.value) {
+    return
+  }
+
+  try {
+    await navigator.clipboard.writeText(plainKey.value)
+    notifications.showSuccessNotification(t("Copied"))
+  } catch (error) {
+    console.error("Error copying MCP API key", error)
+    notifications.showErrorNotification(t("Could not copy the API key"))
+  }
+}
+
+onMounted(loadApiKey)
+</script>

--- a/composer.json
+++ b/composer.json
@@ -153,6 +153,7 @@
     "symfony/lock": "7.4.*",
     "symfony/mailer": "7.4.*",
     "symfony/mailjet-mailer": "7.4.*",
+    "symfony/mcp-bundle": "^0.12",
     "symfony/messenger": "7.4.*",
     "symfony/mime": "7.4.*",
     "symfony/monolog-bundle": "^3.1",
@@ -197,8 +198,9 @@
     "component-dir": "public/assets",
     "sort-packages": true,
     "allow-plugins": {
-      "symfony/flex": true,
       "dealerdirect/phpcodesniffer-composer-installer": true,
+      "php-http/discovery": true,
+      "symfony/flex": true,
       "symfony/runtime": true
     },
     "process-timeout": 900

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f230613c601b62281fa857481dd9ae5a",
+    "content-hash": "ee415409486be996a462970bb4044c5e",
     "packages": [
         {
             "name": "a2lix/auto-form-bundle",
@@ -7734,6 +7734,90 @@
             "time": "2026-06-23T18:43:15+00:00"
         },
         {
+            "name": "mcp/sdk",
+            "version": "v0.7.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/modelcontextprotocol/php-sdk.git",
+                "reference": "a6f415578fa789783d010274d11c922e97659a8a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/modelcontextprotocol/php-sdk/zipball/a6f415578fa789783d010274d11c922e97659a8a",
+                "reference": "a6f415578fa789783d010274d11c922e97659a8a",
+                "shasum": ""
+            },
+            "require": {
+                "ext-fileinfo": "*",
+                "opis/json-schema": "^2.4",
+                "php": "^8.1",
+                "php-http/discovery": "^1.20",
+                "phpdocumentor/reflection-docblock": "^5.6 || ^6.0",
+                "psr/clock": "^1.0",
+                "psr/container": "^1.0 || ^2.0",
+                "psr/event-dispatcher": "^1.0",
+                "psr/http-client": "^1.0",
+                "psr/http-factory": "^1.1",
+                "psr/http-message": "^1.1 || ^2.0",
+                "psr/http-server-handler": "^1.0",
+                "psr/http-server-middleware": "^1.0",
+                "psr/log": "^1.0 || ^2.0 || ^3.0",
+                "symfony/uid": "^5.4 || ^6.4 || ^7.3 || ^8.0"
+            },
+            "require-dev": {
+                "composer/semver": "^3.0",
+                "ext-openssl": "*",
+                "firebase/php-jwt": "^6.10 || ^7.0",
+                "laminas/laminas-httphandlerrunner": "^2.12",
+                "nyholm/psr7": "^1.8",
+                "nyholm/psr7-server": "^1.1",
+                "phar-io/composer-distributor": "^1.0.2",
+                "php-cs-fixer/shim": "^3.91",
+                "phpdocumentor/shim": "^3",
+                "phpstan/phpstan": "^2.1",
+                "phpunit/phpunit": "^10.5",
+                "psr/simple-cache": "^2.0 || ^3.0",
+                "symfony/cache": "^5.4 || ^6.4 || ^7.3 || ^8.0",
+                "symfony/console": "^5.4 || ^6.4 || ^7.3 || ^8.0",
+                "symfony/finder": "^5.4 || ^6.4 || ^7.3 || ^8.0",
+                "symfony/http-client": "^5.4 || ^6.4 || ^7.3 || ^8.0",
+                "symfony/process": "^5.4 || ^6.4 || ^7.3 || ^8.0"
+            },
+            "suggest": {
+                "symfony/finder": "Required for file-based discovery."
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Mcp\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "authors": [
+                {
+                    "name": "Christopher Hertel",
+                    "email": "mail@christopher-hertel.de"
+                },
+                {
+                    "name": "Kyrian Obikwelu",
+                    "email": "koshnawaza@gmail.com"
+                },
+                {
+                    "name": "Tobias Nyholm",
+                    "email": "tobias.nyholm@gmail.com"
+                }
+            ],
+            "description": "Model Context Protocol SDK for Client and Server applications in PHP",
+            "support": {
+                "issues": "https://github.com/modelcontextprotocol/php-sdk/issues",
+                "source": "https://github.com/modelcontextprotocol/php-sdk/tree/v0.7.0"
+            },
+            "time": "2026-07-14T22:58:00+00:00"
+        },
+        {
             "name": "michelf/php-markdown",
             "version": "1.9.1",
             "source": {
@@ -8871,6 +8955,196 @@
             "time": "2026-03-17T11:38:56+00:00"
         },
         {
+            "name": "opis/json-schema",
+            "version": "2.6.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/opis/json-schema.git",
+                "reference": "8458763e0dd0b6baa310e04f1829fc73da4e8c8a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/opis/json-schema/zipball/8458763e0dd0b6baa310e04f1829fc73da4e8c8a",
+                "reference": "8458763e0dd0b6baa310e04f1829fc73da4e8c8a",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "opis/string": "^2.1",
+                "opis/uri": "^1.0",
+                "php": "^7.4 || ^8.0"
+            },
+            "require-dev": {
+                "ext-bcmath": "*",
+                "ext-intl": "*",
+                "phpunit/phpunit": "^9.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Opis\\JsonSchema\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "authors": [
+                {
+                    "name": "Sorin Sarca",
+                    "email": "sarca_sorin@hotmail.com"
+                },
+                {
+                    "name": "Marius Sarca",
+                    "email": "marius.sarca@gmail.com"
+                }
+            ],
+            "description": "Json Schema Validator for PHP",
+            "homepage": "https://opis.io/json-schema",
+            "keywords": [
+                "json",
+                "json-schema",
+                "schema",
+                "validation",
+                "validator"
+            ],
+            "support": {
+                "issues": "https://github.com/opis/json-schema/issues",
+                "source": "https://github.com/opis/json-schema/tree/2.6.0"
+            },
+            "time": "2025-10-17T12:46:48+00:00"
+        },
+        {
+            "name": "opis/string",
+            "version": "2.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/opis/string.git",
+                "reference": "3e4d2aaff518ac518530b89bb26ed40f4503635e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/opis/string/zipball/3e4d2aaff518ac518530b89bb26ed40f4503635e",
+                "reference": "3e4d2aaff518ac518530b89bb26ed40f4503635e",
+                "shasum": ""
+            },
+            "require": {
+                "ext-iconv": "*",
+                "ext-json": "*",
+                "php": "^7.4 || ^8.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Opis\\String\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "authors": [
+                {
+                    "name": "Marius Sarca",
+                    "email": "marius.sarca@gmail.com"
+                },
+                {
+                    "name": "Sorin Sarca",
+                    "email": "sarca_sorin@hotmail.com"
+                }
+            ],
+            "description": "Multibyte strings as objects",
+            "homepage": "https://opis.io/string",
+            "keywords": [
+                "multi-byte",
+                "opis",
+                "string",
+                "string manipulation",
+                "utf-8"
+            ],
+            "support": {
+                "issues": "https://github.com/opis/string/issues",
+                "source": "https://github.com/opis/string/tree/2.1.0"
+            },
+            "time": "2025-10-17T12:38:41+00:00"
+        },
+        {
+            "name": "opis/uri",
+            "version": "1.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/opis/uri.git",
+                "reference": "0f3ca49ab1a5e4a6681c286e0b2cc081b93a7d5a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/opis/uri/zipball/0f3ca49ab1a5e4a6681c286e0b2cc081b93a7d5a",
+                "reference": "0f3ca49ab1a5e4a6681c286e0b2cc081b93a7d5a",
+                "shasum": ""
+            },
+            "require": {
+                "opis/string": "^2.0",
+                "php": "^7.4 || ^8.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Opis\\Uri\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "authors": [
+                {
+                    "name": "Marius Sarca",
+                    "email": "marius.sarca@gmail.com"
+                },
+                {
+                    "name": "Sorin Sarca",
+                    "email": "sarca_sorin@hotmail.com"
+                }
+            ],
+            "description": "Build, parse and validate URIs and URI-templates",
+            "homepage": "https://opis.io",
+            "keywords": [
+                "URI Template",
+                "parse url",
+                "punycode",
+                "uri",
+                "uri components",
+                "url",
+                "validate uri"
+            ],
+            "support": {
+                "issues": "https://github.com/opis/uri/issues",
+                "source": "https://github.com/opis/uri/tree/1.1.0"
+            },
+            "time": "2021-05-22T15:57:08+00:00"
+        },
+        {
             "name": "packbackbooks/lti-1p3-tool",
             "version": "v6.4.3",
             "source": {
@@ -9402,6 +9676,85 @@
                 "source": "https://github.com/PHP-FFMpeg/PHP-FFMpeg/tree/v1.2.0"
             },
             "time": "2024-01-02T10:37:01+00:00"
+        },
+        {
+            "name": "php-http/discovery",
+            "version": "1.20.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-http/discovery.git",
+                "reference": "82fe4c73ef3363caed49ff8dd1539ba06044910d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-http/discovery/zipball/82fe4c73ef3363caed49ff8dd1539ba06044910d",
+                "reference": "82fe4c73ef3363caed49ff8dd1539ba06044910d",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^1.0|^2.0",
+                "php": "^7.1 || ^8.0"
+            },
+            "conflict": {
+                "nyholm/psr7": "<1.0",
+                "zendframework/zend-diactoros": "*"
+            },
+            "provide": {
+                "php-http/async-client-implementation": "*",
+                "php-http/client-implementation": "*",
+                "psr/http-client-implementation": "*",
+                "psr/http-factory-implementation": "*",
+                "psr/http-message-implementation": "*"
+            },
+            "require-dev": {
+                "composer/composer": "^1.0.2|^2.0",
+                "graham-campbell/phpspec-skip-example-extension": "^5.0",
+                "php-http/httplug": "^1.0 || ^2.0",
+                "php-http/message-factory": "^1.0",
+                "phpspec/phpspec": "^5.1 || ^6.1 || ^7.3",
+                "sebastian/comparator": "^3.0.5 || ^4.0.8",
+                "symfony/phpunit-bridge": "^6.4.4 || ^7.0.1"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "class": "Http\\Discovery\\Composer\\Plugin",
+                "plugin-optional": true
+            },
+            "autoload": {
+                "psr-4": {
+                    "Http\\Discovery\\": "src/"
+                },
+                "exclude-from-classmap": [
+                    "src/Composer/Plugin.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Márk Sági-Kazár",
+                    "email": "mark.sagikazar@gmail.com"
+                }
+            ],
+            "description": "Finds and installs PSR-7, PSR-17, PSR-18 and HTTPlug implementations",
+            "homepage": "http://php-http.org",
+            "keywords": [
+                "adapter",
+                "client",
+                "discovery",
+                "factory",
+                "http",
+                "message",
+                "psr17",
+                "psr7"
+            ],
+            "support": {
+                "issues": "https://github.com/php-http/discovery/issues",
+                "source": "https://github.com/php-http/discovery/tree/1.20.0"
+            },
+            "time": "2024-10-02T11:20:13+00:00"
         },
         {
             "name": "phpdocumentor/reflection-common",
@@ -10384,6 +10737,119 @@
                 "source": "https://github.com/php-fig/http-message/tree/1.1"
             },
             "time": "2023-04-04T09:50:52+00:00"
+        },
+        {
+            "name": "psr/http-server-handler",
+            "version": "1.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/http-server-handler.git",
+                "reference": "84c4fb66179be4caaf8e97bd239203245302e7d4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/http-server-handler/zipball/84c4fb66179be4caaf8e97bd239203245302e7d4",
+                "reference": "84c4fb66179be4caaf8e97bd239203245302e7d4",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.0",
+                "psr/http-message": "^1.0 || ^2.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Http\\Server\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for HTTP server-side request handler",
+            "keywords": [
+                "handler",
+                "http",
+                "http-interop",
+                "psr",
+                "psr-15",
+                "psr-7",
+                "request",
+                "response",
+                "server"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/http-server-handler/tree/1.0.2"
+            },
+            "time": "2023-04-10T20:06:20+00:00"
+        },
+        {
+            "name": "psr/http-server-middleware",
+            "version": "1.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/http-server-middleware.git",
+                "reference": "c1481f747daaa6a0782775cd6a8c26a1bf4a3829"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/http-server-middleware/zipball/c1481f747daaa6a0782775cd6a8c26a1bf4a3829",
+                "reference": "c1481f747daaa6a0782775cd6a8c26a1bf4a3829",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.0",
+                "psr/http-message": "^1.0 || ^2.0",
+                "psr/http-server-handler": "^1.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Http\\Server\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for HTTP server-side middleware",
+            "keywords": [
+                "http",
+                "http-interop",
+                "middleware",
+                "psr",
+                "psr-15",
+                "psr-7",
+                "request",
+                "response"
+            ],
+            "support": {
+                "issues": "https://github.com/php-fig/http-server-middleware/issues",
+                "source": "https://github.com/php-fig/http-server-middleware/tree/1.0.2"
+            },
+            "time": "2023-04-11T06:14:47+00:00"
         },
         {
             "name": "psr/link",
@@ -14673,6 +15139,93 @@
             "time": "2026-05-20T07:20:23+00:00"
         },
         {
+            "name": "symfony/mcp-bundle",
+            "version": "v0.12.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/mcp-bundle.git",
+                "reference": "7ffd7bfab9d315a52a8224e35b32bd0db1765d44"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/mcp-bundle/zipball/7ffd7bfab9d315a52a8224e35b32bd0db1765d44",
+                "reference": "7ffd7bfab9d315a52a8224e35b32bd0db1765d44",
+                "shasum": ""
+            },
+            "require": {
+                "mcp/sdk": "^0.7",
+                "php-http/discovery": "^1.20",
+                "symfony/config": "^7.3|^8.0",
+                "symfony/console": "^7.3|^8.0",
+                "symfony/dependency-injection": "^7.3|^8.0",
+                "symfony/finder": "^7.3|^8.0",
+                "symfony/framework-bundle": "^7.3|^8.0",
+                "symfony/http-foundation": "^7.3|^8.0",
+                "symfony/http-kernel": "^7.3|^8.0",
+                "symfony/psr-http-message-bridge": "^7.3|^8.0",
+                "symfony/routing": "^7.3|^8.0",
+                "symfony/service-contracts": "^2.5|^3"
+            },
+            "require-dev": {
+                "nyholm/psr7": "^1.8",
+                "phpstan/phpstan": "^2.1",
+                "phpstan/phpstan-phpunit": "^2.0",
+                "phpstan/phpstan-strict-rules": "^2.0",
+                "phpunit/phpunit": "^11.5.53",
+                "symfony/monolog-bundle": "^3.10 || ^4.0",
+                "symfony/twig-bundle": "^7.3|^8.0"
+            },
+            "type": "symfony-bundle",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/ai",
+                    "name": "symfony/ai"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\AI\\McpBundle\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Christopher Hertel",
+                    "email": "mail@christopher-hertel.de"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony integration bundle for Model Context Protocol (via official mcp/sdk)",
+            "support": {
+                "source": "https://github.com/symfony/mcp-bundle/tree/v0.12.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-07-21T01:04:45+00:00"
+        },
+        {
             "name": "symfony/messenger",
             "version": "v7.4.14",
             "source": {
@@ -16254,6 +16807,94 @@
             ],
             "support": {
                 "source": "https://github.com/symfony/property-info/tree/v7.4.8"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-03-24T13:12:05+00:00"
+        },
+        {
+            "name": "symfony/psr-http-message-bridge",
+            "version": "v7.4.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/psr-http-message-bridge.git",
+                "reference": "76f1a57719a4a04c0ea18678a6c9305b5dcb9da8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/psr-http-message-bridge/zipball/76f1a57719a4a04c0ea18678a6c9305b5dcb9da8",
+                "reference": "76f1a57719a4a04c0ea18678a6c9305b5dcb9da8",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2",
+                "psr/http-message": "^1.0|^2.0",
+                "symfony/http-foundation": "^6.4|^7.0|^8.0"
+            },
+            "conflict": {
+                "php-http/discovery": "<1.15",
+                "symfony/http-kernel": "<6.4"
+            },
+            "require-dev": {
+                "nyholm/psr7": "^1.1",
+                "php-http/discovery": "^1.15",
+                "psr/log": "^1.1.4|^2|^3",
+                "symfony/browser-kit": "^6.4|^7.0|^8.0",
+                "symfony/config": "^6.4|^7.0|^8.0",
+                "symfony/event-dispatcher": "^6.4|^7.0|^8.0",
+                "symfony/framework-bundle": "^6.4.13|^7.1.6|^8.0",
+                "symfony/http-kernel": "^6.4.13|^7.1.6|^8.0",
+                "symfony/runtime": "^6.4.13|^7.1.6|^8.0"
+            },
+            "type": "symfony-bridge",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Bridge\\PsrHttpMessage\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "PSR HTTP message bridge",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "http",
+                "http-message",
+                "psr-17",
+                "psr-7"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/psr-http-message-bridge/tree/v7.4.8"
             },
             "funding": [
                 {
@@ -24837,5 +25478,5 @@
     "platform-overrides": {
         "php": "8.3"
     },
-    "plugin-api-version": "2.9.0"
+    "plugin-api-version": "2.6.0"
 }

--- a/config/bundles.php
+++ b/config/bundles.php
@@ -1,40 +1,79 @@
 <?php
 
+declare(strict_types=1);
+
+use A2lix\AutoFormBundle\A2lixAutoFormBundle;
+use A2lix\TranslationFormBundle\A2lixTranslationFormBundle;
+use ApiPlatform\Symfony\Bundle\ApiPlatformBundle;
+use Chamilo\CoreBundle\ChamiloCoreBundle;
+use Chamilo\CourseBundle\ChamiloCourseBundle;
+use Chamilo\LtiBundle\ChamiloLtiBundle;
+use Cocur\Slugify\Bridge\Symfony\CocurSlugifyBundle;
+use DAMA\DoctrineTestBundle\DAMADoctrineTestBundle;
+use Doctrine\Bundle\DoctrineBundle\DoctrineBundle;
+use Doctrine\Bundle\FixturesBundle\DoctrineFixturesBundle;
+use Doctrine\Bundle\MigrationsBundle\DoctrineMigrationsBundle;
+use Fidry\AliceDataFixtures\Bridge\Symfony\FidryAliceDataFixturesBundle;
+use FOS\JsRoutingBundle\FOSJsRoutingBundle;
+use Gregwar\CaptchaBundle\GregwarCaptchaBundle;
+use Hautelook\AliceBundle\HautelookAliceBundle;
+use KnpU\OAuth2ClientBundle\KnpUOAuth2ClientBundle;
+use Lexik\Bundle\JWTAuthenticationBundle\LexikJWTAuthenticationBundle;
+use Nelmio\Alice\Bridge\Symfony\NelmioAliceBundle;
+use Nelmio\CorsBundle\NelmioCorsBundle;
+use Oh\GoogleMapFormTypeBundle\OhGoogleMapFormTypeBundle;
+use Oneup\FlysystemBundle\OneupFlysystemBundle;
+use Sonata\Exporter\Bridge\Symfony\SonataExporterBundle;
+use Stof\DoctrineExtensionsBundle\StofDoctrineExtensionsBundle;
+use Sylius\Bundle\SettingsBundle\SyliusSettingsBundle;
+use Symfony\AI\McpBundle\McpBundle;
+use Symfony\Bundle\DebugBundle\DebugBundle;
+use Symfony\Bundle\FrameworkBundle\FrameworkBundle;
+use Symfony\Bundle\MakerBundle\MakerBundle;
+use Symfony\Bundle\MonologBundle\MonologBundle;
+use Symfony\Bundle\SecurityBundle\SecurityBundle;
+use Symfony\Bundle\TwigBundle\TwigBundle;
+use Symfony\Bundle\WebProfilerBundle\WebProfilerBundle;
+use Symfony\WebpackEncoreBundle\WebpackEncoreBundle;
+use SymfonyCasts\Bundle\ResetPassword\SymfonyCastsResetPasswordBundle;
+use Twig\Extra\TwigExtraBundle\TwigExtraBundle;
+use Vich\UploaderBundle\VichUploaderBundle;
+
 return [
-    Symfony\Bundle\FrameworkBundle\FrameworkBundle::class => ['all' => true],
-    Doctrine\Bundle\DoctrineBundle\DoctrineBundle::class => ['all' => true],
-    Doctrine\Bundle\FixturesBundle\DoctrineFixturesBundle::class => ['dev' => true, 'test' => true],
-    Doctrine\Bundle\MigrationsBundle\DoctrineMigrationsBundle::class => ['all' => true],
-    Symfony\Bundle\MonologBundle\MonologBundle::class => ['all' => true],
-    Symfony\Bundle\TwigBundle\TwigBundle::class => ['all' => true],
-    Symfony\Bundle\SecurityBundle\SecurityBundle::class => ['all' => true],
-    Symfony\Bundle\DebugBundle\DebugBundle::class => ['dev' => true, 'test' => true],
-    Symfony\Bundle\WebProfilerBundle\WebProfilerBundle::class => ['dev' => true, 'test' => true],
-    FOS\JsRoutingBundle\FOSJsRoutingBundle::class => ['all' => true],
-    Chamilo\CoreBundle\ChamiloCoreBundle::class => ['all' => true],
-    Chamilo\CourseBundle\ChamiloCourseBundle::class => ['all' => true],
-    Chamilo\LtiBundle\ChamiloLtiBundle::class => ['all' => true],
-    Sylius\Bundle\SettingsBundle\SyliusSettingsBundle::class => ['all' => true],
-    Oneup\FlysystemBundle\OneupFlysystemBundle::class => ['all' => true],
-    A2lix\AutoFormBundle\A2lixAutoFormBundle::class => ['all' => true],
-    A2lix\TranslationFormBundle\A2lixTranslationFormBundle::class => ['all' => true],
-    Symfony\WebpackEncoreBundle\WebpackEncoreBundle::class => ['all' => true],
-    Vich\UploaderBundle\VichUploaderBundle::class => ['all' => true],
-    Cocur\Slugify\Bridge\Symfony\CocurSlugifyBundle::class => ['all' => true],
-    KnpU\OAuth2ClientBundle\KnpUOAuth2ClientBundle::class => ['all' => true],
-    Nelmio\CorsBundle\NelmioCorsBundle::class => ['all' => true],
-    ApiPlatform\Symfony\Bundle\ApiPlatformBundle::class => ['all' => true],
-    Twig\Extra\TwigExtraBundle\TwigExtraBundle::class => ['all' => true],
-    Symfony\Bundle\MakerBundle\MakerBundle::class => ['dev' => true],
-    SymfonyCasts\Bundle\ResetPassword\SymfonyCastsResetPasswordBundle::class => ['all' => true],
-    Stof\DoctrineExtensionsBundle\StofDoctrineExtensionsBundle::class => ['all' => true],
-    Lexik\Bundle\JWTAuthenticationBundle\LexikJWTAuthenticationBundle::class => ['all' => true],
-    DAMA\DoctrineTestBundle\DAMADoctrineTestBundle::class => ['test' => true],
-    Nelmio\Alice\Bridge\Symfony\NelmioAliceBundle::class => ['dev' => true, 'test' => true],
-    Fidry\AliceDataFixtures\Bridge\Symfony\FidryAliceDataFixturesBundle::class => ['dev' => true, 'test' => true],
-    Hautelook\AliceBundle\HautelookAliceBundle::class => ['dev' => true, 'test' => true],
-    Sonata\Exporter\Bridge\Symfony\SonataExporterBundle::class => ['all' => true],
-    Oh\GoogleMapFormTypeBundle\OhGoogleMapFormTypeBundle::class => ['all' => true],
-    Gregwar\CaptchaBundle\GregwarCaptchaBundle::class => ['all' => true],
-    Symfony\AI\McpBundle\McpBundle::class => ['all' => true],
+    FrameworkBundle::class => ['all' => true],
+    DoctrineBundle::class => ['all' => true],
+    DoctrineFixturesBundle::class => ['dev' => true, 'test' => true],
+    DoctrineMigrationsBundle::class => ['all' => true],
+    MonologBundle::class => ['all' => true],
+    TwigBundle::class => ['all' => true],
+    SecurityBundle::class => ['all' => true],
+    DebugBundle::class => ['dev' => true, 'test' => true],
+    WebProfilerBundle::class => ['dev' => true, 'test' => true],
+    FOSJsRoutingBundle::class => ['all' => true],
+    ChamiloCoreBundle::class => ['all' => true],
+    ChamiloCourseBundle::class => ['all' => true],
+    ChamiloLtiBundle::class => ['all' => true],
+    SyliusSettingsBundle::class => ['all' => true],
+    OneupFlysystemBundle::class => ['all' => true],
+    A2lixAutoFormBundle::class => ['all' => true],
+    A2lixTranslationFormBundle::class => ['all' => true],
+    WebpackEncoreBundle::class => ['all' => true],
+    VichUploaderBundle::class => ['all' => true],
+    CocurSlugifyBundle::class => ['all' => true],
+    KnpUOAuth2ClientBundle::class => ['all' => true],
+    NelmioCorsBundle::class => ['all' => true],
+    ApiPlatformBundle::class => ['all' => true],
+    TwigExtraBundle::class => ['all' => true],
+    MakerBundle::class => ['dev' => true],
+    SymfonyCastsResetPasswordBundle::class => ['all' => true],
+    StofDoctrineExtensionsBundle::class => ['all' => true],
+    LexikJWTAuthenticationBundle::class => ['all' => true],
+    DAMADoctrineTestBundle::class => ['test' => true],
+    NelmioAliceBundle::class => ['dev' => true, 'test' => true],
+    FidryAliceDataFixturesBundle::class => ['dev' => true, 'test' => true],
+    HautelookAliceBundle::class => ['dev' => true, 'test' => true],
+    SonataExporterBundle::class => ['all' => true],
+    OhGoogleMapFormTypeBundle::class => ['all' => true],
+    GregwarCaptchaBundle::class => ['all' => true],
+    McpBundle::class => ['all' => true],
 ];

--- a/config/bundles.php
+++ b/config/bundles.php
@@ -36,4 +36,5 @@ return [
     Sonata\Exporter\Bridge\Symfony\SonataExporterBundle::class => ['all' => true],
     Oh\GoogleMapFormTypeBundle\OhGoogleMapFormTypeBundle::class => ['all' => true],
     Gregwar\CaptchaBundle\GregwarCaptchaBundle::class => ['all' => true],
+    Symfony\AI\McpBundle\McpBundle::class => ['all' => true],
 ];

--- a/config/packages/framework.yaml
+++ b/config/packages/framework.yaml
@@ -37,6 +37,10 @@ framework:
             policy: 'sliding_window'
             limit: 5
             interval: '1 minute'
+        mcp_authentication:
+            policy: 'sliding_window'
+            limit: 120
+            interval: '1 minute'
 
     # For legacy code (ending in ".php"), also edit public/main/inc/global.inc.php according to the changes you make here
 

--- a/config/packages/http_discovery.yaml
+++ b/config/packages/http_discovery.yaml
@@ -1,0 +1,10 @@
+services:
+    Psr\Http\Message\RequestFactoryInterface: '@http_discovery.psr17_factory'
+    Psr\Http\Message\ResponseFactoryInterface: '@http_discovery.psr17_factory'
+    Psr\Http\Message\ServerRequestFactoryInterface: '@http_discovery.psr17_factory'
+    Psr\Http\Message\StreamFactoryInterface: '@http_discovery.psr17_factory'
+    Psr\Http\Message\UploadedFileFactoryInterface: '@http_discovery.psr17_factory'
+    Psr\Http\Message\UriFactoryInterface: '@http_discovery.psr17_factory'
+
+    http_discovery.psr17_factory:
+        class: Http\Discovery\Psr17Factory

--- a/config/packages/mcp.yaml
+++ b/config/packages/mcp.yaml
@@ -1,0 +1,21 @@
+mcp:
+    app: 'Chamilo'
+    version: '2.1.0'
+    description: 'Chamilo LMS MCP server'
+    pagination_limit: 50
+    instructions: |
+        This server exposes Chamilo LMS capabilities to authenticated users.
+        Every capability must respect the permissions of the authenticated Chamilo user.
+    client_transports:
+        stdio: true
+        http: true
+    http:
+        path: /mcp
+        allowed_hosts:
+            - 'chamilo2.local'
+            - 'localhost'
+            - '127.0.0.1'
+        session:
+            store: file
+            directory: '%kernel.cache_dir%/mcp-sessions'
+            ttl: 3600

--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -68,12 +68,14 @@ security:
             pattern: ^/(_(profiler|wdt)|css|images|js)/
             security: false
 
-        # MCP remote server authenticated with Chamilo JWT.
+        # MCP remote server authenticated with a personal MCP API key or a legacy development JWT.
         mcp:
             pattern: ^/mcp$
             stateless: true
-            jwt: ~
             provider: app_user_provider
+            entry_point: Chamilo\CoreBundle\Security\Authenticator\McpBearerAuthenticator
+            custom_authenticators:
+                - Chamilo\CoreBundle\Security\Authenticator\McpBearerAuthenticator
 
         # Use to connect via a JWT token
         api:

--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -68,6 +68,13 @@ security:
             pattern: ^/(_(profiler|wdt)|css|images|js)/
             security: false
 
+        # MCP remote server authenticated with Chamilo JWT.
+        mcp:
+            pattern: ^/mcp$
+            stateless: true
+            jwt: ~
+            provider: app_user_provider
+
         # Use to connect via a JWT token
         api:
             pattern: ^/api
@@ -130,6 +137,8 @@ security:
                 - Chamilo\CoreBundle\Security\Authenticator\Ldap\LdapAuthenticator
 
     access_control:
+        - { path: '^/mcp$', roles: PUBLIC_ACCESS, methods: [OPTIONS] }
+        - { path: '^/mcp$', roles: ROLE_USER }
         - { path: ^/scim/v2, roles: PUBLIC_ACCESS }
         - { path: ^/login/token/check, roles: PUBLIC_ACCESS }
         - { path: ^/login, roles: PUBLIC_ACCESS }

--- a/config/routes/mcp.yaml
+++ b/config/routes/mcp.yaml
@@ -1,0 +1,3 @@
+mcp:
+    resource: .
+    type: mcp

--- a/public/main/exercise/exercise_result.php
+++ b/public/main/exercise/exercise_result.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /* For licensing terms, see /license.txt */
 
 use Chamilo\CoreBundle\Enums\ActionIcon;
@@ -21,12 +23,13 @@ use ChamiloSession as Session;
  * @todo    split more code up in functions, move functions to library?
  */
 $debug = false;
+
 require_once __DIR__.'/../inc/global.inc.php';
 
 $current_course_tool = TOOL_QUIZ;
 $this_section = SECTION_COURSES;
 
-/* 	ACCESS RIGHTS  */
+/* 	ACCESS RIGHTS */
 api_protect_course_script(true);
 
 $origin = api_get_origin();
@@ -99,6 +102,7 @@ if (empty($objExercise)) {
             && isset($exercise_stat_info['exe_exo_id'])
         ) {
             header('Location: overview.php?exerciseId='.$exercise_stat_info['exe_exo_id'].'&'.api_get_cidreq().'&origin='.$origin);
+
             exit;
         }
 
@@ -189,7 +193,6 @@ if (
     $allowSignature = false === $signature;
 }
 
-
 if ('learnpath' === $origin) {
     $pageTop .= '
         <form method="GET" action="exercise.php?'.api_get_cidreq().'">
@@ -234,8 +237,8 @@ if ($objExercise->selectAttempts() > 0) {
             Display::addFlash(
                 Display::return_message(
                     sprintf(get_lang('You have reached the maximum number of attempts for this test. Being a trainer, you can go on practicing but your Results will not be reported.'), $objExercise->selectTitle(), $objExercise->selectAttempts()),
-                'warning',
-                false
+                    'warning',
+                    false
                 )
             );
         }
@@ -247,14 +250,14 @@ if ($objExercise->selectAttempts() > 0) {
         $template = new Template($nameTools, $showHeader, $showFooter);
         $template->assign('actions', $pageActions);
         $template->display_one_col_template();
+
         exit;
-    } else {
-        $attempt_count++;
-        $remainingAttempts = $objExercise->selectAttempts() - $attempt_count;
-        if ($remainingAttempts) {
-            $attemptMessage = sprintf(get_lang('Remaining %d attempts'), $remainingAttempts);
-            $remainingMessage = sprintf('<p>%s</p> %s', $attemptMessage, $attemptButton);
-        }
+    }
+    $attempt_count++;
+    $remainingAttempts = $objExercise->selectAttempts() - $attempt_count;
+    if ($remainingAttempts) {
+        $attemptMessage = sprintf(get_lang('Remaining %d attempts'), $remainingAttempts);
+        $remainingMessage = sprintf('<p>%s</p> %s', $attemptMessage, $attemptButton);
     }
 } else {
     $remainingMessage = $attemptButton ? "<p>$attemptButton</p>" : '';
@@ -285,7 +288,7 @@ $stats = ExerciseLib::displayQuestionListByAttempt(
     $saveResults,
     $remainingMessage,
     $allowSignature,
-    ('true' === api_get_setting('exercise.quiz_results_answers_report')),
+    'true' === api_get_setting('exercise.quiz_results_answers_report'),
     false
 );
 $pageContent .= ob_get_contents();
@@ -313,7 +316,7 @@ $statsTeacher = ExerciseLib::displayQuestionListByAttempt(
     false,
     $remainingMessage,
     $allowSignature,
-    ('true' === api_get_setting('exercise.quiz_results_answers_report')),
+    'true' === api_get_setting('exercise.quiz_results_answers_report'),
     false
 );
 ob_end_clean();
@@ -348,11 +351,11 @@ $courseCodeForLtiScore = $courseInfo['code'] ?? api_get_course_id();
 
 if ('' !== $ltiLaunchId && $exeId > 0 && !empty($courseCodeForLtiScore)) {
     $scoreUrl = api_get_path(WEB_PLUGIN_PATH).'LtiProvider/tool/api/score.php?'.http_build_query([
-            'lti_launch_id' => $ltiLaunchId,
-            'lti_tool' => 'quiz',
-            'lti_result_id' => $exeId,
-            'cidReq' => $courseCodeForLtiScore,
-        ]);
+        'lti_launch_id' => $ltiLaunchId,
+        'lti_tool' => 'quiz',
+        'lti_result_id' => $exeId,
+        'cidReq' => $courseCodeForLtiScore,
+    ]);
 
     $pageBottom .= '<script>
 (function () {
@@ -372,7 +375,7 @@ if ('' !== $ltiLaunchId && $exeId > 0 && !empty($courseCodeForLtiScore)) {
 </script>';
 }
 
-//Unset session for clock time
+// Unset session for clock time
 ExerciseLib::exercise_time_control_delete(
     $objExercise->id,
     $learnpath_id,
@@ -420,7 +423,7 @@ if (!in_array($origin, ['learnpath', 'embeddable', 'mobileapp'])) {
     $courseId = isset($_REQUEST['cid']) ? (int) $_REQUEST['cid'] : api_get_course_int_id();
     Exercise::saveExerciseInLp($learnpath_item_id, $exeId, $courseId);
 
-    //$pageBottom .= '<script type="text/javascript">'.$href.'</script>';
+    // $pageBottom .= '<script type="text/javascript">'.$href.'</script>';
 
     $showFooter = false;
 }
@@ -469,5 +472,5 @@ function showEmbeddableFinishButton()
         ['class' => 'text-center']
     );
 
-    return $js.PHP_EOL.$html;
+    return $js.\PHP_EOL.$html;
 }

--- a/public/main/exercise/exercise_result.php
+++ b/public/main/exercise/exercise_result.php
@@ -432,12 +432,19 @@ $template->assign('page_bottom', $pageBottom);
 $template->assign('allow_signature', $allowSignature);
 $template->assign('exe_id', $exeId);
 $template->assign('actions', $pageActions);
-$template->assign('content', $template->fetch($template->get_template('exercise/result.tpl')));
+$resultContent = $template->fetch($template->get_template('exercise/result.tpl'));
+$template->assign('content', $resultContent);
 
 if (in_array($origin, ['learnpath', 'embeddable'], true)) {
     $template->display_blank_template();
-} else {
+} elseif ('mobileapp' === $origin) {
     $template->display_one_col_template();
+} else {
+    // Standalone exercise results must use the regular legacy page shell.
+    Display::display_header($nameTools);
+    echo $pageActions;
+    echo $resultContent;
+    Display::display_footer();
 }
 
 function showEmbeddableFinishButton()

--- a/public/main/exercise/exercise_submit.php
+++ b/public/main/exercise/exercise_submit.php
@@ -674,25 +674,22 @@ if (!empty($exercise_stat_info['questions_to_check'])) {
 
 $params = "exe_id=$exe_id&exerciseId=$exerciseId&learnpath_id=$learnpath_id"
     . "&learnpath_item_id=$learnpath_item_id&learnpath_item_view_id=$learnpath_item_view_id"
-    . "&origin=".$origin
     . "&page=" . ($page ?? 1)
-    . "&" . api_get_cidreq();
+    . "&" . api_get_cidreq(true, true, $origin);
 
 // Base query strings used by JS navigation (keep LP context on every click).
 $submitBaseQuery = "exe_id=$exe_id&exerciseId=$exerciseId"
     . "&learnpath_id=$learnpath_id"
     . "&learnpath_item_id=$learnpath_item_id"
     . "&learnpath_item_view_id=$learnpath_item_view_id"
-    . "&origin=".$origin
     . "&reminder=$reminder"
-    . "&" . api_get_cidreq();
+    . "&" . api_get_cidreq(true, true, $origin);
 
 $resultBaseQuery = "exe_id=$exe_id"
     . "&learnpath_id=$learnpath_id"
     . "&learnpath_item_id=$learnpath_item_id"
     . "&learnpath_item_view_id=$learnpath_item_view_id"
-    . "&origin=".$origin
-    . "&" . api_get_cidreq();
+    . "&" . api_get_cidreq(true, true, $origin);
 
 
 if (2 === $reminder && empty($myRemindList)) {

--- a/public/main/exercise/exercise_submit.php
+++ b/public/main/exercise/exercise_submit.php
@@ -5,7 +5,6 @@
 use Chamilo\CoreBundle\Component\Exercise\FinalExamAccessRule;
 use Chamilo\CoreBundle\Enums\ActionIcon;
 use Chamilo\CoreBundle\Enums\StateIcon;
-use Chamilo\CoreBundle\Framework\Container;
 use ChamiloSession as Session;
 
 /**
@@ -66,21 +65,25 @@ switch ($glossaryExtraTools) {
     case 'exercise':
         // Only show in standalone exercises, not when launched from LP
         $showGlossary = ('learnpath' !== $origin);
+
         break;
 
     case 'lp':
         // Only show when the exercise is launched from a learning path
         $showGlossary = ('learnpath' === $origin);
+
         break;
 
     case 'exercise_and_lp':
     case 'true':
         // Show in both standalone exercises and LP context
         $showGlossary = true;
+
         break;
 
     default:
         $showGlossary = false;
+
         break;
 }
 if ($showGlossary) {
@@ -222,14 +225,14 @@ $exercise_attempt_table = Database::get_main_table(TABLE_STATISTIC_TRACK_E_ATTEM
 /*  Teacher takes an exam and want to see a preview,
     we delete the objExercise from the session in order to get the latest
     changes in the exercise */
-if (api_is_allowed_to_edit(null, true) &&
-    isset($_GET['preview']) && 1 == $_GET['preview']
+if (api_is_allowed_to_edit(null, true)
+    && isset($_GET['preview']) && 1 == $_GET['preview']
 ) {
     Session::erase('objExercise');
 }
 
 // 1. Loading the $objExercise variable
-/** @var \Exercise $exerciseInSession */
+/** @var Exercise $exerciseInSession */
 $exerciseInSession = Session::read('objExercise');
 if (empty($exerciseInSession) || (!empty($exerciseInSession) && ($exerciseInSession->id != $_GET['exerciseId']))) {
     // Construction of Exercise
@@ -241,8 +244,8 @@ if (empty($exerciseInSession) || (!empty($exerciseInSession) && ($exerciseInSess
     Session::erase('questionList');
 
     // if the specified exercise doesn't exist or is disabled
-    if (!$objExercise->read($exerciseId) ||
-        (!$objExercise->selectStatus() && !$is_allowedToEdit && !in_array($origin, ['learnpath', 'embeddable']))
+    if (!$objExercise->read($exerciseId)
+        || (!$objExercise->selectStatus() && !$is_allowedToEdit && !in_array($origin, ['learnpath', 'embeddable']))
     ) {
         unset($objExercise);
         $error = get_lang('Test not found or not visible');
@@ -253,6 +256,7 @@ if (empty($exerciseInSession) || (!empty($exerciseInSession) && ($exerciseInSess
 } else {
     Session::write('firstTime', false);
 }
+
 // 2. Checking if $objExercise is set.
 /** @var |Exercise $objExercise */
 if (!isset($objExercise) && isset($exerciseInSession)) {
@@ -267,6 +271,7 @@ $exerciseInSession = Session::read('objExercise');
 // 3. $objExercise is not set, then return to the exercise list.
 if (!is_object($objExercise)) {
     header('Location: exercise.php?'.api_get_cidreq());
+
     exit;
 }
 
@@ -468,6 +473,7 @@ if ($objExercise->selectAttempts() > 0) {
 
         echo $attempt_html;
         Display::display_footer();
+
         exit;
     }
 }
@@ -489,8 +495,8 @@ if (ONE_PER_PAGE == $objExercise->type) {
         $q = Question::read($qid);
         if (
             $q
-            && $q->type !== PAGE_BREAK
-            && $q->type !== MEDIA_QUESTION
+            && PAGE_BREAK !== $q->type
+            && MEDIA_QUESTION !== $q->type
         ) {
             $filtered[] = $qid;
         }
@@ -498,7 +504,7 @@ if (ONE_PER_PAGE == $objExercise->type) {
     $questionListUncompressed = $filtered;
     Session::write('question_list_uncompressed', $questionListUncompressed);
 
-    if (Session::read('questionList') !== null) {
+    if (null !== Session::read('questionList')) {
         Session::write('questionList', $filtered);
     }
 }
@@ -515,7 +521,7 @@ if (empty($exercise_stat_info)) {
     $total_weight = 0;
     foreach ($questionList as $question_id) {
         $objQuestionTmp = Question::read((int) $question_id);
-        if ($objQuestionTmp && (int) $objQuestionTmp->type !== MEDIA_QUESTION && (int) $objQuestionTmp->type !== PAGE_BREAK) {
+        if ($objQuestionTmp && MEDIA_QUESTION !== (int) $objQuestionTmp->type && PAGE_BREAK !== (int) $objQuestionTmp->type) {
             $total_weight += (float) $objQuestionTmp->weighting;
         }
     }
@@ -532,7 +538,7 @@ if (empty($exercise_stat_info)) {
             error_log('5.3. $expected_time '.$clock_expired_time->format('Y-m-d H:i:s'));
         }
 
-        //Sessions  that contain the expired time
+        // Sessions  that contain the expired time
         $_SESSION['expired_time'][$current_expired_time_key] = $clock_expired_time->format('Y-m-d H:i:s');
         if ($debug) {
             error_log(
@@ -556,8 +562,8 @@ if (empty($exercise_stat_info)) {
     );
 
     // Send notification at the start
-    if (!api_is_allowed_to_edit(null, true) &&
-        !api_is_excluded_user_type()
+    if (!api_is_allowed_to_edit(null, true)
+        && !api_is_excluded_user_type()
     ) {
         $objExercise->send_mail_notification_for_exam(
             'start',
@@ -635,7 +641,8 @@ if (!isset($questionListInSession)) {
     // Keep order; filter out non-renderable media questions
     $questionList = array_values(array_filter($questionList, function (int $qid) {
         $q = Question::read($qid);
-        return $q && $q->type !== MEDIA_QUESTION;
+
+        return $q && MEDIA_QUESTION !== $q->type;
     }));
 
     // Prepare category grouping when feature is enabled, using the persisted list order.
@@ -650,10 +657,10 @@ if (!isset($questionListInSession)) {
 
     Session::write('questionList', $questionList);
 } else {
-    if (isset($objExercise) && isset($exerciseInSession)) {
+    if (isset($objExercise, $exerciseInSession)) {
         $questionList = Session::read('questionList');
         // Ensure categoryList exists if blocking by category is enabled
-        if ($allowBlockCategory && Session::read('categoryList') === null) {
+        if ($allowBlockCategory && null === Session::read('categoryList')) {
             $categoryList = [];
             foreach ($questionList as $question) {
                 $categoryId = TestCategory::getCategoryForQuestion($question);
@@ -673,30 +680,30 @@ if (!empty($exercise_stat_info['questions_to_check'])) {
 }
 
 $params = "exe_id=$exe_id&exerciseId=$exerciseId&learnpath_id=$learnpath_id"
-    . "&learnpath_item_id=$learnpath_item_id&learnpath_item_view_id=$learnpath_item_view_id"
-    . "&page=" . ($page ?? 1)
-    . "&" . api_get_cidreq(true, true, $origin);
+    ."&learnpath_item_id=$learnpath_item_id&learnpath_item_view_id=$learnpath_item_view_id"
+    .'&page='.($page ?? 1)
+    .'&'.api_get_cidreq(true, true, $origin);
 
 // Base query strings used by JS navigation (keep LP context on every click).
 $submitBaseQuery = "exe_id=$exe_id&exerciseId=$exerciseId"
-    . "&learnpath_id=$learnpath_id"
-    . "&learnpath_item_id=$learnpath_item_id"
-    . "&learnpath_item_view_id=$learnpath_item_view_id"
-    . "&reminder=$reminder"
-    . "&" . api_get_cidreq(true, true, $origin);
+    ."&learnpath_id=$learnpath_id"
+    ."&learnpath_item_id=$learnpath_item_id"
+    ."&learnpath_item_view_id=$learnpath_item_view_id"
+    ."&reminder=$reminder"
+    .'&'.api_get_cidreq(true, true, $origin);
 
 $resultBaseQuery = "exe_id=$exe_id"
-    . "&learnpath_id=$learnpath_id"
-    . "&learnpath_item_id=$learnpath_item_id"
-    . "&learnpath_item_view_id=$learnpath_item_view_id"
-    . "&" . api_get_cidreq(true, true, $origin);
-
+    ."&learnpath_id=$learnpath_id"
+    ."&learnpath_item_id=$learnpath_item_id"
+    ."&learnpath_item_view_id=$learnpath_item_view_id"
+    .'&'.api_get_cidreq(true, true, $origin);
 
 if (2 === $reminder && empty($myRemindList)) {
     if ($debug) {
         error_log('6.2 calling the exercise_reminder.php ');
     }
     header('Location: exercise_reminder.php?'.$params);
+
     exit;
 }
 
@@ -743,7 +750,7 @@ if ($time_control) {
                     api_strtotime($exercise_stat_info['start_date'], 'UTC') + $diff
                 );
             } else {
-                //Recalculate the time control due #2069
+                // Recalculate the time control due #2069
                 $diff = $current_timestamp - api_strtotime($last_attempt_date, 'UTC');
                 $last_attempt_date = api_get_utc_datetime(api_strtotime($last_attempt_date, 'UTC') + $diff);
             }
@@ -792,24 +799,25 @@ $time_left = api_strtotime($clock_expired_time, 'UTC') - time();
  * for more details of how it works see this link : http://eric.garside.name/docs.html?p=epiclock
  */
 if ($time_control) {
-    //Sends the exercise form when the expired time is finished.
+    // Sends the exercise form when the expired time is finished.
     $htmlHeadXtra[] = $objExercise->showTimeControlJS($time_left);
     if (isset($exe_id) && $time_left <= 0) {
-        Database::query("
-        UPDATE " . Database::get_main_table(TABLE_STATISTIC_TRACK_E_EXERCISES) . "
+        Database::query('
+        UPDATE '.Database::get_main_table(TABLE_STATISTIC_TRACK_E_EXERCISES)."
         SET status = 'completed',
-            exe_date = FROM_UNIXTIME(LEAST(UNIX_TIMESTAMP('" . Database::escape_string($clock_expired_time) . "'), UNIX_TIMESTAMP()))
-        WHERE exe_id = " . (int) $exe_id . "
+            exe_date = FROM_UNIXTIME(LEAST(UNIX_TIMESTAMP('".Database::escape_string($clock_expired_time)."'), UNIX_TIMESTAMP()))
+        WHERE exe_id = ".(int) $exe_id."
           AND status = 'incomplete'
     ");
 
         $resultUrl = 'exercise_result.php?'.$resultBaseQuery;
-        header('Location: ' . $resultUrl);
+        header('Location: '.$resultUrl);
+
         exit;
     }
 }
 
-//in LP's is enabled the "remember question" feature?
+// in LP's is enabled the "remember question" feature?
 // Do not rely on random flags; always prefer persisted data_tracking when available
 if (!isset($_SESSION['questionList'])) {
     if (!empty($exercise_stat_info['data_tracking'])) {
@@ -821,11 +829,12 @@ if (!isset($_SESSION['questionList'])) {
     // Keep order; filter out non-renderable media questions
     $questionList = array_values(array_filter($questionList, function (int $qid) {
         $q = Question::read($qid);
-        return $q && $q->type !== MEDIA_QUESTION;
+
+        return $q && MEDIA_QUESTION !== $q->type;
     }));
     Session::write('questionList', $questionList);
 } else {
-    if (isset($objExercise) && isset($_SESSION['objExercise'])) {
+    if (isset($objExercise, $_SESSION['objExercise'])) {
         $questionList = Session::read('questionList');
     }
 }
@@ -833,11 +842,11 @@ if (!isset($_SESSION['questionList'])) {
 // Remove any leading page breaks
 while (count($questionList) > 0) {
     // reset() moves the internal pointer to the first element…
-    $firstId  = reset($questionList);
+    $firstId = reset($questionList);
     // …key() returns its key, so we can unset by that key
     $firstKey = key($questionList);
-    $q        = Question::read((int) $firstId);
-    if ($q && $q->type === PAGE_BREAK) {
+    $q = Question::read((int) $firstId);
+    if ($q && PAGE_BREAK === $q->type) {
         unset($questionList[$firstKey]);
     } else {
         // stop once the first element is not a page break
@@ -848,10 +857,10 @@ while (count($questionList) > 0) {
 // Remove any trailing page breaks
 while (count($questionList) > 0) {
     // end() moves the internal pointer to the last element
-    $lastId  = end($questionList);
+    $lastId = end($questionList);
     $lastKey = key($questionList);
-    $q       = Question::read((int) $lastId);
-    if ($q && $q->type === PAGE_BREAK) {
+    $q = Question::read((int) $lastId);
+    if ($q && PAGE_BREAK === $q->type) {
         unset($questionList[$lastKey]);
     } else {
         // stop once the last element is not a page break
@@ -860,9 +869,10 @@ while (count($questionList) > 0) {
 }
 
 $hasMediaWithChildren = false;
-$mediaQids = array_filter($objExercise->getQuestionOrderedList(), function(int $qid) {
+$mediaQids = array_filter($objExercise->getQuestionOrderedList(), function (int $qid) {
     $q = Question::read($qid);
-    return $q && $q->type === MEDIA_QUESTION;
+
+    return $q && MEDIA_QUESTION === $q->type;
 });
 
 if (!empty($mediaQids)) {
@@ -870,6 +880,7 @@ if (!empty($mediaQids)) {
         $q = Question::read($qid);
         if ($q && in_array($q->parent_id, $mediaQids, true)) {
             $hasMediaWithChildren = true;
+
             break;
         }
     }
@@ -881,9 +892,10 @@ if ($forceGrouped) {
 }
 
 if (ALL_ON_ONE_PAGE === $objExercise->type || $forceGrouped) {
-    $flat = array_filter($questionList, function(int $qid) {
+    $flat = array_filter($questionList, function (int $qid) {
         $q = Question::read($qid);
-        return $q && $q->type !== MEDIA_QUESTION;
+
+        return $q && MEDIA_QUESTION !== $q->type;
     });
 
     if ($hasMediaWithChildren) {
@@ -903,25 +915,25 @@ if (ALL_ON_ONE_PAGE === $objExercise->type || $forceGrouped) {
             }
         }
 
-        $totalPages   = count($pages);
-        $page         = min(max(1, $page), $totalPages);
+        $totalPages = count($pages);
+        $page = min(max(1, $page), $totalPages);
         $questionList = $pages[$page - 1]['questions'];
         $currentBreakId = null;
     } else {
-        $pages    = [[]];
+        $pages = [[]];
         $breakIds = [null];
         foreach ($flat as $qid) {
             $q = Question::read($qid);
-            if ($q->type === PAGE_BREAK) {
-                $pages[]    = [];
+            if (PAGE_BREAK === $q->type) {
+                $pages[] = [];
                 $breakIds[] = $qid;
             } else {
                 $pages[count($pages) - 1][] = $qid;
             }
         }
-        $totalPages    = count($pages);
-        $page          = min(max(1, $page), $totalPages);
-        $questionList  = $pages[$page - 1];
+        $totalPages = count($pages);
+        $page = min(max(1, $page), $totalPages);
+        $questionList = $pages[$page - 1];
         $currentBreakId = ($page > 1 ? $breakIds[$page - 1] : null);
     }
 
@@ -937,15 +949,14 @@ if (ALL_ON_ONE_PAGE === $objExercise->type || $forceGrouped) {
 }
 
 $isLastQuestionInCategory = 0;
-if ($allowBlockCategory &&
-    ONE_PER_PAGE == $objExercise->type &&
-    EX_Q_SELECTION_CATEGORIES_ORDERED_QUESTIONS_RANDOM == $selectionType
+if ($allowBlockCategory
+    && ONE_PER_PAGE == $objExercise->type
+    && EX_Q_SELECTION_CATEGORIES_ORDERED_QUESTIONS_RANDOM == $selectionType
 ) {
     // Check current attempt.
     $currentAttempt = Event::get_exercise_results_by_attempt($exe_id, 'incomplete');
     $answeredQuestions = [];
-    if (!empty($currentAttempt) && isset($currentAttempt[$exe_id]) &&
-        isset($currentAttempt[$exe_id]['question_list'])
+    if (!empty($currentAttempt) && isset($currentAttempt[$exe_id], $currentAttempt[$exe_id]['question_list'])
     ) {
         $answeredQuestions = array_keys($currentAttempt[$exe_id]['question_list']);
     }
@@ -957,6 +968,7 @@ if ($allowBlockCategory &&
         foreach ($categoryQuestionList as $questionInCategoryId) {
             if (in_array($questionInCategoryId, $answeredQuestions)) {
                 $answered++;
+
                 break;
             }
         }
@@ -976,6 +988,7 @@ if ($allowBlockCategory &&
         // if it is not the right question, goes to the next loop iteration
         if ((int) $current_question === $count) {
             $questionCheck = Question::read($questionId);
+
             break;
         }
         $count++;
@@ -1056,7 +1069,7 @@ if ($formSent && isset($_POST)) {
         $exerciseResultCoordinates = [];
     }
 
-    //Only for hotspot
+    // Only for hotspot
     if (!isset($choice) && isset($_REQUEST['hidden_hotspot_id'])) {
         $hotspot_id = (int) $_REQUEST['hidden_hotspot_id'];
         $choice = [$hotspot_id => ''];
@@ -1128,7 +1141,7 @@ if ($formSent && isset($_POST)) {
                 if ($debug) {
                     error_log('10. Exercise ALL_ON_ONE_PAGE -> Redirecting to exercise_result.php');
                 }
-                //We check if the user attempts before sending to the exercise_result.php
+                // We check if the user attempts before sending to the exercise_result.php
                 if ($objExercise->selectAttempts() > 0) {
                     $attempt_count = Event::get_attempt_count(
                         api_get_user_id(),
@@ -1144,8 +1157,8 @@ if ($formSent && isset($_POST)) {
                             false
                         );
                         if (!in_array($origin, ['learnpath', 'embeddable'])) {
-                            //so we are not in learnpath tool
-                            echo '</div>'; //End glossary div
+                            // so we are not in learnpath tool
+                            echo '</div>'; // End glossary div
                             Display::display_footer();
                         } else {
                             echo '</body></html>';
@@ -1159,33 +1172,34 @@ if ($formSent && isset($_POST)) {
                     : 'exercise_result.php?'.$resultBaseQuery;
 
                 header('Location: '.$endUrl);
-                exit;
-            } else {
-                if ($debug) {
-                    error_log('10. Redirecting to exercise_result.php');
-                }
-                header('Location: exercise_result.php?'.$resultBaseQuery);
+
                 exit;
             }
-        } else {
             if ($debug) {
-                error_log('10. Redirecting to exercise_submit.php');
+                error_log('10. Redirecting to exercise_result.php');
             }
-            header('Location: exercise_submit.php?'.$submitBaseQuery);
+            header('Location: exercise_result.php?'.$resultBaseQuery);
+
             exit;
         }
+        if ($debug) {
+            error_log('10. Redirecting to exercise_submit.php');
+        }
+        header('Location: exercise_submit.php?'.$submitBaseQuery);
+
+        exit;
     }
     if ($debug) {
         error_log('11. $formSent was set - end');
     }
 }
 
-$reqGetNum  = isset($_GET['num'])  ? (int) $_GET['num']  : null;
+$reqGetNum = isset($_GET['num']) ? (int) $_GET['num'] : null;
 $reqPostNum = isset($_POST['num']) ? (int) $_POST['num'] : null;
 
-if ($_SERVER['REQUEST_METHOD'] === 'POST' && $reqPostNum !== null) {
+if ('POST' === $_SERVER['REQUEST_METHOD'] && null !== $reqPostNum) {
     $current_question = max(1, $reqPostNum + 1);
-} elseif ($reqGetNum !== null) {
+} elseif (null !== $reqGetNum) {
     $current_question = max(1, $reqGetNum);
 } else {
     $current_question = 1;
@@ -1194,7 +1208,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && $reqPostNum !== null) {
         // Resume position using the persisted questionList order
         // Using DB-backed order avoids inconsistencies when sessions expire.
         $idx = array_search((int) $latestQuestionId, $questionList ?? [], true);
-        if ($idx === false) {
+        if (false === $idx) {
             // Fallback to legacy computation if not found in current in-memory list
             $pos = (int) $objExercise->getPositionInCompressedQuestionList($latestQuestionId);
             $current_question = max(1, $pos + 1);
@@ -1205,8 +1219,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && $reqPostNum !== null) {
 }
 
 $question_count = !empty($questionList) ? count($questionList) : 0;
-if ($_SERVER['REQUEST_METHOD'] === 'GET'
-    && $reqGetNum !== null
+if ('GET' === $_SERVER['REQUEST_METHOD']
+    && null !== $reqGetNum
     && $question_count > 0
     && $reqGetNum > $question_count
 ) {
@@ -1216,6 +1230,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET'
     } else {
         header('Location: exercise_result.php?'.$resultBaseQuery);
     }
+
     exit;
 }
 
@@ -1224,8 +1239,8 @@ if ($question_count > 0 && $current_question > $question_count) {
 }
 
 if (0 != $question_count) {
-    if (ALL_ON_ONE_PAGE == $objExercise->type ||
-        $current_question > $question_count
+    if (ALL_ON_ONE_PAGE == $objExercise->type
+        || $current_question > $question_count
     ) {
         if (api_is_allowed_to_session_edit()) {
             // goes to the script that will show the result of the exercise
@@ -1250,40 +1265,44 @@ if (0 != $question_count) {
                             false
                         );
                         if (!in_array($origin, ['learnpath', 'embeddable'])) {
-                            //so we are not in learnpath tool
-                            echo '</div>'; //End glossary div
+                            // so we are not in learnpath tool
+                            echo '</div>'; // End glossary div
                             Display::display_footer();
                         } else {
                             echo '</body></html>';
                         }
+
                         exit;
                     }
                 }
             } else {
                 if ($objExercise->review_answers) {
                     header('Location: exercise_reminder.php?'.$params);
-                    exit;
-                } else {
-                    $certaintyQuestionPresent = false;
-                    foreach ($questionList as $questionId) {
-                        $question = Question::read($questionId);
-                        if (MULTIPLE_ANSWER_TRUE_FALSE_DEGREE_CERTAINTY == $question->type) {
-                            $certaintyQuestionPresent = true;
 
-                            break;
-                        }
-                    }
-                    if ($certaintyQuestionPresent) {
-                        // Certainty grade question
-                        // We send an email to the student before redirection to the result page
-                        MultipleAnswerTrueFalseDegreeCertainty::sendQuestionCertaintyNotification(
-                            $user_id, $objExercise, $exe_id
-                        );
-                    }
-
-                    header('Location: exercise_result.php?'.$resultBaseQuery);
                     exit;
                 }
+                $certaintyQuestionPresent = false;
+                foreach ($questionList as $questionId) {
+                    $question = Question::read($questionId);
+                    if (MULTIPLE_ANSWER_TRUE_FALSE_DEGREE_CERTAINTY == $question->type) {
+                        $certaintyQuestionPresent = true;
+
+                        break;
+                    }
+                }
+                if ($certaintyQuestionPresent) {
+                    // Certainty grade question
+                    // We send an email to the student before redirection to the result page
+                    MultipleAnswerTrueFalseDegreeCertainty::sendQuestionCertaintyNotification(
+                        $user_id,
+                        $objExercise,
+                        $exe_id
+                    );
+                }
+
+                header('Location: exercise_result.php?'.$resultBaseQuery);
+
+                exit;
             }
         }
     }
@@ -1342,7 +1361,7 @@ if ($allowTimePerQuestion && ONE_PER_PAGE == $objExercise->type) {
             api_location($nextQuestionUrl);
         }
 
-        $seconds = $seconds - $timeSpent;
+        $seconds -= $timeSpent;
         $questionTimeCondition = "
                 var timer = new easytimer.Timer();
                 timer.start({countdown: true, startValues: {seconds: $seconds}});
@@ -1401,8 +1420,9 @@ $is_visible_return = $objExercise->is_visible(
 if (false == $is_visible_return['value']) {
     echo $is_visible_return['message'];
     if (!in_array($origin, ['learnpath', 'embeddable'])) {
-        Display :: display_footer();
+        Display::display_footer();
     }
+
     exit;
 }
 
@@ -1410,6 +1430,7 @@ if (!api_is_allowed_to_session_edit()) {
     if (!in_array($origin, ['learnpath', 'embeddable'])) {
         Display::display_footer();
     }
+
     exit;
 }
 
@@ -1445,18 +1466,18 @@ if ($limit_time_exists) {
             if (!in_array($origin, ['learnpath', 'embeddable'])) {
                 Display::display_footer();
             }
+
             exit;
-        } else {
-            $message_warning = $permission_to_start ? get_lang('Time limit reached') : get_lang('The trainer did not allow the test to start yet');
-            echo Display::return_message(
-                sprintf(
-                    $message_warning,
-                    $exercise_title,
-                    $objExercise->selectAttempts()
-                ),
-                'warning'
-            );
         }
+        $message_warning = $permission_to_start ? get_lang('Time limit reached') : get_lang('The trainer did not allow the test to start yet');
+        echo Display::return_message(
+            sprintf(
+                $message_warning,
+                $exercise_title,
+                $objExercise->selectAttempts()
+            ),
+            'warning'
+        );
     }
 }
 
@@ -1503,7 +1524,7 @@ if (!in_array($origin, ['learnpath', 'embeddable'])) {
 if (2 == $reminder) {
     $data_tracking = $exercise_stat_info['data_tracking'];
     $data_tracking = explode(',', $data_tracking);
-    $current_question = 1; //set by default the 1st question
+    $current_question = 1; // set by default the 1st question
 
     if (!empty($myRemindList)) {
         // Checking which questions we are going to call from the remind list
@@ -1546,6 +1567,7 @@ if (2 == $reminder) {
                 error_log('. redirecting to exercise_reminder.php ');
             }
             header("Location: exercise_reminder.php?$params");
+
             exit;
         }
     }
@@ -1554,6 +1576,7 @@ if (2 == $reminder) {
 if (!empty($error)) {
     Display::addFlash(Display::return_message($error, 'error', false));
     api_not_allowed();
+
     exit;
 }
 
@@ -1584,24 +1607,22 @@ if (!empty($questionList)) {
             // if it is not the right question, goes to the next loop iteration
             if ($current_question != $i) {
                 continue;
-            } else {
-                if (in_array($selectType, [HOT_SPOT, HOT_SPOT_COMBINATION, HOT_SPOT_DELINEATION])) {
-                    $number_of_hotspot_questions++;
-                }
-
-                break;
             }
-        } else {
             if (in_array($selectType, [HOT_SPOT, HOT_SPOT_COMBINATION, HOT_SPOT_DELINEATION])) {
                 $number_of_hotspot_questions++;
             }
+
+            break;
+        }
+        if (in_array($selectType, [HOT_SPOT, HOT_SPOT_COMBINATION, HOT_SPOT_DELINEATION])) {
+            $number_of_hotspot_questions++;
         }
     }
 }
 
-if ($allowBlockCategory &&
-    ONE_PER_PAGE == $objExercise->type &&
-    EX_Q_SELECTION_CATEGORIES_ORDERED_QUESTIONS_RANDOM == $selectionType
+if ($allowBlockCategory
+    && ONE_PER_PAGE == $objExercise->type
+    && EX_Q_SELECTION_CATEGORIES_ORDERED_QUESTIONS_RANDOM == $selectionType
 ) {
     if (0 === $isLastQuestionInCategory && 2 === $reminder) {
         $endReminderValue = false;
@@ -1758,7 +1779,7 @@ echo '<script>
                 var $btn = $(this);
 
                 $(\'button[name="save_question_list"]\').prop(\'disabled\', true);
-                $btn.append(\' ' . addslashes($loading) . '\');
+                $btn.append(\' '.addslashes($loading).'\');
 
                 var listStr = $btn.data(\'list\') || \'\';
                 if (!listStr) {
@@ -2008,12 +2029,12 @@ echo '<script>
     </script>';
 
 echo '<form id="exercise_form" method="post" action="'
-    . api_get_self() . '?' . api_get_cidreq()
-    . '&origin=' . urlencode($origin)
-    . '&page=' . $page
-    . '&reminder=' . $reminder
-    . '&autocomplete=off&exerciseId=' . $exerciseId
-    . '" name="frm_exercise">
+    .api_get_self().'?'.api_get_cidreq()
+    .'&origin='.urlencode($origin)
+    .'&page='.$page
+    .'&reminder='.$reminder
+    .'&autocomplete=off&exerciseId='.$exerciseId
+    .'" name="frm_exercise">
          <input type="hidden" name="formSent" value="1" />
          <input type="hidden" name="exerciseId" value="'.$exerciseId.'" />
          <input type="hidden" name="num" value="'.$current_question.'" id="num_current_id" />
@@ -2033,8 +2054,8 @@ if (isset($exe_id)) {
 }
 
 $remind_list = [];
-if (isset($exercise_stat_info['questions_to_check']) &&
-    !empty($exercise_stat_info['questions_to_check'])
+if (isset($exercise_stat_info['questions_to_check'])
+    && !empty($exercise_stat_info['questions_to_check'])
 ) {
     $remind_list = explode(',', $exercise_stat_info['questions_to_check']);
 }
@@ -2059,28 +2080,28 @@ foreach ($questionList as $questionId) {
             $i++;
 
             continue;
-        } else {
-            if (!in_array($objExercise->getFeedbackType(), [EXERCISE_FEEDBACK_TYPE_DIRECT, EXERCISE_FEEDBACK_TYPE_POPUP])) {
-                // if the user has already answered this question
-                if (isset($exerciseResult[$questionId])) {
-                    // construction of the Question object
-                    $objQuestionTmp = Question::read($questionId);
-                    $questionName = $objQuestionTmp->selectTitle();
-                    // destruction of the Question object
-                    unset($objQuestionTmp);
-                    echo Display::return_message(get_lang('You already answered the question'));
-                    $i++;
+        }
+        if (!in_array($objExercise->getFeedbackType(), [EXERCISE_FEEDBACK_TYPE_DIRECT, EXERCISE_FEEDBACK_TYPE_POPUP])) {
+            // if the user has already answered this question
+            if (isset($exerciseResult[$questionId])) {
+                // construction of the Question object
+                $objQuestionTmp = Question::read($questionId);
+                $questionName = $objQuestionTmp->selectTitle();
+                // destruction of the Question object
+                unset($objQuestionTmp);
+                echo Display::return_message(get_lang('You already answered the question'));
+                $i++;
 
-                    break;
-                }
+                break;
             }
+        }
 
-            if (1 === $exerciseInSession->getPreventBackwards()) {
-                if (isset($attempt_list[$questionId])) {
-                    echo Display::return_message(get_lang('Already answered'));
-                    $i++;
-                    break;
-                }
+        if (1 === $exerciseInSession->getPreventBackwards()) {
+            if (isset($attempt_list[$questionId])) {
+                echo Display::return_message(get_lang('Already answered'));
+                $i++;
+
+                break;
             }
         }
     }
@@ -2090,6 +2111,7 @@ foreach ($questionList as $questionId) {
         $user_choice = $attempt_list[$questionId];
     } elseif ($objExercise->getSaveCorrectAnswers()) {
         $correctAnswers = [];
+
         switch ($objExercise->getSaveCorrectAnswers()) {
             case 1:
                 $correctAnswers = $objExercise->getCorrectAnswersInAllAttempts(
@@ -2098,6 +2120,7 @@ foreach ($questionList as $questionId) {
                 );
 
                 break;
+
             case 2:
                 $correctAnswers = $objExercise->getAnswersInAllAttempts(
                     $learnpath_id,
@@ -2115,8 +2138,8 @@ foreach ($questionList as $questionId) {
 
     $remind_highlight = '';
     // Hides questions when reviewing a ALL_ON_ONE_PAGE exercise see #4542 no_remind_highlight class hide with jquery
-    if (ALL_ON_ONE_PAGE == $objExercise->type &&
-        isset($_GET['reminder']) && 2 == $_GET['reminder']
+    if (ALL_ON_ONE_PAGE == $objExercise->type
+        && isset($_GET['reminder']) && 2 == $_GET['reminder']
     ) {
         $remind_highlight = 'no_remind_highlight';
     }
@@ -2151,10 +2174,10 @@ foreach ($questionList as $questionId) {
     $q = Question::read($questionId);
     $currentParent = $q->parent_id > 0 ? $q->parent_id : null;
     if ($currentParent !== $prevParent) {
-        if ($prevParent !== null) {
+        if (null !== $prevParent) {
             echo "</div>\n";
         }
-        if ($currentParent !== null) {
+        if (null !== $currentParent) {
             echo '<div class="media-group" style="border:1px dashed #aaa; padding:15px; margin:20px 0;">';
             ExerciseLib::showQuestion(
                 $objExercise,
@@ -2171,8 +2194,8 @@ foreach ($questionList as $questionId) {
 
     $showQuestion = true;
     $exerciseResultFromSession = Session::read('exerciseResult');
-    if (EXERCISE_FEEDBACK_TYPE_POPUP === $objExercise->getFeedbackType() &&
-        isset($exerciseResultFromSession[$questionId])
+    if (EXERCISE_FEEDBACK_TYPE_POPUP === $objExercise->getFeedbackType()
+        && isset($exerciseResultFromSession[$questionId])
     ) {
         $showQuestion = false;
     }
@@ -2212,6 +2235,7 @@ foreach ($questionList as $questionId) {
                 );
 
                 break;
+
             case ALL_ON_ONE_PAGE:
                 if (api_is_allowed_to_session_edit()) {
                     $button = [
@@ -2224,10 +2248,10 @@ foreach ($questionList as $questionId) {
                                 'data-question' => $questionId,
                             ]
                         ),
-                        '<span id="save_for_now_' . $questionId . '"></span>&nbsp;',
+                        '<span id="save_for_now_'.$questionId.'"></span>&nbsp;',
                     ];
                     $exerciseActions .= Display::div(
-                        implode(PHP_EOL, $button),
+                        implode(\PHP_EOL, $button),
                         ['class' => 'exercise_save_now_button mb-4']
                     );
                 }
@@ -2269,31 +2293,30 @@ foreach ($questionList as $questionId) {
     }
 }
 
-if ($prevParent !== null) {
+if (null !== $prevParent) {
     echo "</div>\n";
 }
 
-
 if (ALL_ON_ONE_PAGE == $objExercise->type || $forceGrouped) {
-    //$currentPageIds = implode(',', $pages[$page - 1]);
+    // $currentPageIds = implode(',', $pages[$page - 1]);
     $currentPageIds = implode(',', $questionList);
     echo '<div class="exercise_actions exercise-pagination mb-4">';
     if ($page > 1) {
-        $prevUrl = api_get_self() . '?' . $submitBaseQuery . "&page=" . ($page - 1);
+        $prevUrl = api_get_self().'?'.$submitBaseQuery.'&page='.($page - 1);
         echo '<button type="button" class="btn btn--secondary" '
-            . "onclick=\"window.location='$prevUrl'\">"
-            . '‹ ' . get_lang('Previous')
-            . '</button> ';
+            ."onclick=\"window.location='$prevUrl'\">"
+            .'‹ '.get_lang('Previous')
+            .'</button> ';
     }
 
     $label = $page < $totalPages
-        ? get_lang('Next') . ' ›'
+        ? get_lang('Next').' ›'
         : get_lang('End test');
     echo '<button type="button" name="save_question_list" '
-        . 'data-list="' . $currentPageIds . '" '
-        . 'class="btn btn--primary">'
-        . $label
-        . '</button>';
+        .'data-list="'.$currentPageIds.'" '
+        .'class="btn btn--primary">'
+        .$label
+        .'</button>';
 
     echo '</div>';
 }

--- a/src/CoreBundle/AiProvider/AiCourseAnalyzerService.php
+++ b/src/CoreBundle/AiProvider/AiCourseAnalyzerService.php
@@ -118,8 +118,7 @@ final class AiCourseAnalyzerService
         bool $includeStandaloneDocuments = false,
         bool $includeStandaloneExercises = false,
         bool $includeDraftResources = false,
-    ): array
-    {
+    ): array {
         $payload = $this->buildPayload(
             $course,
             $session,
@@ -180,8 +179,7 @@ final class AiCourseAnalyzerService
         bool $includeStandaloneDocuments = false,
         bool $includeStandaloneExercises = false,
         bool $includeDraftResources = false,
-    ): array
-    {
+    ): array {
         $totalCharacters = 0;
         $lessonDocumentIds = [];
         $lessonExerciseIds = [];
@@ -268,8 +266,7 @@ final class AiCourseAnalyzerService
         array &$lessonDocumentIds,
         array &$lessonExerciseIds,
         bool $includeDraftResources,
-    ): array
-    {
+    ): array {
         $qb = $this->entityManager->createQueryBuilder();
         $qb
             ->select('learningPath', 'resourceNode', 'resourceLink')
@@ -384,8 +381,7 @@ final class AiCourseAnalyzerService
         array &$lessonDocumentIds,
         array &$lessonExerciseIds,
         bool $includeDraftResources,
-    ): array
-    {
+    ): array {
         $itemType = strtolower($item->getItemType());
         $resourceReference = $this->resolveLessonItemResourceReference($item);
 
@@ -519,8 +515,7 @@ final class AiCourseAnalyzerService
         Course $course,
         ?Session $session,
         bool $includeDraftResources,
-    ): ?CDocument
-    {
+    ): ?CDocument {
         $documentId = $this->normalizePositiveIntegerReference($reference);
         if (null === $documentId) {
             return null;
@@ -545,8 +540,7 @@ final class AiCourseAnalyzerService
         Course $course,
         ?Session $session,
         bool $includeDraftResources,
-    ): ?CQuiz
-    {
+    ): ?CQuiz {
         $quizId = $this->normalizePositiveIntegerReference($reference);
         if (null === $quizId) {
             return null;
@@ -582,8 +576,7 @@ final class AiCourseAnalyzerService
         Course $course,
         ?Session $session,
         bool $includeDraftResources,
-    ): bool
-    {
+    ): bool {
         return $this->findReviewableResourceLink(
             $resourceNode,
             $course,
@@ -597,8 +590,7 @@ final class AiCourseAnalyzerService
         Course $course,
         ?Session $session,
         bool $includeDraftResources,
-    ): ?ResourceLink
-    {
+    ): ?ResourceLink {
         foreach ($resourceNode->getResourceLinks() as $resourceLink) {
             if (!$resourceLink instanceof ResourceLink) {
                 continue;
@@ -660,8 +652,7 @@ final class AiCourseAnalyzerService
         QueryBuilder $queryBuilder,
         string $resourceLinkAlias,
         bool $includeDraftResources,
-    ): void
-    {
+    ): void {
         if ($includeDraftResources) {
             $queryBuilder
                 ->andWhere($resourceLinkAlias.'.visibility IN (:reviewVisibilities)')
@@ -762,8 +753,7 @@ final class AiCourseAnalyzerService
         array $excludedDocumentIds,
         int &$totalCharacters,
         bool $includeDraftResources,
-    ): array
-    {
+    ): array {
         $qb = $this->entityManager->createQueryBuilder();
         $qb
             ->select('document', 'resourceNode', 'resourceLink', 'resourceFile')
@@ -822,8 +812,7 @@ final class AiCourseAnalyzerService
         ?Session $session,
         array $excludedExerciseIds,
         bool $includeDraftResources,
-    ): array
-    {
+    ): array {
         $qb = $this->entityManager->createQueryBuilder();
         $qb
             ->select('quiz', 'resourceNode', 'resourceLink', 'quizQuestionRel', 'question', 'answer')
@@ -1042,8 +1031,7 @@ final class AiCourseAnalyzerService
         ?Course $course = null,
         ?Session $session = null,
         bool $includeDraftResources = false,
-    ): array
-    {
+    ): array {
         $resourceNode = $document->getResourceNode();
         $resourceLink = $resourceNode instanceof ResourceNode && $course instanceof Course
             ? $this->findReviewableResourceLink($resourceNode, $course, $session, $includeDraftResources)
@@ -1126,8 +1114,7 @@ final class AiCourseAnalyzerService
         ?Course $course = null,
         ?Session $session = null,
         bool $includeDraftResources = false,
-    ): array
-    {
+    ): array {
         $questions = [];
 
         foreach ($quiz->getQuestions() as $quizQuestionRel) {
@@ -1862,8 +1849,8 @@ final class AiCourseAnalyzerService
     private function decodeStructuredResponse(string $rawResponse): ?array
     {
         $response = trim($rawResponse);
-        $response = preg_replace('/^```(?:json)?\\s*/i', '', $response) ?? $response;
-        $response = preg_replace('/\\s*```$/', '', $response) ?? $response;
+        $response = preg_replace('/^```(?:json)?\s*/i', '', $response) ?? $response;
+        $response = preg_replace('/\s*```$/', '', $response) ?? $response;
 
         $start = strpos($response, '{');
         $end = strrpos($response, '}');

--- a/src/CoreBundle/AiProvider/AiCourseAnalyzerService.php
+++ b/src/CoreBundle/AiProvider/AiCourseAnalyzerService.php
@@ -17,9 +17,13 @@ use Chamilo\CourseBundle\Entity\CLpItem;
 use Chamilo\CourseBundle\Entity\CQuiz;
 use Chamilo\CourseBundle\Entity\CQuizAnswer;
 use Chamilo\CourseBundle\Entity\CQuizQuestion;
+use Chamilo\CourseBundle\Entity\CStudentPublication;
+use Chamilo\CourseBundle\Entity\CSurvey;
+use Chamilo\CourseBundle\Repository\CDocumentRepository;
 use Doctrine\DBAL\ArrayParameterType;
 use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\QueryBuilder;
 use Symfony\Component\HttpFoundation\File\File;
 use Throwable;
 use ZipArchive;
@@ -38,11 +42,17 @@ final class AiCourseAnalyzerService
     private const MAX_ITEMS_PER_LESSON = 120;
     private const MAX_STANDALONE_DOCUMENTS = 25;
     private const MAX_STANDALONE_EXERCISES = 20;
+    private const MAX_ASSIGNMENTS = 20;
+    private const MAX_SURVEYS = 15;
+    private const MAX_SURVEY_QUESTIONS = 50;
+    private const MAX_SURVEY_OPTIONS = 20;
     private const MAX_EXERCISES = 20;
     private const MAX_QUESTIONS_PER_EXERCISE = 80;
     private const MAX_ANSWERS_PER_QUESTION = 20;
     private const MAX_CHARS_PER_DOCUMENT = 12000;
     private const MAX_TOTAL_TEXT_CHARS = 90000;
+    private const MAX_ANALYSIS_OUTPUT_TOKENS = 12000;
+    private const MAX_COMPACT_OUTPUT_TOKENS = 7000;
 
     /**
      * @var string[]
@@ -94,6 +104,7 @@ final class AiCourseAnalyzerService
     public function __construct(
         private readonly EntityManagerInterface $entityManager,
         private readonly AiChatCompletionClientInterface $chatCompletionClient,
+        private readonly CDocumentRepository $documentRepository,
     ) {}
 
     /**
@@ -106,23 +117,44 @@ final class AiCourseAnalyzerService
         string $provider,
         bool $includeStandaloneDocuments = false,
         bool $includeStandaloneExercises = false,
-    ): array {
+        bool $includeDraftResources = false,
+    ): array
+    {
         $payload = $this->buildPayload(
             $course,
             $session,
             $teacherPrompt,
             $includeStandaloneDocuments,
             $includeStandaloneExercises,
+            $includeDraftResources,
         );
-        $messages = $this->buildMessages($payload);
-
-        $rawResponse = $this->chatCompletionClient->chat($provider, $messages, [
-            'temperature' => 0.2,
-            'max_tokens' => 6000,
-            'throw_on_error' => true,
-        ]);
+        $messages = $this->buildMessages($payload, false);
+        $rawResponse = $this->requestStructuredAnalysis(
+            $provider,
+            $messages,
+            self::MAX_ANALYSIS_OUTPUT_TOKENS,
+        );
 
         $structuredResponse = $this->decodeStructuredResponse($rawResponse);
+        $responseRepaired = false;
+        $responseMode = 'full';
+
+        if (!\is_array($structuredResponse)) {
+            /*
+             * A long per-resource analysis can reach a provider output limit.
+             * Retry once with a compact contract instead of exposing a
+             * truncated JSON response to the MCP client.
+             */
+            $responseRepaired = true;
+            $responseMode = 'compact_retry';
+            $rawResponse = $this->requestStructuredAnalysis(
+                $provider,
+                $this->buildMessages($payload, true),
+                self::MAX_COMPACT_OUTPUT_TOKENS,
+            );
+            $structuredResponse = $this->decodeStructuredResponse($rawResponse);
+        }
+
         if (\is_array($structuredResponse)) {
             $structuredResponse = $this->normalizeStructuredResponse($payload, $structuredResponse);
         }
@@ -131,6 +163,10 @@ final class AiCourseAnalyzerService
             'payload' => $payload,
             'rawResponse' => $rawResponse,
             'structuredResponse' => $structuredResponse,
+            'responseRepaired' => $responseRepaired,
+            'responseMode' => $responseMode,
+            'rawResponseLength' => mb_strlen($rawResponse),
+            'payloadStats' => $this->buildPayloadStats($payload),
         ];
     }
 
@@ -143,7 +179,9 @@ final class AiCourseAnalyzerService
         string $teacherPrompt,
         bool $includeStandaloneDocuments = false,
         bool $includeStandaloneExercises = false,
-    ): array {
+        bool $includeDraftResources = false,
+    ): array
+    {
         $totalCharacters = 0;
         $lessonDocumentIds = [];
         $lessonExerciseIds = [];
@@ -153,13 +191,24 @@ final class AiCourseAnalyzerService
             $totalCharacters,
             $lessonDocumentIds,
             $lessonExerciseIds,
+            $includeDraftResources,
         );
         $standaloneDocuments = $includeStandaloneDocuments
-            ? $this->collectVisibleStandaloneDocuments($course, $session, $lessonDocumentIds, $totalCharacters)
+            ? $this->collectVisibleStandaloneDocuments($course, $session, $lessonDocumentIds, $totalCharacters, $includeDraftResources)
             : [];
         $standaloneExercises = $includeStandaloneExercises
-            ? $this->collectVisibleStandaloneExercises($course, $session, $lessonExerciseIds)
+            ? $this->collectVisibleStandaloneExercises($course, $session, $lessonExerciseIds, $includeDraftResources)
             : [];
+        $assignments = $this->collectReviewAssignments(
+            $course,
+            $session,
+            $includeDraftResources,
+        );
+        $surveys = $this->collectReviewSurveys(
+            $course,
+            $session,
+            $includeDraftResources,
+        );
 
         return [
             'course' => [
@@ -170,17 +219,30 @@ final class AiCourseAnalyzerService
             ],
             'teacherPrompt' => trim($teacherPrompt),
             'analysisScope' => [
-                'defaultScope' => 'visible_lessons',
+                'defaultScope' => $includeDraftResources
+                    ? 'teacher_course_resources_including_drafts'
+                    : 'published_lessons',
                 'includeStandaloneDocuments' => $includeStandaloneDocuments,
                 'includeStandaloneExercises' => $includeStandaloneExercises,
-                'standaloneDocumentsDescription' => 'Standalone documents are visible course documents that were not referenced by any analyzed lesson item.',
-                'standaloneExercisesDescription' => 'Standalone exercises are visible course tests that were not referenced by any analyzed lesson item.',
+                'includeDraftResources' => $includeDraftResources,
+                'resourceVisibilityDescription' => $includeDraftResources
+                    ? 'Published, pending and draft resources are included for teacher review. Their visibility is reported in each payload item.'
+                    : 'Only published resources are included.',
+                'standaloneDocumentsDescription' => $includeDraftResources
+                    ? 'Standalone documents include teacher-reviewable published, pending and draft course documents that were not referenced by any analyzed lesson item.'
+                    : 'Standalone documents are published course documents that were not referenced by any analyzed lesson item.',
+                'standaloneExercisesDescription' => $includeDraftResources
+                    ? 'Standalone exercises include teacher-reviewable published, pending and draft course tests that were not referenced by any analyzed lesson item.'
+                    : 'Standalone exercises are published course tests that were not referenced by any analyzed lesson item.',
             ],
             'limits' => [
                 'maxLessons' => self::MAX_LESSONS,
                 'maxItemsPerLesson' => self::MAX_ITEMS_PER_LESSON,
                 'maxStandaloneDocuments' => self::MAX_STANDALONE_DOCUMENTS,
                 'maxStandaloneExercises' => self::MAX_STANDALONE_EXERCISES,
+                'maxAssignments' => self::MAX_ASSIGNMENTS,
+                'maxSurveys' => self::MAX_SURVEYS,
+                'maxSurveyQuestions' => self::MAX_SURVEY_QUESTIONS,
                 'maxExercises' => self::MAX_EXERCISES,
                 'maxQuestionsPerExercise' => self::MAX_QUESTIONS_PER_EXERCISE,
                 'maxCharactersPerDocument' => self::MAX_CHARS_PER_DOCUMENT,
@@ -189,6 +251,8 @@ final class AiCourseAnalyzerService
             'lessons' => $lessons,
             'standaloneDocuments' => $standaloneDocuments,
             'standaloneExercises' => $standaloneExercises,
+            'assignments' => $assignments,
+            'surveys' => $surveys,
         ];
     }
 
@@ -203,7 +267,9 @@ final class AiCourseAnalyzerService
         int &$totalCharacters,
         array &$lessonDocumentIds,
         array &$lessonExerciseIds,
-    ): array {
+        bool $includeDraftResources,
+    ): array
+    {
         $qb = $this->entityManager->createQueryBuilder();
         $qb
             ->select('learningPath', 'resourceNode', 'resourceLink')
@@ -211,12 +277,16 @@ final class AiCourseAnalyzerService
             ->innerJoin('learningPath.resourceNode', 'resourceNode')
             ->innerJoin('resourceNode.resourceLinks', 'resourceLink')
             ->andWhere('resourceLink.course = :course')
-            ->andWhere('resourceLink.visibility = :visibility')
             ->setParameter('course', (int) $course->getId())
-            ->setParameter('visibility', ResourceLink::VISIBILITY_PUBLISHED, Types::INTEGER)
             ->setMaxResults(self::MAX_LESSONS)
             ->orderBy('resourceLink.displayOrder', 'ASC')
         ;
+
+        $this->applyReviewVisibilityFilter(
+            $qb,
+            'resourceLink',
+            $includeDraftResources,
+        );
 
         if ($session instanceof Session) {
             $qb
@@ -249,11 +319,15 @@ final class AiCourseAnalyzerService
                     $totalCharacters,
                     $lessonDocumentIds,
                     $lessonExerciseIds,
+                    $includeDraftResources,
                 );
                 $itemCount++;
             }
 
             $resourceNode = $learningPath->getResourceNode();
+            $resourceLink = $resourceNode instanceof ResourceNode
+                ? $this->findReviewableResourceLink($resourceNode, $course, $session, $includeDraftResources)
+                : null;
 
             $lessons[] = [
                 'id' => $learningPath->getIid(),
@@ -263,6 +337,7 @@ final class AiCourseAnalyzerService
                 'resourceNodeId' => $resourceNode instanceof ResourceNode ? $resourceNode->getId() : null,
                 'resourcePath' => $resourceNode instanceof ResourceNode ? $resourceNode->getPathForDisplay() : null,
                 'editUrl' => $this->buildLearningPathEditUrl($learningPath, $course, $session),
+                'visibility' => $this->buildVisibilityPayload($resourceLink),
                 'items' => $lessonItems,
             ];
         }
@@ -308,8 +383,12 @@ final class AiCourseAnalyzerService
         int &$totalCharacters,
         array &$lessonDocumentIds,
         array &$lessonExerciseIds,
-    ): array {
+        bool $includeDraftResources,
+    ): array
+    {
         $itemType = strtolower($item->getItemType());
+        $resourceReference = $this->resolveLessonItemResourceReference($item);
+
         $payload = [
             'id' => $item->getIid(),
             'title' => $item->getTitle(),
@@ -318,6 +397,8 @@ final class AiCourseAnalyzerService
             'ref' => $item->getRef(),
             'description' => $this->cleanText((string) $item->getDescription()),
             'path' => $item->getPath(),
+            'resourceReferenceId' => $resourceReference['id'],
+            'resourceReferenceSource' => $resourceReference['source'],
             'position' => $item->getDisplayOrder(),
             'level' => $item->getLvl(),
             'parentItemId' => $item->getParentItemId(),
@@ -332,32 +413,42 @@ final class AiCourseAnalyzerService
         ];
 
         if (\in_array($itemType, self::DOCUMENT_LIKE_ITEM_TYPES, true)) {
-            $document = $this->findVisibleDocumentByReference($item->getRef(), $course, $session);
+            $document = $this->findVisibleDocumentByReference(
+                $resourceReference['value'],
+                $course,
+                $session,
+                $includeDraftResources,
+            );
             if (!$document instanceof CDocument) {
-                $payload['notice'] = 'The referenced lesson document is not visible or no longer available.';
+                $payload['notice'] = 'The referenced lesson document is not available in the selected teacher-review scope.';
 
                 return $payload;
             }
 
             $documentId = (int) $document->getIid();
             $lessonDocumentIds[$documentId] = $documentId;
-            $payload['document'] = $this->buildDocumentPayload($document, $totalCharacters, $course, $session);
+            $payload['document'] = $this->buildDocumentPayload($document, $totalCharacters, $course, $session, $includeDraftResources);
             $payload['contentIncluded'] = true === ($payload['document']['textIncluded'] ?? false);
 
             return $payload;
         }
 
         if (\in_array($itemType, self::EXERCISE_LIKE_ITEM_TYPES, true)) {
-            $quiz = $this->findVisibleQuizByReference($item->getRef(), $course, $session);
+            $quiz = $this->findVisibleQuizByReference(
+                $resourceReference['value'],
+                $course,
+                $session,
+                $includeDraftResources,
+            );
             if (!$quiz instanceof CQuiz) {
-                $payload['notice'] = 'The referenced lesson exercise is not visible or no longer available.';
+                $payload['notice'] = 'The referenced lesson exercise is not available in the selected teacher-review scope.';
 
                 return $payload;
             }
 
             $exerciseId = (int) $quiz->getIid();
             $lessonExerciseIds[$exerciseId] = $exerciseId;
-            $payload['exercise'] = $this->buildExercisePayload($quiz, $course, $session);
+            $payload['exercise'] = $this->buildExercisePayload($quiz, $course, $session, $includeDraftResources);
             $payload['contentIncluded'] = true;
 
             return $payload;
@@ -385,7 +476,50 @@ final class AiCourseAnalyzerService
         return 'metadata';
     }
 
-    private function findVisibleDocumentByReference(string $reference, Course $course, ?Session $session): ?CDocument
+    /**
+     * Legacy learning-path items do not consistently use the `ref` column.
+     * Items created through learnpath::add_item() can keep `ref` empty and
+     * store the numeric document or quiz identifier in `path`.
+     *
+     * Prefer a valid numeric `ref` and use a numeric `path` only as the
+     * compatibility fallback. Non-numeric paths remain metadata and cannot be
+     * mistaken for local resource identifiers.
+     *
+     * @return array{id:int|null,value:string,source:string|null}
+     */
+    private function resolveLessonItemResourceReference(CLpItem $item): array
+    {
+        $references = [
+            'ref' => trim((string) $item->getRef()),
+            'path' => trim((string) $item->getPath()),
+        ];
+
+        foreach ($references as $source => $reference) {
+            $resourceId = $this->normalizePositiveIntegerReference($reference);
+            if (null === $resourceId) {
+                continue;
+            }
+
+            return [
+                'id' => $resourceId,
+                'value' => (string) $resourceId,
+                'source' => $source,
+            ];
+        }
+
+        return [
+            'id' => null,
+            'value' => '',
+            'source' => null,
+        ];
+    }
+
+    private function findVisibleDocumentByReference(
+        string $reference,
+        Course $course,
+        ?Session $session,
+        bool $includeDraftResources,
+    ): ?CDocument
     {
         $documentId = $this->normalizePositiveIntegerReference($reference);
         if (null === $documentId) {
@@ -399,14 +533,19 @@ final class AiCourseAnalyzerService
         }
 
         $resourceNode = $document->getResourceNode();
-        if (!$resourceNode instanceof ResourceNode || !$this->isResourceNodeVisibleInCourse($resourceNode, $course, $session)) {
+        if (!$resourceNode instanceof ResourceNode || !$this->isResourceNodeVisibleInCourse($resourceNode, $course, $session, $includeDraftResources)) {
             return null;
         }
 
         return $document;
     }
 
-    private function findVisibleQuizByReference(string $reference, Course $course, ?Session $session): ?CQuiz
+    private function findVisibleQuizByReference(
+        string $reference,
+        Course $course,
+        ?Session $session,
+        bool $includeDraftResources,
+    ): ?CQuiz
     {
         $quizId = $this->normalizePositiveIntegerReference($reference);
         if (null === $quizId) {
@@ -420,7 +559,7 @@ final class AiCourseAnalyzerService
         }
 
         $resourceNode = $quiz->getResourceNode();
-        if (!$resourceNode instanceof ResourceNode || !$this->isResourceNodeVisibleInCourse($resourceNode, $course, $session)) {
+        if (!$resourceNode instanceof ResourceNode || !$this->isResourceNodeVisibleInCourse($resourceNode, $course, $session, $includeDraftResources)) {
             return null;
         }
 
@@ -438,7 +577,27 @@ final class AiCourseAnalyzerService
         return $id > 0 ? $id : null;
     }
 
-    private function isResourceNodeVisibleInCourse(ResourceNode $resourceNode, Course $course, ?Session $session): bool
+    private function isResourceNodeVisibleInCourse(
+        ResourceNode $resourceNode,
+        Course $course,
+        ?Session $session,
+        bool $includeDraftResources,
+    ): bool
+    {
+        return $this->findReviewableResourceLink(
+            $resourceNode,
+            $course,
+            $session,
+            $includeDraftResources,
+        ) instanceof ResourceLink;
+    }
+
+    private function findReviewableResourceLink(
+        ResourceNode $resourceNode,
+        Course $course,
+        ?Session $session,
+        bool $includeDraftResources,
+    ): ?ResourceLink
     {
         foreach ($resourceNode->getResourceLinks() as $resourceLink) {
             if (!$resourceLink instanceof ResourceLink) {
@@ -449,20 +608,77 @@ final class AiCourseAnalyzerService
                 continue;
             }
 
-            if (ResourceLink::VISIBILITY_PUBLISHED !== $resourceLink->getVisibility()) {
+            if (!$this->isReviewableVisibility($resourceLink->getVisibility(), $includeDraftResources)) {
                 continue;
             }
 
             if (!$session instanceof Session && null === $resourceLink->getSession()) {
-                return true;
+                return $resourceLink;
             }
 
             if ($session instanceof Session && (null === $resourceLink->getSession() || $this->isSameSession($resourceLink->getSession(), $session))) {
-                return true;
+                return $resourceLink;
             }
         }
 
-        return false;
+        return null;
+    }
+
+    private function isReviewableVisibility(int $visibility, bool $includeDraftResources): bool
+    {
+        if (!$includeDraftResources) {
+            return ResourceLink::VISIBILITY_PUBLISHED === $visibility;
+        }
+
+        return \in_array($visibility, [
+            ResourceLink::VISIBILITY_DRAFT,
+            ResourceLink::VISIBILITY_PENDING,
+            ResourceLink::VISIBILITY_PUBLISHED,
+        ], true);
+    }
+
+    /**
+     * @return array{value:int|null,label:string,published:bool}
+     */
+    private function buildVisibilityPayload(?ResourceLink $resourceLink): array
+    {
+        $visibility = $resourceLink?->getVisibility();
+
+        return [
+            'value' => $visibility,
+            'label' => match ($visibility) {
+                ResourceLink::VISIBILITY_DRAFT => 'draft',
+                ResourceLink::VISIBILITY_PENDING => 'pending',
+                ResourceLink::VISIBILITY_PUBLISHED => 'published',
+                default => 'unknown',
+            },
+            'published' => ResourceLink::VISIBILITY_PUBLISHED === $visibility,
+        ];
+    }
+
+    private function applyReviewVisibilityFilter(
+        QueryBuilder $queryBuilder,
+        string $resourceLinkAlias,
+        bool $includeDraftResources,
+    ): void
+    {
+        if ($includeDraftResources) {
+            $queryBuilder
+                ->andWhere($resourceLinkAlias.'.visibility IN (:reviewVisibilities)')
+                ->setParameter('reviewVisibilities', [
+                    ResourceLink::VISIBILITY_DRAFT,
+                    ResourceLink::VISIBILITY_PENDING,
+                    ResourceLink::VISIBILITY_PUBLISHED,
+                ], ArrayParameterType::INTEGER)
+            ;
+
+            return;
+        }
+
+        $queryBuilder
+            ->andWhere($resourceLinkAlias.'.visibility = :publishedVisibility')
+            ->setParameter('publishedVisibility', ResourceLink::VISIBILITY_PUBLISHED, Types::INTEGER)
+        ;
     }
 
     private function isSameCourse(?Course $left, Course $right): bool
@@ -545,7 +761,9 @@ final class AiCourseAnalyzerService
         ?Session $session,
         array $excludedDocumentIds,
         int &$totalCharacters,
-    ): array {
+        bool $includeDraftResources,
+    ): array
+    {
         $qb = $this->entityManager->createQueryBuilder();
         $qb
             ->select('document', 'resourceNode', 'resourceLink', 'resourceFile')
@@ -554,10 +772,8 @@ final class AiCourseAnalyzerService
             ->innerJoin('resourceNode.resourceLinks', 'resourceLink')
             ->leftJoin('resourceNode.resourceFiles', 'resourceFile')
             ->andWhere('resourceLink.course = :course')
-            ->andWhere('resourceLink.visibility = :visibility')
             ->andWhere('document.filetype = :filetype')
             ->setParameter('course', (int) $course->getId())
-            ->setParameter('visibility', ResourceLink::VISIBILITY_PUBLISHED, Types::INTEGER)
             ->setParameter('filetype', 'file', Types::STRING)
             ->setMaxResults(self::MAX_STANDALONE_DOCUMENTS)
             ->orderBy('resourceLink.displayOrder', 'ASC')
@@ -569,6 +785,12 @@ final class AiCourseAnalyzerService
                 ->setParameter('excludedDocumentIds', array_values($excludedDocumentIds), ArrayParameterType::INTEGER)
             ;
         }
+
+        $this->applyReviewVisibilityFilter(
+            $qb,
+            'resourceLink',
+            $includeDraftResources,
+        );
 
         if ($session instanceof Session) {
             $qb
@@ -584,7 +806,7 @@ final class AiCourseAnalyzerService
 
         $documents = [];
         foreach ($documentList as $document) {
-            $documents[] = $this->buildDocumentPayload($document, $totalCharacters, $course, $session);
+            $documents[] = $this->buildDocumentPayload($document, $totalCharacters, $course, $session, $includeDraftResources);
         }
 
         return $documents;
@@ -595,7 +817,12 @@ final class AiCourseAnalyzerService
      *
      * @return array<int, array<string, mixed>>
      */
-    private function collectVisibleStandaloneExercises(Course $course, ?Session $session, array $excludedExerciseIds): array
+    private function collectVisibleStandaloneExercises(
+        Course $course,
+        ?Session $session,
+        array $excludedExerciseIds,
+        bool $includeDraftResources,
+    ): array
     {
         $qb = $this->entityManager->createQueryBuilder();
         $qb
@@ -607,9 +834,7 @@ final class AiCourseAnalyzerService
             ->leftJoin('quizQuestionRel.question', 'question')
             ->leftJoin('question.answers', 'answer')
             ->andWhere('resourceLink.course = :course')
-            ->andWhere('resourceLink.visibility = :visibility')
             ->setParameter('course', (int) $course->getId())
-            ->setParameter('visibility', ResourceLink::VISIBILITY_PUBLISHED, Types::INTEGER)
             ->setMaxResults(self::MAX_STANDALONE_EXERCISES)
             ->orderBy('resourceLink.displayOrder', 'ASC')
         ;
@@ -620,6 +845,12 @@ final class AiCourseAnalyzerService
                 ->setParameter('excludedExerciseIds', array_values($excludedExerciseIds), ArrayParameterType::INTEGER)
             ;
         }
+
+        $this->applyReviewVisibilityFilter(
+            $qb,
+            'resourceLink',
+            $includeDraftResources,
+        );
 
         if ($session instanceof Session) {
             $qb
@@ -635,10 +866,171 @@ final class AiCourseAnalyzerService
 
         $exercises = [];
         foreach ($quizList as $quiz) {
-            $exercises[] = $this->buildExercisePayload($quiz, $course, $session);
+            $exercises[] = $this->buildExercisePayload($quiz, $course, $session, $includeDraftResources);
         }
 
         return $exercises;
+    }
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    private function collectReviewAssignments(
+        Course $course,
+        ?Session $session,
+        bool $includeDraftResources,
+    ): array {
+        $qb = $this->entityManager->createQueryBuilder();
+        $qb
+            ->select('assignment', 'resourceNode', 'resourceLink')
+            ->from(CStudentPublication::class, 'assignment')
+            ->innerJoin('assignment.resourceNode', 'resourceNode')
+            ->innerJoin('resourceNode.resourceLinks', 'resourceLink')
+            ->andWhere('resourceLink.course = :course')
+            ->andWhere('assignment.publicationParent IS NULL')
+            ->setParameter('course', (int) $course->getId())
+            ->setMaxResults(self::MAX_ASSIGNMENTS)
+            ->orderBy('resourceLink.displayOrder', 'ASC')
+        ;
+
+        $this->applyReviewVisibilityFilter(
+            $qb,
+            'resourceLink',
+            $includeDraftResources,
+        );
+
+        if ($session instanceof Session) {
+            $qb
+                ->andWhere('(resourceLink.session IS NULL OR resourceLink.session = :session)')
+                ->setParameter('session', (int) $session->getId())
+            ;
+        } else {
+            $qb->andWhere('resourceLink.session IS NULL');
+        }
+
+        /** @var CStudentPublication[] $assignmentList */
+        $assignmentList = $qb->getQuery()->getResult();
+
+        $assignments = [];
+        foreach ($assignmentList as $assignment) {
+            $resourceNode = $assignment->getResourceNode();
+            $resourceLink = $resourceNode instanceof ResourceNode
+                ? $this->findReviewableResourceLink(
+                    $resourceNode,
+                    $course,
+                    $session,
+                    $includeDraftResources,
+                )
+                : null;
+
+            $assignments[] = [
+                'id' => $assignment->getIid(),
+                'title' => $assignment->getTitle(),
+                'description' => $this->cleanText((string) $assignment->getDescription()),
+                'maximumScore' => $assignment->getQualification(),
+                'submissionMode' => $assignment->getAllowTextAssignment(),
+                'active' => $assignment->getActive(),
+                'visibility' => $this->buildVisibilityPayload($resourceLink),
+            ];
+        }
+
+        return $assignments;
+    }
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    private function collectReviewSurveys(
+        Course $course,
+        ?Session $session,
+        bool $includeDraftResources,
+    ): array {
+        $qb = $this->entityManager->createQueryBuilder();
+        $qb
+            ->select('survey', 'resourceNode', 'resourceLink')
+            ->from(CSurvey::class, 'survey')
+            ->innerJoin('survey.resourceNode', 'resourceNode')
+            ->innerJoin('resourceNode.resourceLinks', 'resourceLink')
+            ->andWhere('resourceLink.course = :course')
+            ->setParameter('course', (int) $course->getId())
+            ->setMaxResults(self::MAX_SURVEYS)
+            ->orderBy('resourceLink.displayOrder', 'ASC')
+        ;
+
+        $this->applyReviewVisibilityFilter(
+            $qb,
+            'resourceLink',
+            $includeDraftResources,
+        );
+
+        if ($session instanceof Session) {
+            $qb
+                ->andWhere('(resourceLink.session IS NULL OR resourceLink.session = :session)')
+                ->setParameter('session', (int) $session->getId())
+            ;
+        } else {
+            $qb->andWhere('resourceLink.session IS NULL');
+        }
+
+        /** @var CSurvey[] $surveyList */
+        $surveyList = $qb->getQuery()->getResult();
+
+        $surveys = [];
+        foreach ($surveyList as $survey) {
+            $questions = [];
+
+            foreach ($survey->getQuestions() as $question) {
+                if (\count($questions) >= self::MAX_SURVEY_QUESTIONS) {
+                    break;
+                }
+
+                $options = [];
+                foreach ($question->getOptions() as $option) {
+                    if (\count($options) >= self::MAX_SURVEY_OPTIONS) {
+                        break;
+                    }
+
+                    $options[] = [
+                        'text' => $this->cleanText((string) $option->getOptionText()),
+                        'value' => $option->getValue(),
+                    ];
+                }
+
+                $questions[] = [
+                    'id' => $question->getIid(),
+                    'question' => $this->cleanText($question->getSurveyQuestion()),
+                    'comment' => $this->cleanText((string) $question->getSurveyQuestionComment()),
+                    'type' => $question->getType(),
+                    'mandatory' => $question->isMandatory(),
+                    'position' => $question->getSort(),
+                    'options' => $options,
+                ];
+            }
+
+            $resourceNode = $survey->getResourceNode();
+            $resourceLink = $resourceNode instanceof ResourceNode
+                ? $this->findReviewableResourceLink(
+                    $resourceNode,
+                    $course,
+                    $session,
+                    $includeDraftResources,
+                )
+                : null;
+
+            $surveys[] = [
+                'id' => $survey->getIid(),
+                'title' => $survey->getTitle(),
+                'introduction' => $this->cleanText((string) $survey->getIntro()),
+                'thanks' => $this->cleanText((string) $survey->getSurveythanks()),
+                'language' => $survey->getLang(),
+                'anonymous' => '1' === $survey->getAnonymous(),
+                'questionCount' => \count($questions),
+                'visibility' => $this->buildVisibilityPayload($resourceLink),
+                'questions' => $questions,
+            ];
+        }
+
+        return $surveys;
     }
 
     /**
@@ -649,8 +1041,13 @@ final class AiCourseAnalyzerService
         int &$totalCharacters,
         ?Course $course = null,
         ?Session $session = null,
-    ): array {
+        bool $includeDraftResources = false,
+    ): array
+    {
         $resourceNode = $document->getResourceNode();
+        $resourceLink = $resourceNode instanceof ResourceNode && $course instanceof Course
+            ? $this->findReviewableResourceLink($resourceNode, $course, $session, $includeDraftResources)
+            : null;
 
         $metadata = [
             'id' => $document->getIid(),
@@ -660,10 +1057,14 @@ final class AiCourseAnalyzerService
             'resourceNodeId' => $resourceNode instanceof ResourceNode ? $resourceNode->getId() : null,
             'resourcePath' => $resourceNode instanceof ResourceNode ? $resourceNode->getPathForDisplay() : null,
             'editUrl' => $course instanceof Course ? $this->buildDocumentEditUrl($document, $course, $session) : null,
+            'visibility' => $this->buildVisibilityPayload($resourceLink),
             'fileName' => null,
             'mimeType' => null,
             'size' => null,
             'textIncluded' => false,
+            'textSource' => null,
+            'textLength' => 0,
+            'textTruncated' => false,
             'text' => '',
             'notice' => null,
         ];
@@ -694,14 +1095,23 @@ final class AiCourseAnalyzerService
             return $metadata;
         }
 
-        $text = $this->extractResourceFileText($resourceFile, min(self::MAX_CHARS_PER_DOCUMENT, $remainingCharacters));
+        $extracted = $this->extractDocumentText(
+            $document,
+            $resourceFile,
+            min(self::MAX_CHARS_PER_DOCUMENT, $remainingCharacters),
+        );
+        $text = $extracted['text'];
+
         if ('' === $text) {
-            $metadata['notice'] = 'This file type is listed but was not included as text in this proof of concept.';
+            $metadata['notice'] = 'The document content could not be read from Chamilo storage.';
 
             return $metadata;
         }
 
         $metadata['textIncluded'] = true;
+        $metadata['textSource'] = $extracted['source'];
+        $metadata['textLength'] = mb_strlen($text);
+        $metadata['textTruncated'] = $extracted['truncated'];
         $metadata['text'] = $text;
         $totalCharacters += mb_strlen($text);
 
@@ -711,7 +1121,12 @@ final class AiCourseAnalyzerService
     /**
      * @return array<string, mixed>
      */
-    private function buildExercisePayload(CQuiz $quiz, ?Course $course = null, ?Session $session = null): array
+    private function buildExercisePayload(
+        CQuiz $quiz,
+        ?Course $course = null,
+        ?Session $session = null,
+        bool $includeDraftResources = false,
+    ): array
     {
         $questions = [];
 
@@ -759,13 +1174,75 @@ final class AiCourseAnalyzerService
             ];
         }
 
+        $resourceNode = $quiz->getResourceNode();
+        $resourceLink = $resourceNode instanceof ResourceNode && $course instanceof Course
+            ? $this->findReviewableResourceLink($resourceNode, $course, $session, $includeDraftResources)
+            : null;
+
         return [
             'id' => $quiz->getIid(),
             'title' => $quiz->getTitle(),
             'description' => $this->cleanText((string) $quiz->getDescription()),
             'type' => $quiz->getType(),
             'editUrl' => $course instanceof Course ? $this->buildExerciseEditUrl($quiz, $course, $session) : null,
+            'visibility' => $this->buildVisibilityPayload($resourceLink),
             'questions' => $questions,
+        ];
+    }
+
+    /**
+     * Read through the Chamilo repository first so Flysystem/Vich-backed
+     * resources and editable text content are available outside a file upload
+     * request. Fall back to the direct ResourceFile path for legacy files.
+     *
+     * @return array{text:string,source:string|null,truncated:bool}
+     */
+    private function extractDocumentText(
+        CDocument $document,
+        ResourceFile $resourceFile,
+        int $maxCharacters,
+    ): array {
+        if ($maxCharacters <= 0) {
+            return [
+                'text' => '',
+                'source' => null,
+                'truncated' => false,
+            ];
+        }
+
+        $fileName = (string) (
+            $resourceFile->getOriginalName()
+            ?: $resourceFile->getTitle()
+            ?: ''
+        );
+        $extension = strtolower((string) pathinfo($fileName, PATHINFO_EXTENSION));
+        $mimeType = strtolower((string) $resourceFile->getMimeType());
+
+        if ('docx' !== $extension && $this->isPlainTextResource($extension, $mimeType)) {
+            try {
+                $rawContent = $this->documentRepository->getResourceFileContent($document);
+                $cleanContent = $this->cleanText($rawContent);
+
+                if ('' !== $cleanContent) {
+                    $truncated = mb_strlen($cleanContent) > $maxCharacters;
+
+                    return [
+                        'text' => $this->truncateText($cleanContent, $maxCharacters),
+                        'source' => 'chamilo_repository',
+                        'truncated' => $truncated,
+                    ];
+                }
+            } catch (Throwable) {
+                // Continue with the direct ResourceFile fallback.
+            }
+        }
+
+        $text = $this->extractResourceFileText($resourceFile, $maxCharacters);
+
+        return [
+            'text' => $text,
+            'source' => '' !== $text ? 'resource_file_fallback' : null,
+            'truncated' => '' !== $text && mb_strlen($text) >= $maxCharacters,
         ];
     }
 
@@ -870,6 +1347,8 @@ final class AiCourseAnalyzerService
         $structuredLessons = $this->arrayList($structured['lessons'] ?? []);
         $structuredStandaloneDocuments = $this->arrayList($structured['standaloneDocuments'] ?? []);
         $structuredStandaloneExercises = $this->arrayList($structured['standaloneExercises'] ?? []);
+        $structuredAssignments = $this->arrayList($structured['assignments'] ?? []);
+        $structuredSurveys = $this->arrayList($structured['surveys'] ?? []);
 
         $structured['lessons'] = $this->normalizeLessonFeedbackList(
             $this->arrayList($payload['lessons'] ?? []),
@@ -882,6 +1361,16 @@ final class AiCourseAnalyzerService
         $structured['standaloneExercises'] = $this->normalizeStandaloneExerciseFeedbackList(
             $this->arrayList($payload['standaloneExercises'] ?? []),
             $structuredStandaloneExercises,
+        );
+        $structured['assignments'] = $this->normalizeSimpleResourceFeedbackList(
+            $this->arrayList($payload['assignments'] ?? []),
+            $structuredAssignments,
+            'Assignment',
+        );
+        $structured['surveys'] = $this->normalizeSimpleResourceFeedbackList(
+            $this->arrayList($payload['surveys'] ?? []),
+            $structuredSurveys,
+            'Survey',
         );
 
         return $structured;
@@ -1015,6 +1504,42 @@ final class AiCourseAnalyzerService
     }
 
     /**
+     * @param array<int, mixed> $payloadItems
+     * @param array<int, mixed> $structuredItems
+     *
+     * @return array<int, array<string, mixed>>
+     */
+    private function normalizeSimpleResourceFeedbackList(
+        array $payloadItems,
+        array $structuredItems,
+        string $fallbackTitle,
+    ): array {
+        $items = [];
+
+        foreach ($payloadItems as $payloadItem) {
+            if (!\is_array($payloadItem)) {
+                continue;
+            }
+
+            $structuredItem = $this->findStructuredFeedback(
+                $structuredItems,
+                $payloadItem,
+            );
+
+            $items[] = [
+                'id' => $payloadItem['id'] ?? null,
+                'title' => $payloadItem['title'] ?? $fallbackTitle,
+                'feedback' => $this->stringValue($structuredItem['feedback'] ?? ''),
+                'recommendations' => $this->stringList(
+                    $structuredItem['recommendations'] ?? [],
+                ),
+            ];
+        }
+
+        return $items;
+    }
+
+    /**
      * @param array<int, mixed> $payloadQuestions
      * @param array<int, mixed> $structuredQuestions
      *
@@ -1029,14 +1554,28 @@ final class AiCourseAnalyzerService
                 continue;
             }
 
-            $structuredQuestion = $this->findStructuredFeedback($structuredQuestions, $payloadQuestion);
+            $structuredQuestion = $this->findStructuredFeedback(
+                $structuredQuestions,
+                $payloadQuestion,
+            );
+            $feedback = $this->stringValue($structuredQuestion['feedback'] ?? '');
+            $answersFeedback = $this->stringValue(
+                $structuredQuestion['answersFeedback'] ?? '',
+            );
+            $recommendations = $this->stringList(
+                $structuredQuestion['recommendations'] ?? [],
+            );
+
+            if ('' === $feedback && '' === $answersFeedback && [] === $recommendations) {
+                continue;
+            }
 
             $items[] = [
                 'id' => $payloadQuestion['id'] ?? null,
                 'question' => $payloadQuestion['question'] ?? 'Question',
-                'feedback' => $this->stringValue($structuredQuestion['feedback'] ?? ''),
-                'answersFeedback' => $this->stringValue($structuredQuestion['answersFeedback'] ?? ''),
-                'recommendations' => $this->stringList($structuredQuestion['recommendations'] ?? []),
+                'feedback' => $feedback,
+                'answersFeedback' => $answersFeedback,
+                'recommendations' => $recommendations,
             ];
         }
 
@@ -1149,48 +1688,149 @@ final class AiCourseAnalyzerService
     /**
      * @param array<string, mixed> $payload
      *
+     * @return array<string, int>
+     */
+    private function buildPayloadStats(array $payload): array
+    {
+        $documents = [];
+        $exerciseCount = 0;
+        $questionCount = 0;
+
+        foreach ($this->arrayList($payload['lessons'] ?? []) as $lesson) {
+            if (!\is_array($lesson)) {
+                continue;
+            }
+
+            foreach ($this->arrayList($lesson['items'] ?? []) as $item) {
+                if (!\is_array($item)) {
+                    continue;
+                }
+
+                if (\is_array($item['document'] ?? null)) {
+                    $documents[] = $item['document'];
+                }
+
+                if (\is_array($item['exercise'] ?? null)) {
+                    ++$exerciseCount;
+                    $questionCount += \count(
+                        $this->arrayList($item['exercise']['questions'] ?? []),
+                    );
+                }
+            }
+        }
+
+        foreach ($this->arrayList($payload['standaloneDocuments'] ?? []) as $document) {
+            if (\is_array($document)) {
+                $documents[] = $document;
+            }
+        }
+
+        foreach ($this->arrayList($payload['standaloneExercises'] ?? []) as $exercise) {
+            if (!\is_array($exercise)) {
+                continue;
+            }
+
+            ++$exerciseCount;
+            $questionCount += \count(
+                $this->arrayList($exercise['questions'] ?? []),
+            );
+        }
+
+        $documentsWithText = 0;
+        $documentsWithoutText = 0;
+        $truncatedDocuments = 0;
+        $includedTextCharacters = 0;
+
+        foreach ($documents as $document) {
+            if (true === ($document['textIncluded'] ?? false)) {
+                ++$documentsWithText;
+                $includedTextCharacters += (int) ($document['textLength'] ?? 0);
+
+                if (true === ($document['textTruncated'] ?? false)) {
+                    ++$truncatedDocuments;
+                }
+
+                continue;
+            }
+
+            ++$documentsWithoutText;
+        }
+
+        return [
+            'documents_total' => \count($documents),
+            'documents_with_text' => $documentsWithText,
+            'documents_without_text' => $documentsWithoutText,
+            'documents_truncated' => $truncatedDocuments,
+            'included_text_characters' => $includedTextCharacters,
+            'exercises_total' => $exerciseCount,
+            'questions_total' => $questionCount,
+            'assignments_total' => \count($this->arrayList($payload['assignments'] ?? [])),
+            'surveys_total' => \count($this->arrayList($payload['surveys'] ?? [])),
+        ];
+    }
+
+    /**
+     * @param array<string, mixed> $payload
+     *
      * @return array<int, array{role:string,content:string}>
      */
-    private function buildMessages(array $payload): array
-    {
-        $payloadJson = json_encode($payload, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+    private function buildMessages(
+        array $payload,
+        bool $compact,
+    ): array {
+        $payloadJson = json_encode(
+            $payload,
+            JSON_PRETTY_PRINT
+                | JSON_UNESCAPED_UNICODE
+                | JSON_UNESCAPED_SLASHES,
+        );
         if (!\is_string($payloadJson)) {
             $payloadJson = '{}';
         }
 
+        $detailRules = $compact
+            ? [
+                'This is a compact retry after an invalid or truncated response.',
+                'Keep general feedback under 900 characters.',
+                'Return at most 5 strengths, 5 risks and 7 recommendations.',
+                'Keep each resource feedback under 280 characters and each resource recommendation list to at most 3 concise items.',
+                'Only include question-level feedback for questions with a concrete defect. Omit question objects that need no correction.',
+            ]
+            : [
+                'Keep general feedback under 1400 characters.',
+                'Return at most 7 strengths, 7 risks and 10 recommendations.',
+                'Keep each resource feedback concise and evidence-based.',
+                'Question-level feedback should focus only on concrete wording, answer, scoring or feedback defects.',
+            ];
+
         return [
             [
                 'role' => 'system',
-                'content' => implode("\n", [
+                'content' => implode("\n", array_merge([
                     'You are an expert instructional designer and e-learning quality reviewer.',
-                    'Analyze the Chamilo course by prioritizing the visible learning path structure.',
+                    'Analyze the Chamilo course by prioritizing its learning path structure and respecting each resource visibility state.',
                     'Review each lesson as an ordered pedagogical sequence, and explain the purpose and quality of each lesson item when possible.',
-                    'When an item or standalone exercise includes questions and answers, analyze question wording, answer quality, correct-answer alignment, feedback comments and scoring.',
-                    'Documents and exercises inside lessons are the primary analysis scope. Standalone documents and standalone exercises are secondary and only included when the teacher explicitly selected those options.',
+                    'When a document includes text, base your feedback on that text rather than its title or generation topic.',
+                    'When an exercise includes questions and answers, analyze wording, answer quality, correct-answer alignment, feedback comments and scoring.',
+                    'Review assignment descriptions, scoring and submission mode, and review survey structure, wording, option quality and anonymity.',
+                    'Draft and pending resources are teacher work in progress. Analyze them and do not describe the course as empty merely because resources are unpublished.',
                     'Return only valid JSON, without markdown fences.',
-                    'Do not invent lessons, items, documents, exercises or questions.',
-                    'Use the exact id and title/question values from the payload whenever possible.',
-                    'Return one feedback object for every lesson, lesson item, standalone document, standalone exercise and exercise question present in the payload. If a file has metadata only, still provide a short recommendation based on its title, type and position.',
-                    'Use this exact structure:',
+                    'Do not invent lessons, items, documents, exercises, assignments, surveys or questions.',
+                    'Use exact IDs and titles from the payload whenever possible.',
+                ], $detailRules, [
+                    'Use this JSON structure:',
                     '{',
                     '  "generalFeedback": "string",',
                     '  "strengths": ["string"],',
                     '  "risks": ["string"],',
                     '  "recommendations": ["string"],',
-                    '  "lessons": [',
-                    '    {',
-                    '      "id": 0,',
-                    '      "title": "string",',
-                    '      "feedback": "string",',
-                    '      "sequenceFeedback": "string",',
-                    '      "items": [{"id": 0, "title": "string", "type": "string", "purpose": "string", "feedback": "string", "questions": [{"id": 0, "question": "string", "feedback": "string", "answersFeedback": "string", "recommendations": ["string"]}], "recommendations": ["string"]}],',
-                    '      "recommendations": ["string"]',
-                    '    }',
-                    '  ],',
+                    '  "lessons": [{"id": 0, "title": "string", "feedback": "string", "sequenceFeedback": "string", "items": [{"id": 0, "title": "string", "type": "string", "purpose": "string", "feedback": "string", "questions": [{"id": 0, "question": "string", "feedback": "string", "answersFeedback": "string", "recommendations": ["string"]}], "recommendations": ["string"]}], "recommendations": ["string"]}],',
                     '  "standaloneDocuments": [{"id": 0, "title": "string", "feedback": "string", "recommendations": ["string"]}],',
-                    '  "standaloneExercises": [{"id": 0, "title": "string", "feedback": "string", "questions": [{"id": 0, "question": "string", "feedback": "string", "answersFeedback": "string", "recommendations": ["string"]}], "recommendations": ["string"]}]',
+                    '  "standaloneExercises": [{"id": 0, "title": "string", "feedback": "string", "questions": [{"id": 0, "question": "string", "feedback": "string", "answersFeedback": "string", "recommendations": ["string"]}], "recommendations": ["string"]}],',
+                    '  "assignments": [{"id": 0, "title": "string", "feedback": "string", "recommendations": ["string"]}],',
+                    '  "surveys": [{"id": 0, "title": "string", "feedback": "string", "recommendations": ["string"]}]',
                     '}',
-                ]),
+                ])),
             ],
             [
                 'role' => 'user',
@@ -1200,13 +1840,37 @@ final class AiCourseAnalyzerService
     }
 
     /**
+     * @param array<int, array{role:string,content:string}> $messages
+     */
+    private function requestStructuredAnalysis(
+        string $provider,
+        array $messages,
+        int $maxTokens,
+    ): string {
+        return $this->chatCompletionClient->chat($provider, $messages, [
+            'temperature' => 0.15,
+            'max_tokens' => $maxTokens,
+            'max_output_tokens' => $maxTokens,
+            'response_mime_type' => 'application/json',
+            'throw_on_error' => true,
+        ]);
+    }
+
+    /**
      * @return array<string, mixed>|null
      */
     private function decodeStructuredResponse(string $rawResponse): ?array
     {
         $response = trim($rawResponse);
-        $response = preg_replace('/^```(?:json)?\s*/i', '', $response) ?? $response;
-        $response = preg_replace('/\s*```$/', '', $response) ?? $response;
+        $response = preg_replace('/^```(?:json)?\\s*/i', '', $response) ?? $response;
+        $response = preg_replace('/\\s*```$/', '', $response) ?? $response;
+
+        $start = strpos($response, '{');
+        $end = strrpos($response, '}');
+
+        if (false !== $start && false !== $end && $end >= $start) {
+            $response = substr($response, $start, $end - $start + 1);
+        }
 
         try {
             $decoded = json_decode($response, true, 512, JSON_THROW_ON_ERROR);

--- a/src/CoreBundle/AiProvider/GeminiProvider.php
+++ b/src/CoreBundle/AiProvider/GeminiProvider.php
@@ -177,7 +177,8 @@ final class GeminiProvider implements AiProviderInterface, AiImageProviderInterf
             temperature: $resolved['temperature'],
             maxOutputTokens: $resolved['max_output_tokens'],
             prompt: $prompt,
-            toolName: 'generateText'
+            toolName: 'generateText',
+            responseMimeType: $resolved['response_mime_type'],
         );
 
         if (null === $result || '' === trim($result)) {
@@ -413,7 +414,14 @@ final class GeminiProvider implements AiProviderInterface, AiImageProviderInterf
             );
     }
 
-    private function requestGeminiText(string $url, float $temperature, int $maxOutputTokens, string $prompt, string $toolName): ?string
+    private function requestGeminiText(
+        string $url,
+        float $temperature,
+        int $maxOutputTokens,
+        string $prompt,
+        string $toolName,
+        ?string $responseMimeType = null,
+    ): ?string
     {
         $this->lastTextError = null;
 
@@ -437,6 +445,10 @@ final class GeminiProvider implements AiProviderInterface, AiImageProviderInterf
                 'maxOutputTokens' => $maxOutputTokens,
             ],
         ];
+
+        if (null !== $responseMimeType) {
+            $payload['generationConfig']['responseMimeType'] = $responseMimeType;
+        }
 
         try {
             $data = $this->postJson($url, $payload);
@@ -1258,7 +1270,7 @@ final class GeminiProvider implements AiProviderInterface, AiImageProviderInterf
      *
      * @param array<string,mixed> $options
      *
-     * @return array{url:string,temperature:float,max_output_tokens:int}
+     * @return array{url:string,temperature:float,max_output_tokens:int,response_mime_type:string|null}
      */
     private function resolveTextOptions(array $options): array
     {
@@ -1278,10 +1290,17 @@ final class GeminiProvider implements AiProviderInterface, AiImageProviderInterf
             $max = $this->textMaxOutputTokens > 0 ? $this->textMaxOutputTokens : 1000;
         }
 
+        $responseMimeType = $options['response_mime_type'] ?? $options['responseMimeType'] ?? null;
+        $responseMimeType = null !== $responseMimeType ? trim((string) $responseMimeType) : null;
+        if (!\in_array($responseMimeType, [null, 'application/json', 'text/plain'], true)) {
+            $responseMimeType = null;
+        }
+
         return [
             'url' => $url,
             'temperature' => $temperature,
             'max_output_tokens' => $max,
+            'response_mime_type' => $responseMimeType,
         ];
     }
 

--- a/src/CoreBundle/AiProvider/GeminiProvider.php
+++ b/src/CoreBundle/AiProvider/GeminiProvider.php
@@ -421,8 +421,7 @@ final class GeminiProvider implements AiProviderInterface, AiImageProviderInterf
         string $prompt,
         string $toolName,
         ?string $responseMimeType = null,
-    ): ?string
-    {
+    ): ?string {
         $this->lastTextError = null;
 
         $userId = $this->getUserId();

--- a/src/CoreBundle/ApiResource/Mcp/McpApiKey.php
+++ b/src/CoreBundle/ApiResource/Mcp/McpApiKey.php
@@ -1,0 +1,99 @@
+<?php
+
+/* For licensing terms, see /license.txt */
+
+declare(strict_types=1);
+
+namespace Chamilo\CoreBundle\ApiResource\Mcp;
+
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\Delete;
+use ApiPlatform\Metadata\Get;
+use ApiPlatform\Metadata\Post;
+use Chamilo\CoreBundle\State\Mcp\McpApiKeyProcessor;
+use Chamilo\CoreBundle\State\Mcp\McpApiKeyProvider;
+use Symfony\Component\Serializer\Attribute\Groups;
+
+#[ApiResource(
+    shortName: 'McpApiKey',
+    operations: [
+        new Get(
+            uriTemplate: '/mcp_api_key',
+            security: "is_granted('IS_AUTHENTICATED_FULLY')",
+            name: 'get_current_mcp_api_key',
+            provider: McpApiKeyProvider::class,
+        ),
+        new Post(
+            uriTemplate: '/mcp_api_key',
+            input: false,
+            read: false,
+            security: "is_granted('IS_AUTHENTICATED_FULLY')",
+            name: 'generate_current_mcp_api_key',
+            processor: McpApiKeyProcessor::class,
+        ),
+        new Delete(
+            uriTemplate: '/mcp_api_key',
+            input: false,
+            output: false,
+            read: false,
+            security: "is_granted('IS_AUTHENTICATED_FULLY')",
+            name: 'revoke_current_mcp_api_key',
+            processor: McpApiKeyProcessor::class,
+        ),
+    ],
+    normalizationContext: ['groups' => ['mcp_api_key:read']],
+)]
+final class McpApiKey
+{
+    #[ApiProperty(identifier: true)]
+    #[Groups(['mcp_api_key:read'])]
+    public string $id = 'current';
+
+    #[Groups(['mcp_api_key:read'])]
+    public bool $active = false;
+
+    #[Groups(['mcp_api_key:read'])]
+    public ?string $maskedKey = null;
+
+    /**
+     * Only populated in the immediate response to a generation or rotation.
+     */
+    #[Groups(['mcp_api_key:read'])]
+    public ?string $plainKey = null;
+
+    #[Groups(['mcp_api_key:read'])]
+    public string $endpoint = '';
+
+    #[Groups(['mcp_api_key:read'])]
+    public ?string $createdAt = null;
+
+    #[Groups(['mcp_api_key:read'])]
+    public ?string $lastUsedAt = null;
+
+    #[Groups(['mcp_api_key:read'])]
+    public ?string $revokedAt = null;
+
+    public function getId(): string
+    {
+        return $this->id;
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     */
+    public static function fromArray(array $data): self
+    {
+        $resource = new self();
+        $resource->id = (string) ($data['id'] ?? 'current');
+        $resource->active = (bool) ($data['active'] ?? false);
+        $resource->maskedKey = isset($data['maskedKey']) ? (string) $data['maskedKey'] : null;
+        $resource->plainKey = isset($data['plainKey']) ? (string) $data['plainKey'] : null;
+        $resource->endpoint = (string) ($data['endpoint'] ?? '');
+        $resource->createdAt = isset($data['createdAt']) ? (string) $data['createdAt'] : null;
+        $resource->lastUsedAt = isset($data['lastUsedAt']) ? (string) $data['lastUsedAt'] : null;
+        $resource->revokedAt = isset($data['revokedAt']) ? (string) $data['revokedAt'] : null;
+
+        return $resource;
+    }
+}

--- a/src/CoreBundle/Entity/User.php
+++ b/src/CoreBundle/Entity/User.php
@@ -748,9 +748,6 @@ class User implements UserInterface, EquatableInterface, ResourceInterface, Reso
     #[ORM\OneToMany(mappedBy: 'user', targetEntity: TrackELogin::class, cascade: ['persist', 'remove'])]
     protected Collection $logins;
 
-    #[ORM\OneToOne(mappedBy: 'user', targetEntity: Admin::class, cascade: ['persist', 'remove'], orphanRemoval: true)]
-    protected ?Admin $admin = null;
-
     #[ORM\Column(type: 'uuid', unique: true)]
     protected Uuid $uuid;
 
@@ -2242,37 +2239,14 @@ class User implements UserInterface, EquatableInterface, ResourceInterface, Reso
         return '/img/user_default.svg';
     }
 
-    public function getAdmin(): ?Admin
-    {
-        return $this->admin;
-    }
-
-    public function setAdmin(?Admin $admin): self
-    {
-        $this->admin = $admin;
-
-        return $this;
-    }
-
     public function addUserAsAdmin(): self
     {
-        if (null === $this->admin) {
-            $admin = new Admin();
-            $admin->setUser($this);
-            $this->setAdmin($admin);
-            $this->addRole('ROLE_ADMIN');
-        }
-
-        return $this;
+        return $this->addRole('ROLE_ADMIN');
     }
 
     public function removeUserAsAdmin(): self
     {
-        $this->admin->setUser(null);
-        $this->admin = null;
-        $this->removeRole('ROLE_ADMIN');
-
-        return $this;
+        return $this->removeRole('ROLE_ADMIN');
     }
 
     public function getSessionsByStatusInCourseSubscription(int $status): ReadableCollection

--- a/src/CoreBundle/Entity/UserApiKey.php
+++ b/src/CoreBundle/Entity/UserApiKey.php
@@ -6,15 +6,22 @@ declare(strict_types=1);
 
 namespace Chamilo\CoreBundle\Entity;
 
+use Chamilo\CoreBundle\Repository\UserApiKeyRepository;
 use DateTime;
 use Doctrine\ORM\Mapping as ORM;
 
 /**
- * UserApiKey.
+ * API keys associated with Chamilo users.
+ *
+ * Legacy services continue to use rows with api_service = "default".
+ * MCP rows use api_service = "mcp" and store a SHA-256 hash instead of the
+ * recoverable secret.
  */
 #[ORM\Table(name: 'user_api_key')]
 #[ORM\Index(name: 'idx_user_api_keys_user', columns: ['user_id'])]
-#[ORM\Entity]
+#[ORM\Index(name: 'idx_user_api_key_mcp_lookup', columns: ['api_service', 'api_key', 'access_url_id', 'revoked_at'])]
+#[ORM\UniqueConstraint(name: 'uniq_user_api_key_service_url', columns: ['user_id', 'api_service', 'access_url_id'])]
+#[ORM\Entity(repositoryClass: UserApiKeyRepository::class)]
 class UserApiKey
 {
     #[ORM\Column(name: 'id', type: 'integer')]
@@ -25,7 +32,7 @@ class UserApiKey
     #[ORM\Column(name: 'user_id', type: 'integer', nullable: false)]
     protected int $userId;
 
-    #[ORM\Column(name: 'api_key', type: 'string', length: 32, nullable: false)]
+    #[ORM\Column(name: 'api_key', type: 'string', length: 64, nullable: false)]
     protected string $apiKey;
 
     #[ORM\Column(name: 'api_service', type: 'string', length: 10, nullable: false)]
@@ -46,189 +53,177 @@ class UserApiKey
     #[ORM\Column(name: 'description', type: 'text', nullable: true)]
     protected ?string $description = null;
 
-    /**
-     * Set userId.
-     *
-     * @return UserApiKey
-     */
-    public function setUserId(int $userId)
+    #[ORM\Column(name: 'access_url_id', type: 'integer', nullable: true)]
+    protected ?int $accessUrlId = null;
+
+    #[ORM\Column(name: 'key_prefix', type: 'string', length: 32, nullable: true)]
+    protected ?string $keyPrefix = null;
+
+    #[ORM\Column(name: 'last_used_at', type: 'datetime', nullable: true)]
+    protected ?DateTime $lastUsedAt = null;
+
+    #[ORM\Column(name: 'revoked_at', type: 'datetime', nullable: true)]
+    protected ?DateTime $revokedAt = null;
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function setUserId(int $userId): self
     {
         $this->userId = $userId;
 
         return $this;
     }
 
-    /**
-     * Get userId.
-     *
-     * @return int
-     */
-    public function getUserId()
+    public function getUserId(): int
     {
         return $this->userId;
     }
 
-    /**
-     * Set apiKey.
-     *
-     * @return UserApiKey
-     */
-    public function setApiKey(string $apiKey)
+    public function setApiKey(string $apiKey): self
     {
         $this->apiKey = $apiKey;
 
         return $this;
     }
 
-    /**
-     * Get apiKey.
-     *
-     * @return string
-     */
-    public function getApiKey()
+    public function getApiKey(): string
     {
         return $this->apiKey;
     }
 
-    /**
-     * Set apiService.
-     *
-     * @return UserApiKey
-     */
-    public function setApiService(string $apiService)
+    public function setApiService(string $apiService): self
     {
         $this->apiService = $apiService;
 
         return $this;
     }
 
-    /**
-     * Get apiService.
-     *
-     * @return string
-     */
-    public function getApiService()
+    public function getApiService(): string
     {
         return $this->apiService;
     }
 
-    /**
-     * Set apiEndPoint.
-     *
-     * @return UserApiKey
-     */
-    public function setApiEndPoint(string $apiEndPoint)
+    public function setApiEndPoint(?string $apiEndPoint): self
     {
         $this->apiEndPoint = $apiEndPoint;
 
         return $this;
     }
 
-    /**
-     * Get apiEndPoint.
-     *
-     * @return string
-     */
-    public function getApiEndPoint()
+    public function getApiEndPoint(): ?string
     {
         return $this->apiEndPoint;
     }
 
-    /**
-     * Set createdDate.
-     *
-     * @return UserApiKey
-     */
-    public function setCreatedDate(DateTime $createdDate)
+    public function setCreatedDate(?DateTime $createdDate): self
     {
         $this->createdDate = $createdDate;
 
         return $this;
     }
 
-    /**
-     * Get createdDate.
-     *
-     * @return DateTime
-     */
-    public function getCreatedDate()
+    public function getCreatedDate(): ?DateTime
     {
         return $this->createdDate;
     }
 
-    /**
-     * Set validityStartDate.
-     *
-     * @return UserApiKey
-     */
-    public function setValidityStartDate(DateTime $validityStartDate)
+    public function setValidityStartDate(?DateTime $validityStartDate): self
     {
         $this->validityStartDate = $validityStartDate;
 
         return $this;
     }
 
-    /**
-     * Get validityStartDate.
-     *
-     * @return DateTime
-     */
-    public function getValidityStartDate()
+    public function getValidityStartDate(): ?DateTime
     {
         return $this->validityStartDate;
     }
 
-    /**
-     * Set validityEndDate.
-     *
-     * @return UserApiKey
-     */
-    public function setValidityEndDate(DateTime $validityEndDate)
+    public function setValidityEndDate(?DateTime $validityEndDate): self
     {
         $this->validityEndDate = $validityEndDate;
 
         return $this;
     }
 
-    /**
-     * Get validityEndDate.
-     *
-     * @return DateTime
-     */
-    public function getValidityEndDate()
+    public function getValidityEndDate(): ?DateTime
     {
         return $this->validityEndDate;
     }
 
-    /**
-     * Set description.
-     *
-     * @return UserApiKey
-     */
-    public function setDescription(string $description)
+    public function setDescription(?string $description): self
     {
         $this->description = $description;
 
         return $this;
     }
 
-    /**
-     * Get description.
-     *
-     * @return string
-     */
-    public function getDescription()
+    public function getDescription(): ?string
     {
         return $this->description;
     }
 
-    /**
-     * Get id.
-     *
-     * @return int
-     */
-    public function getId()
+    public function setAccessUrlId(?int $accessUrlId): self
     {
-        return $this->id;
+        $this->accessUrlId = $accessUrlId;
+
+        return $this;
+    }
+
+    public function getAccessUrlId(): ?int
+    {
+        return $this->accessUrlId;
+    }
+
+    public function setKeyPrefix(?string $keyPrefix): self
+    {
+        $this->keyPrefix = $keyPrefix;
+
+        return $this;
+    }
+
+    public function getKeyPrefix(): ?string
+    {
+        return $this->keyPrefix;
+    }
+
+    public function setLastUsedAt(?DateTime $lastUsedAt): self
+    {
+        $this->lastUsedAt = $lastUsedAt;
+
+        return $this;
+    }
+
+    public function getLastUsedAt(): ?DateTime
+    {
+        return $this->lastUsedAt;
+    }
+
+    public function setRevokedAt(?DateTime $revokedAt): self
+    {
+        $this->revokedAt = $revokedAt;
+
+        return $this;
+    }
+
+    public function getRevokedAt(): ?DateTime
+    {
+        return $this->revokedAt;
+    }
+
+    public function isActiveAt(DateTime $date): bool
+    {
+        if (null !== $this->revokedAt) {
+            return false;
+        }
+
+        if (null !== $this->validityStartDate && $this->validityStartDate > $date) {
+            return false;
+        }
+
+        return null === $this->validityEndDate || $this->validityEndDate > $date;
     }
 }

--- a/src/CoreBundle/Mcp/CourseOverviewTool.php
+++ b/src/CoreBundle/Mcp/CourseOverviewTool.php
@@ -15,7 +15,9 @@ use Chamilo\CourseBundle\Entity\CDocument;
 use Chamilo\CourseBundle\Entity\CForum;
 use Chamilo\CourseBundle\Entity\CLp;
 use Chamilo\CourseBundle\Entity\CQuiz;
+use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\QueryBuilder;
 use Mcp\Capability\Attribute\McpTool;
 use RuntimeException;
 use Symfony\Bundle\SecurityBundle\Security;
@@ -131,19 +133,23 @@ final readonly class CourseOverviewTool
     private function createBaseCourseResourceCountQuery(
         string $resourceClass,
         Course $course,
-    ): \Doctrine\ORM\QueryBuilder {
+    ): QueryBuilder {
         return $this->entityManager
             ->createQueryBuilder()
             ->select('COUNT(DISTINCT resource.iid)')
             ->from($resourceClass, 'resource')
             ->innerJoin('resource.resourceNode', 'node')
             ->innerJoin('node.resourceLinks', 'resourceLink')
-            ->andWhere('resourceLink.course = :course')
+            ->andWhere('IDENTITY(resourceLink.course) = :courseId')
             ->andWhere('resourceLink.session IS NULL')
             ->andWhere('resourceLink.group IS NULL')
             ->andWhere('resourceLink.userGroup IS NULL')
             ->andWhere('resourceLink.user IS NULL')
-            ->setParameter('course', $course)
+            ->setParameter(
+                'courseId',
+                (int) $course->getId(),
+                Types::INTEGER,
+            )
         ;
     }
 }

--- a/src/CoreBundle/Mcp/CourseOverviewTool.php
+++ b/src/CoreBundle/Mcp/CourseOverviewTool.php
@@ -1,0 +1,149 @@
+<?php
+
+/* For licensing terms, see /license.txt */
+
+declare(strict_types=1);
+
+namespace Chamilo\CoreBundle\Mcp;
+
+use Chamilo\CoreBundle\Entity\AbstractResource;
+use Chamilo\CoreBundle\Entity\Course;
+use Chamilo\CoreBundle\Entity\User;
+use Chamilo\CoreBundle\Helpers\AccessUrlHelper;
+use Chamilo\CoreBundle\Repository\CourseRelUserRepository;
+use Chamilo\CourseBundle\Entity\CDocument;
+use Chamilo\CourseBundle\Entity\CForum;
+use Chamilo\CourseBundle\Entity\CLp;
+use Chamilo\CourseBundle\Entity\CQuiz;
+use Doctrine\ORM\EntityManagerInterface;
+use Mcp\Capability\Attribute\McpTool;
+use RuntimeException;
+use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\Security\Core\Exception\AccessDeniedException;
+
+final readonly class CourseOverviewTool
+{
+    public function __construct(
+        private Security $security,
+        private AccessUrlHelper $accessUrlHelper,
+        private CourseRelUserRepository $courseRelUserRepository,
+        private EntityManagerInterface $entityManager,
+    ) {}
+
+    /**
+     * @return array{
+     *     scope: string,
+     *     course: array{
+     *         course_id: int,
+     *         title: string,
+     *         code: string,
+     *         visual_code: string|null,
+     *         language: string,
+     *         visibility: int,
+     *         description: string|null
+     *     },
+     *     metrics: array{
+     *         direct_students: int,
+     *         documents: int,
+     *         tests: int,
+     *         learning_paths: int,
+     *         forums: int
+     *     }
+     * }
+     */
+    #[McpTool(
+        name: 'get_course_overview',
+        description: 'Return base-course information and resource counts for a course managed by the authenticated teacher.',
+    )]
+    public function getCourseOverview(int $courseId): array
+    {
+        if ($courseId <= 0) {
+            throw new RuntimeException('The course ID must be a positive integer.');
+        }
+
+        $user = $this->security->getUser();
+        if (!$user instanceof User || null === $user->getId()) {
+            throw new AccessDeniedException('An authenticated Chamilo user is required.');
+        }
+
+        $accessUrl = $this->accessUrlHelper->getCurrent();
+        if (null === $accessUrl) {
+            throw new RuntimeException('The current Chamilo access URL could not be resolved.');
+        }
+
+        $course = $this->courseRelUserRepository->findTeacherCourseForUserAndAccessUrl(
+            $user,
+            $accessUrl,
+            $courseId,
+        );
+
+        if (!$course instanceof Course) {
+            throw new AccessDeniedException('The course was not found or is not managed by the authenticated teacher.');
+        }
+
+        return [
+            'scope' => 'base_course',
+            'course' => [
+                'course_id' => (int) $course->getId(),
+                'title' => $course->getTitle(),
+                'code' => $course->getCode(),
+                'visual_code' => $course->getVisualCode(),
+                'language' => $course->getCourseLanguage(),
+                'visibility' => $course->getVisibility(),
+                'description' => $course->getDescription(),
+            ],
+            'metrics' => [
+                'direct_students' => $this->courseRelUserRepository->countDirectStudentsForCourse($course),
+                'documents' => $this->countBaseCourseDocuments($course),
+                'tests' => $this->countBaseCourseResources(CQuiz::class, $course),
+                'learning_paths' => $this->countBaseCourseResources(CLp::class, $course),
+                'forums' => $this->countBaseCourseResources(CForum::class, $course),
+            ],
+        ];
+    }
+
+    private function countBaseCourseDocuments(Course $course): int
+    {
+        return (int) $this->createBaseCourseResourceCountQuery(CDocument::class, $course)
+            ->andWhere('resource.filetype != :folderType')
+            ->andWhere('resource.template = :isTemplate')
+            ->setParameter('folderType', 'folder')
+            ->setParameter('isTemplate', false)
+            ->getQuery()
+            ->getSingleScalarResult()
+        ;
+    }
+
+    /**
+     * @param class-string<AbstractResource> $resourceClass
+     */
+    private function countBaseCourseResources(string $resourceClass, Course $course): int
+    {
+        return (int) $this->createBaseCourseResourceCountQuery($resourceClass, $course)
+            ->getQuery()
+            ->getSingleScalarResult()
+        ;
+    }
+
+    /**
+     * @param class-string<AbstractResource> $resourceClass
+     */
+    private function createBaseCourseResourceCountQuery(
+        string $resourceClass,
+        Course $course,
+    ): \Doctrine\ORM\QueryBuilder {
+        return $this->entityManager
+            ->createQueryBuilder()
+            ->select('COUNT(DISTINCT resource.iid)')
+            ->from($resourceClass, 'resource')
+            ->innerJoin('resource.resourceNode', 'node')
+            ->innerJoin('node.resourceLinks', 'resourceLink')
+            ->andWhere('resourceLink.course = :course')
+            ->andWhere('resourceLink.session IS NULL')
+            ->andWhere('resourceLink.group IS NULL')
+            ->andWhere('resourceLink.userGroup IS NULL')
+            ->andWhere('resourceLink.user IS NULL')
+            ->setParameter('course', $course)
+        ;
+    }
+}

--- a/src/CoreBundle/Mcp/CreateCourseAssignmentTool.php
+++ b/src/CoreBundle/Mcp/CreateCourseAssignmentTool.php
@@ -57,11 +57,7 @@ final readonly class CreateCourseAssignmentTool
         } catch (AccessDeniedException|InvalidArgumentException|RuntimeException $exception) {
             throw new ToolCallException($exception->getMessage());
         } catch (Throwable $throwable) {
-            throw new ToolCallException(
-                'The assignment could not be created because of an unexpected server error. Check the Chamilo log for technical details.',
-                0,
-                $throwable,
-            );
+            throw new ToolCallException('The assignment could not be created because of an unexpected server error. Check the Chamilo log for technical details.', 0, $throwable);
         }
     }
 }

--- a/src/CoreBundle/Mcp/CreateCourseAssignmentTool.php
+++ b/src/CoreBundle/Mcp/CreateCourseAssignmentTool.php
@@ -1,0 +1,67 @@
+<?php
+
+/* For licensing terms, see /license.txt */
+
+declare(strict_types=1);
+
+namespace Chamilo\CoreBundle\Mcp;
+
+use Chamilo\CoreBundle\Service\Assignment\McpCourseAssignmentCreator;
+use Chamilo\CoreBundle\Service\Mcp\McpTeacherCourseContext;
+use InvalidArgumentException;
+use Mcp\Capability\Attribute\McpTool;
+use Mcp\Exception\ToolCallException;
+use RuntimeException;
+use Symfony\Component\Security\Core\Exception\AccessDeniedException;
+use Throwable;
+
+final readonly class CreateCourseAssignmentTool
+{
+    public function __construct(
+        private McpTeacherCourseContext $courseContext,
+        private McpCourseAssignmentCreator $assignmentCreator,
+    ) {}
+
+    /**
+     * @return array{created: true, assignment: array<string, mixed>}
+     */
+    #[McpTool(
+        name: 'create_course_assignment',
+        description: 'Create an assignment with a description and maximum score in a base course managed by the authenticated teacher. The assignment is a draft unless publish is true.',
+    )]
+    public function createCourseAssignment(
+        int $courseId,
+        string $title,
+        string $description,
+        float $maximumScore,
+        bool $publish = false,
+        int $submissionMode = 0,
+    ): array {
+        try {
+            $context = $this->courseContext->resolve($courseId);
+
+            return [
+                'created' => true,
+                'assignment' => $this->assignmentCreator->create(
+                    $context['course'],
+                    $context['user'],
+                    $title,
+                    $description,
+                    $maximumScore,
+                    $publish,
+                    $submissionMode,
+                ),
+            ];
+        } catch (ToolCallException $exception) {
+            throw $exception;
+        } catch (AccessDeniedException|InvalidArgumentException|RuntimeException $exception) {
+            throw new ToolCallException($exception->getMessage());
+        } catch (Throwable $throwable) {
+            throw new ToolCallException(
+                'The assignment could not be created because of an unexpected server error. Check the Chamilo log for technical details.',
+                0,
+                $throwable,
+            );
+        }
+    }
+}

--- a/src/CoreBundle/Mcp/CreateCourseDocumentTool.php
+++ b/src/CoreBundle/Mcp/CreateCourseDocumentTool.php
@@ -20,12 +20,19 @@ use Chamilo\CourseBundle\Repository\CDocumentRepository;
 use Doctrine\ORM\EntityManager;
 use InvalidArgumentException;
 use Mcp\Capability\Attribute\McpTool;
+use Mcp\Exception\ToolCallException;
 use RuntimeException;
 use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\KernelInterface;
 use Symfony\Component\Security\Core\Exception\AccessDeniedException;
 use Symfony\Contracts\Translation\TranslatorInterface;
+use Throwable;
+
+use const ENT_HTML5;
+use const ENT_QUOTES;
+use const JSON_THROW_ON_ERROR;
+use const PREG_SPLIT_NO_EMPTY;
 
 final readonly class CreateCourseDocumentTool
 {
@@ -62,6 +69,7 @@ final readonly class CreateCourseDocumentTool
      *         word_count_within_20_percent: bool,
      *         published: bool,
      *         ai_assisted: true,
+     *         content_type: 'text/html',
      *         content_url: string
      *     }
      * }
@@ -78,6 +86,54 @@ final readonly class CreateCourseDocumentTool
         string $content,
         ?string $language = null,
         bool $publish = true,
+    ): array {
+        try {
+            return $this->doCreateCourseDocument(
+                $courseId,
+                $title,
+                $topic,
+                $requestedWordCount,
+                $content,
+                $language,
+                $publish,
+            );
+        } catch (ToolCallException $exception) {
+            throw $exception;
+        } catch (AccessDeniedException|InvalidArgumentException|RuntimeException $exception) {
+            throw new ToolCallException($exception->getMessage());
+        } catch (Throwable $throwable) {
+            throw new ToolCallException('The course document could not be created because of an unexpected server error. Check the Chamilo log for technical details.', 0, $throwable);
+        }
+    }
+
+    /**
+     * @return array{
+     *     created: true,
+     *     document: array{
+     *         document_id: int,
+     *         resource_node_id: int,
+     *         parent_resource_node_id: int,
+     *         title: string,
+     *         file_name: string|null,
+     *         topic: string,
+     *         requested_word_count: int,
+     *         actual_word_count: int,
+     *         word_count_within_20_percent: bool,
+     *         published: bool,
+     *         ai_assisted: true,
+     *         content_type: 'text/html',
+     *         content_url: string
+     *     }
+     * }
+     */
+    private function doCreateCourseDocument(
+        int $courseId,
+        string $title,
+        string $topic,
+        int $requestedWordCount,
+        string $content,
+        ?string $language,
+        bool $publish,
     ): array {
         if ($courseId <= 0) {
             throw new InvalidArgumentException('The course ID must be a positive integer.');
@@ -100,9 +156,7 @@ final readonly class CreateCourseDocumentTool
         );
 
         if (null === $course) {
-            throw new AccessDeniedException(
-                'The course was not found or is not managed by the authenticated teacher.'
-            );
+            throw new AccessDeniedException('The course was not found or is not managed by the authenticated teacher.');
         }
 
         $title = trim(strip_tags($title));
@@ -127,13 +181,7 @@ final readonly class CreateCourseDocumentTool
             $requestedWordCount < self::MIN_REQUESTED_WORDS
             || $requestedWordCount > self::MAX_REQUESTED_WORDS
         ) {
-            throw new InvalidArgumentException(
-                \sprintf(
-                    'The requested word count must be between %d and %d.',
-                    self::MIN_REQUESTED_WORDS,
-                    self::MAX_REQUESTED_WORDS
-                )
-            );
+            throw new InvalidArgumentException(\sprintf('The requested word count must be between %d and %d.', self::MIN_REQUESTED_WORDS, self::MAX_REQUESTED_WORDS));
         }
 
         $content = trim($content);
@@ -185,17 +233,17 @@ final readonly class CreateCourseDocumentTool
                         'parentResourceNodeId' => (int) $courseResourceNode->getId(),
                         'resourceLinkList' => json_encode(
                             [['visibility' => $visibility]],
-                            JSON_THROW_ON_ERROR
+                            JSON_THROW_ON_ERROR,
                         ),
                         'ai_assisted' => '1',
                     ],
                     [],
                     [],
                     [],
-                    ''
+                    '',
                 );
 
-                return ($this->createDocumentFileAction)(
+                $document = ($this->createDocumentFileAction)(
                     $request,
                     $this->documentRepository,
                     $this->entityManager,
@@ -205,6 +253,20 @@ final readonly class CreateCourseDocumentTool
                     $this->courseHelper,
                     $this->aiDisclosureHelper,
                 );
+
+                $resourceFile = $document->getResourceNode()?->getFirstResourceFile();
+
+                if (!$resourceFile instanceof ResourceFile) {
+                    throw new RuntimeException('Chamilo created the HTML document without a resource file.');
+                }
+
+                // Vich/Finfo can detect short HTML fragments as text/plain.
+                // The tool created and sanitized an HTML file explicitly, so
+                // normalize the persisted metadata after Vich processed it.
+                $resourceFile->setMimeType('text/html');
+                $this->entityManager->persist($resourceFile);
+
+                return $document;
             }
         );
 
@@ -240,9 +302,10 @@ final readonly class CreateCourseDocumentTool
                     && $actualWordCount <= $maximumExpected,
                 'published' => $publish,
                 'ai_assisted' => true,
+                'content_type' => 'text/html',
                 'content_url' => $this->documentRepository->getResourceFileUrl(
                     $document,
-                    ['cid' => $courseId]
+                    ['cid' => $courseId],
                 ),
             ],
         ];
@@ -257,7 +320,7 @@ final readonly class CreateCourseDocumentTool
         if (\defined('COURSEMANAGERLOWSECURITY')) {
             return (string) \Security::remove_XSS(
                 $content,
-                (int) \constant('COURSEMANAGERLOWSECURITY')
+                (int) \constant('COURSEMANAGERLOWSECURITY'),
             );
         }
 
@@ -269,7 +332,7 @@ final readonly class CreateCourseDocumentTool
         $plainText = html_entity_decode(
             strip_tags($html),
             ENT_QUOTES | ENT_HTML5,
-            'UTF-8'
+            'UTF-8',
         );
         $plainText = trim((string) preg_replace('/\s+/u', ' ', $plainText));
 

--- a/src/CoreBundle/Mcp/CreateCourseDocumentTool.php
+++ b/src/CoreBundle/Mcp/CreateCourseDocumentTool.php
@@ -53,7 +53,7 @@ final readonly class CreateCourseDocumentTool
      *     document: array{
      *         document_id: int,
      *         resource_node_id: int,
-     *         documents_root_node_id: int,
+     *         parent_resource_node_id: int,
      *         title: string,
      *         file_name: string|null,
      *         topic: string,
@@ -166,7 +166,10 @@ final readonly class CreateCourseDocumentTool
         /** @var CDocument $document */
         $document = $this->entityManager->wrapInTransaction(
             function () use ($course, $courseId, $title, $topic, $content, $language, $visibility): CDocument {
-                $documentsRoot = $this->documentRepository->ensureCourseDocumentsRootNode($course);
+                $courseResourceNode = $course->getResourceNode();
+                if (null === $courseResourceNode || null === $courseResourceNode->getId()) {
+                    throw new RuntimeException('The course resource node could not be resolved.');
+                }
 
                 $request = Request::create(
                     '/api/documents?cid='.$courseId,
@@ -179,7 +182,7 @@ final readonly class CreateCourseDocumentTool
                         'contentFileExtension' => 'html',
                         'contentFileMimeType' => 'text/html',
                         'language' => $language ?? '',
-                        'parentResourceNodeId' => (int) $documentsRoot->getId(),
+                        'parentResourceNodeId' => (int) $courseResourceNode->getId(),
                         'resourceLinkList' => json_encode(
                             [['visibility' => $visibility]],
                             JSON_THROW_ON_ERROR
@@ -213,11 +216,6 @@ final readonly class CreateCourseDocumentTool
             throw new RuntimeException('Chamilo created an incomplete document resource.');
         }
 
-        $documentsRoot = $this->documentRepository->getCourseDocumentsRootNode($course);
-        if (null === $documentsRoot || null === $documentsRoot->getId()) {
-            throw new RuntimeException('The course Documents root could not be resolved.');
-        }
-
         $resourceFile = $resourceNode?->getFirstResourceFile();
         $fileName = $resourceFile instanceof ResourceFile
             ? ($resourceFile->getOriginalName() ?: $resourceFile->getTitle())
@@ -232,7 +230,7 @@ final readonly class CreateCourseDocumentTool
             'document' => [
                 'document_id' => $documentId,
                 'resource_node_id' => $resourceNodeId,
-                'documents_root_node_id' => (int) $documentsRoot->getId(),
+                'parent_resource_node_id' => (int) $course->getResourceNode()?->getId(),
                 'title' => $document->getTitle(),
                 'file_name' => $fileName,
                 'topic' => $topic,

--- a/src/CoreBundle/Mcp/CreateCourseDocumentTool.php
+++ b/src/CoreBundle/Mcp/CreateCourseDocumentTool.php
@@ -1,0 +1,286 @@
+<?php
+
+/* For licensing terms, see /license.txt */
+
+declare(strict_types=1);
+
+namespace Chamilo\CoreBundle\Mcp;
+
+use Chamilo\CoreBundle\Controller\Api\CreateDocumentFileAction;
+use Chamilo\CoreBundle\Entity\ResourceFile;
+use Chamilo\CoreBundle\Entity\ResourceLink;
+use Chamilo\CoreBundle\Entity\User;
+use Chamilo\CoreBundle\Helpers\AccessUrlHelper;
+use Chamilo\CoreBundle\Helpers\AiDisclosureHelper;
+use Chamilo\CoreBundle\Helpers\CourseHelper;
+use Chamilo\CoreBundle\Repository\CourseRelUserRepository;
+use Chamilo\CoreBundle\Repository\Node\CourseRepository;
+use Chamilo\CourseBundle\Entity\CDocument;
+use Chamilo\CourseBundle\Repository\CDocumentRepository;
+use Doctrine\ORM\EntityManager;
+use InvalidArgumentException;
+use Mcp\Capability\Attribute\McpTool;
+use RuntimeException;
+use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\KernelInterface;
+use Symfony\Component\Security\Core\Exception\AccessDeniedException;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+final readonly class CreateCourseDocumentTool
+{
+    private const MAX_CONTENT_LENGTH = 2_000_000;
+    private const MAX_REQUESTED_WORDS = 5_000;
+    private const MIN_REQUESTED_WORDS = 50;
+
+    public function __construct(
+        private Security $security,
+        private AccessUrlHelper $accessUrlHelper,
+        private CourseRelUserRepository $courseRelUserRepository,
+        private CDocumentRepository $documentRepository,
+        private CreateDocumentFileAction $createDocumentFileAction,
+        private EntityManager $entityManager,
+        private KernelInterface $kernel,
+        private TranslatorInterface $translator,
+        private CourseRepository $courseRepository,
+        private CourseHelper $courseHelper,
+        private AiDisclosureHelper $aiDisclosureHelper,
+    ) {}
+
+    /**
+     * @return array{
+     *     created: true,
+     *     document: array{
+     *         document_id: int,
+     *         resource_node_id: int,
+     *         documents_root_node_id: int,
+     *         title: string,
+     *         file_name: string|null,
+     *         topic: string,
+     *         requested_word_count: int,
+     *         actual_word_count: int,
+     *         word_count_within_20_percent: bool,
+     *         published: bool,
+     *         ai_assisted: true,
+     *         content_url: string
+     *     }
+     * }
+     */
+    #[McpTool(
+        name: 'create_course_document',
+        description: 'Create an AI-assisted HTML document in the root Documents folder of a course managed by the authenticated teacher. The MCP client must supply the generated HTML content.',
+    )]
+    public function createCourseDocument(
+        int $courseId,
+        string $title,
+        string $topic,
+        int $requestedWordCount,
+        string $content,
+        ?string $language = null,
+        bool $publish = true,
+    ): array {
+        if ($courseId <= 0) {
+            throw new InvalidArgumentException('The course ID must be a positive integer.');
+        }
+
+        $user = $this->security->getUser();
+        if (!$user instanceof User || null === $user->getId()) {
+            throw new AccessDeniedException('An authenticated Chamilo user is required.');
+        }
+
+        $accessUrl = $this->accessUrlHelper->getCurrent();
+        if (null === $accessUrl) {
+            throw new RuntimeException('The current Chamilo access URL could not be resolved.');
+        }
+
+        $course = $this->courseRelUserRepository->findTeacherCourseForUserAndAccessUrl(
+            $user,
+            $accessUrl,
+            $courseId,
+        );
+
+        if (null === $course) {
+            throw new AccessDeniedException(
+                'The course was not found or is not managed by the authenticated teacher.'
+            );
+        }
+
+        $title = trim(strip_tags($title));
+        if ('' === $title) {
+            throw new InvalidArgumentException('The document title is required.');
+        }
+
+        if (mb_strlen($title) > 250) {
+            throw new InvalidArgumentException('The document title cannot be longer than 250 characters.');
+        }
+
+        $topic = trim(strip_tags($topic));
+        if ('' === $topic) {
+            throw new InvalidArgumentException('The document topic is required.');
+        }
+
+        if (mb_strlen($topic) > 500) {
+            throw new InvalidArgumentException('The document topic cannot be longer than 500 characters.');
+        }
+
+        if (
+            $requestedWordCount < self::MIN_REQUESTED_WORDS
+            || $requestedWordCount > self::MAX_REQUESTED_WORDS
+        ) {
+            throw new InvalidArgumentException(
+                \sprintf(
+                    'The requested word count must be between %d and %d.',
+                    self::MIN_REQUESTED_WORDS,
+                    self::MAX_REQUESTED_WORDS
+                )
+            );
+        }
+
+        $content = trim($content);
+        if ('' === $content) {
+            throw new InvalidArgumentException('The document HTML content is required.');
+        }
+
+        if (mb_strlen($content) > self::MAX_CONTENT_LENGTH) {
+            throw new InvalidArgumentException('The document HTML content is too large.');
+        }
+
+        $content = $this->sanitizeHtml($content);
+        if ('' === trim(strip_tags($content))) {
+            throw new InvalidArgumentException('The document content is empty after sanitization.');
+        }
+
+        $language = null !== $language ? trim($language) : null;
+        if ('' === $language) {
+            $language = null;
+        }
+
+        if (null !== $language && !preg_match('/^[a-zA-Z0-9_-]{1,8}$/', $language)) {
+            throw new InvalidArgumentException('The document language code is invalid.');
+        }
+
+        $visibility = $publish
+            ? ResourceLink::VISIBILITY_PUBLISHED
+            : ResourceLink::VISIBILITY_DRAFT;
+
+        /** @var CDocument $document */
+        $document = $this->entityManager->wrapInTransaction(
+            function () use ($course, $courseId, $title, $topic, $content, $language, $visibility): CDocument {
+                $documentsRoot = $this->documentRepository->ensureCourseDocumentsRootNode($course);
+
+                $request = Request::create(
+                    '/api/documents?cid='.$courseId,
+                    'POST',
+                    [
+                        'title' => $title,
+                        'filetype' => 'file',
+                        'comment' => $topic,
+                        'contentFile' => $content,
+                        'contentFileExtension' => 'html',
+                        'contentFileMimeType' => 'text/html',
+                        'language' => $language ?? '',
+                        'parentResourceNodeId' => (int) $documentsRoot->getId(),
+                        'resourceLinkList' => json_encode(
+                            [['visibility' => $visibility]],
+                            JSON_THROW_ON_ERROR
+                        ),
+                        'ai_assisted' => '1',
+                    ],
+                    [],
+                    [],
+                    [],
+                    ''
+                );
+
+                return ($this->createDocumentFileAction)(
+                    $request,
+                    $this->documentRepository,
+                    $this->entityManager,
+                    $this->kernel,
+                    $this->translator,
+                    $this->courseRepository,
+                    $this->courseHelper,
+                    $this->aiDisclosureHelper,
+                );
+            }
+        );
+
+        $documentId = (int) ($document->getIid() ?? 0);
+        $resourceNode = $document->getResourceNode();
+        $resourceNodeId = (int) ($resourceNode?->getId() ?? 0);
+
+        if ($documentId <= 0 || $resourceNodeId <= 0) {
+            throw new RuntimeException('Chamilo created an incomplete document resource.');
+        }
+
+        $documentsRoot = $this->documentRepository->getCourseDocumentsRootNode($course);
+        if (null === $documentsRoot || null === $documentsRoot->getId()) {
+            throw new RuntimeException('The course Documents root could not be resolved.');
+        }
+
+        $resourceFile = $resourceNode?->getFirstResourceFile();
+        $fileName = $resourceFile instanceof ResourceFile
+            ? ($resourceFile->getOriginalName() ?: $resourceFile->getTitle())
+            : null;
+
+        $actualWordCount = $this->countWords($content);
+        $minimumExpected = (int) floor($requestedWordCount * 0.8);
+        $maximumExpected = (int) ceil($requestedWordCount * 1.2);
+
+        return [
+            'created' => true,
+            'document' => [
+                'document_id' => $documentId,
+                'resource_node_id' => $resourceNodeId,
+                'documents_root_node_id' => (int) $documentsRoot->getId(),
+                'title' => $document->getTitle(),
+                'file_name' => $fileName,
+                'topic' => $topic,
+                'requested_word_count' => $requestedWordCount,
+                'actual_word_count' => $actualWordCount,
+                'word_count_within_20_percent' => $actualWordCount >= $minimumExpected
+                    && $actualWordCount <= $maximumExpected,
+                'published' => $publish,
+                'ai_assisted' => true,
+                'content_url' => $this->documentRepository->getResourceFileUrl(
+                    $document,
+                    ['cid' => $courseId]
+                ),
+            ],
+        ];
+    }
+
+    private function sanitizeHtml(string $content): string
+    {
+        if (!class_exists(\Security::class)) {
+            throw new RuntimeException('The Chamilo HTML security service is unavailable.');
+        }
+
+        if (\defined('COURSEMANAGERLOWSECURITY')) {
+            return (string) \Security::remove_XSS(
+                $content,
+                (int) \constant('COURSEMANAGERLOWSECURITY')
+            );
+        }
+
+        return (string) \Security::remove_XSS($content);
+    }
+
+    private function countWords(string $html): int
+    {
+        $plainText = html_entity_decode(
+            strip_tags($html),
+            ENT_QUOTES | ENT_HTML5,
+            'UTF-8'
+        );
+        $plainText = trim((string) preg_replace('/\s+/u', ' ', $plainText));
+
+        if ('' === $plainText) {
+            return 0;
+        }
+
+        $words = preg_split('/\s+/u', $plainText, -1, PREG_SPLIT_NO_EMPTY);
+
+        return \is_array($words) ? \count($words) : 0;
+    }
+}

--- a/src/CoreBundle/Mcp/CreateCourseIllustrationTool.php
+++ b/src/CoreBundle/Mcp/CreateCourseIllustrationTool.php
@@ -12,10 +12,10 @@ use Chamilo\CoreBundle\Entity\ResourceFile;
 use Chamilo\CoreBundle\Entity\User;
 use Chamilo\CoreBundle\Helpers\AccessUrlHelper;
 use Chamilo\CoreBundle\Helpers\AiDisclosureHelper;
-use Chamilo\CoreBundle\Service\Mcp\McpCourseAiFeatureManager;
 use Chamilo\CoreBundle\Repository\CourseRelUserRepository;
 use Chamilo\CoreBundle\Service\Ai\AiRequestQuotaGuard;
 use Chamilo\CoreBundle\Service\Ai\GeneratedMediaStorageService;
+use Chamilo\CoreBundle\Service\Mcp\McpCourseAiFeatureManager;
 use Chamilo\CourseBundle\Repository\CDocumentRepository;
 use InvalidArgumentException;
 use Mcp\Capability\Attribute\McpTool;
@@ -88,15 +88,11 @@ final readonly class CreateCourseIllustrationTool
         } catch (ToolCallException $exception) {
             throw $exception;
         } catch (
-            InvalidArgumentException
-            | RuntimeException
-            | AccessDeniedException $exception
+            AccessDeniedException|InvalidArgumentException|RuntimeException $exception
         ) {
             throw new ToolCallException($exception->getMessage());
         } catch (Throwable) {
-            throw new ToolCallException(
-                'The illustration could not be created because of an unexpected server error. Check the Chamilo log for technical details.'
-            );
+            throw new ToolCallException('The illustration could not be created because of an unexpected server error. Check the Chamilo log for technical details.');
         }
     }
 
@@ -131,23 +127,17 @@ final readonly class CreateCourseIllustrationTool
         bool $publish,
     ): array {
         if ($courseId <= 0) {
-            throw new InvalidArgumentException(
-                'The course ID must be a positive integer.'
-            );
+            throw new InvalidArgumentException('The course ID must be a positive integer.');
         }
 
         $user = $this->security->getUser();
         if (!$user instanceof User || null === $user->getId()) {
-            throw new AccessDeniedException(
-                'An authenticated Chamilo user is required.'
-            );
+            throw new AccessDeniedException('An authenticated Chamilo user is required.');
         }
 
         $accessUrl = $this->accessUrlHelper->getCurrent();
         if (null === $accessUrl) {
-            throw new RuntimeException(
-                'The current Chamilo access URL could not be resolved.'
-            );
+            throw new RuntimeException('The current Chamilo access URL could not be resolved.');
         }
 
         $course = $this->courseRelUserRepository
@@ -155,12 +145,11 @@ final readonly class CreateCourseIllustrationTool
                 $user,
                 $accessUrl,
                 $courseId,
-            );
+            )
+        ;
 
         if (null === $course) {
-            throw new AccessDeniedException(
-                'The course was not found or is not managed by the authenticated teacher.'
-            );
+            throw new AccessDeniedException('The course was not found or is not managed by the authenticated teacher.');
         }
 
         $enabledFeatures = $this->courseAiFeatureManager->ensureEnabled(
@@ -172,28 +161,20 @@ final readonly class CreateCourseIllustrationTool
 
         $title = trim(strip_tags($title));
         if ('' === $title) {
-            throw new InvalidArgumentException(
-                'The illustration title is required.'
-            );
+            throw new InvalidArgumentException('The illustration title is required.');
         }
 
         if (mb_strlen($title) > 180) {
-            throw new InvalidArgumentException(
-                'The illustration title cannot be longer than 180 characters.'
-            );
+            throw new InvalidArgumentException('The illustration title cannot be longer than 180 characters.');
         }
 
         $topic = trim(strip_tags($topic));
         if ('' === $topic) {
-            throw new InvalidArgumentException(
-                'The illustration topic is required.'
-            );
+            throw new InvalidArgumentException('The illustration topic is required.');
         }
 
         if (mb_strlen($topic) > 1_000) {
-            throw new InvalidArgumentException(
-                'The illustration topic cannot be longer than 1000 characters.'
-            );
+            throw new InvalidArgumentException('The illustration topic cannot be longer than 1000 characters.');
         }
 
         $prompt = null !== $prompt ? trim($prompt) : '';
@@ -202,9 +183,7 @@ final readonly class CreateCourseIllustrationTool
         }
 
         if (mb_strlen($prompt) > self::MAX_PROMPT_LENGTH) {
-            throw new InvalidArgumentException(
-                'The image prompt cannot be longer than 4000 characters.'
-            );
+            throw new InvalidArgumentException('The image prompt cannot be longer than 4000 characters.');
         }
 
         $language = null !== $language ? trim($language) : '';
@@ -213,18 +192,15 @@ final readonly class CreateCourseIllustrationTool
         }
 
         if (!preg_match('/^[a-zA-Z0-9_-]{1,20}$/', $language)) {
-            throw new InvalidArgumentException(
-                'The image language code is invalid.'
-            );
+            throw new InvalidArgumentException('The image language code is invalid.');
         }
 
         $availableProviders = $this->aiProviderFactory
-            ->getProvidersForType('image');
+            ->getProvidersForType('image')
+        ;
 
         if ([] === $availableProviders) {
-            throw new RuntimeException(
-                'No AI providers are configured for image generation.'
-            );
+            throw new RuntimeException('No AI providers are configured for image generation.');
         }
 
         $provider = null !== $provider ? trim($provider) : '';
@@ -233,9 +209,7 @@ final readonly class CreateCourseIllustrationTool
         }
 
         if (!\in_array($provider, $availableProviders, true)) {
-            throw new InvalidArgumentException(
-                'The selected AI image provider is not available.'
-            );
+            throw new InvalidArgumentException('The selected AI image provider is not available.');
         }
 
         $this->quotaGuard->assertCanRequest(
@@ -245,12 +219,11 @@ final readonly class CreateCourseIllustrationTool
         );
 
         $imageProvider = $this->aiProviderFactory
-            ->getProvider($provider, 'image');
+            ->getProvider($provider, 'image')
+        ;
 
         if (!$imageProvider instanceof AiImageProviderInterface) {
-            throw new RuntimeException(
-                'The selected provider does not support image generation.'
-            );
+            throw new RuntimeException('The selected provider does not support image generation.');
         }
 
         $generatedResult = $imageProvider->generateImage(
@@ -264,9 +237,7 @@ final readonly class CreateCourseIllustrationTool
         );
 
         if (null === $generatedResult || [] === $generatedResult) {
-            throw new RuntimeException(
-                'The AI provider returned an empty image.'
-            );
+            throw new RuntimeException('The AI provider returned an empty image.');
         }
 
         if (
@@ -294,9 +265,7 @@ final readonly class CreateCourseIllustrationTool
         $resourceNodeId = (int) ($resourceNode?->getId() ?? 0);
 
         if ($documentId <= 0 || $resourceNodeId <= 0) {
-            throw new RuntimeException(
-                'Chamilo created an incomplete illustration resource.'
-            );
+            throw new RuntimeException('Chamilo created an incomplete illustration resource.');
         }
 
         $resourceFile = $resourceNode?->getFirstResourceFile();

--- a/src/CoreBundle/Mcp/CreateCourseIllustrationTool.php
+++ b/src/CoreBundle/Mcp/CreateCourseIllustrationTool.php
@@ -12,7 +12,7 @@ use Chamilo\CoreBundle\Entity\ResourceFile;
 use Chamilo\CoreBundle\Entity\User;
 use Chamilo\CoreBundle\Helpers\AccessUrlHelper;
 use Chamilo\CoreBundle\Helpers\AiDisclosureHelper;
-use Chamilo\CoreBundle\Helpers\AiFeatureAccessHelper;
+use Chamilo\CoreBundle\Service\Mcp\McpCourseAiFeatureManager;
 use Chamilo\CoreBundle\Repository\CourseRelUserRepository;
 use Chamilo\CoreBundle\Service\Ai\AiRequestQuotaGuard;
 use Chamilo\CoreBundle\Service\Ai\GeneratedMediaStorageService;
@@ -33,7 +33,7 @@ final readonly class CreateCourseIllustrationTool
         private Security $security,
         private AccessUrlHelper $accessUrlHelper,
         private CourseRelUserRepository $courseRelUserRepository,
-        private AiFeatureAccessHelper $aiFeatureAccessHelper,
+        private McpCourseAiFeatureManager $courseAiFeatureManager,
         private AiProviderFactory $aiProviderFactory,
         private AiRequestQuotaGuard $quotaGuard,
         private GeneratedMediaStorageService $mediaStorage,
@@ -163,16 +163,12 @@ final readonly class CreateCourseIllustrationTool
             );
         }
 
-        if (
-            !$this->aiFeatureAccessHelper->isFeatureEnabledForCourse(
-                'image_generator',
-                $courseId,
-            )
-        ) {
-            throw new AccessDeniedException(
-                'Image generation is not enabled for this course.'
-            );
-        }
+        $enabledFeatures = $this->courseAiFeatureManager->ensureEnabled(
+            $course,
+            $user,
+            'image_generator',
+            'create_course_illustration',
+        );
 
         $title = trim(strip_tags($title));
         if ('' === $title) {
@@ -329,6 +325,7 @@ final readonly class CreateCourseIllustrationTool
 
         return [
             'created' => true,
+            'course_features_enabled' => $enabledFeatures,
             'illustration' => [
                 'document_id' => $documentId,
                 'resource_node_id' => $resourceNodeId,

--- a/src/CoreBundle/Mcp/CreateCourseIllustrationTool.php
+++ b/src/CoreBundle/Mcp/CreateCourseIllustrationTool.php
@@ -1,0 +1,359 @@
+<?php
+
+/* For licensing terms, see /license.txt */
+
+declare(strict_types=1);
+
+namespace Chamilo\CoreBundle\Mcp;
+
+use Chamilo\CoreBundle\AiProvider\AiImageProviderInterface;
+use Chamilo\CoreBundle\AiProvider\AiProviderFactory;
+use Chamilo\CoreBundle\Entity\ResourceFile;
+use Chamilo\CoreBundle\Entity\User;
+use Chamilo\CoreBundle\Helpers\AccessUrlHelper;
+use Chamilo\CoreBundle\Helpers\AiDisclosureHelper;
+use Chamilo\CoreBundle\Helpers\AiFeatureAccessHelper;
+use Chamilo\CoreBundle\Repository\CourseRelUserRepository;
+use Chamilo\CoreBundle\Service\Ai\AiRequestQuotaGuard;
+use Chamilo\CoreBundle\Service\Ai\GeneratedMediaStorageService;
+use Chamilo\CourseBundle\Repository\CDocumentRepository;
+use InvalidArgumentException;
+use Mcp\Capability\Attribute\McpTool;
+use Mcp\Exception\ToolCallException;
+use RuntimeException;
+use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\Security\Core\Exception\AccessDeniedException;
+use Throwable;
+
+final readonly class CreateCourseIllustrationTool
+{
+    private const MAX_PROMPT_LENGTH = 4_000;
+
+    public function __construct(
+        private Security $security,
+        private AccessUrlHelper $accessUrlHelper,
+        private CourseRelUserRepository $courseRelUserRepository,
+        private AiFeatureAccessHelper $aiFeatureAccessHelper,
+        private AiProviderFactory $aiProviderFactory,
+        private AiRequestQuotaGuard $quotaGuard,
+        private GeneratedMediaStorageService $mediaStorage,
+        private CDocumentRepository $documentRepository,
+        private AiDisclosureHelper $aiDisclosureHelper,
+    ) {}
+
+    /**
+     * @return array{
+     *     created: true,
+     *     illustration: array{
+     *         document_id: int,
+     *         resource_node_id: int,
+     *         parent_resource_node_id: int,
+     *         title: string,
+     *         file_name: string|null,
+     *         topic: string,
+     *         prompt: string,
+     *         provider_used: string,
+     *         revised_prompt: string|null,
+     *         published: bool,
+     *         ai_assisted: true,
+     *         content_type: string|null,
+     *         size: int|null,
+     *         content_url: string
+     *     }
+     * }
+     */
+    #[McpTool(
+        name: 'create_course_illustration',
+        description: 'Generate an AI illustration about a topic and save it as a real file in the Documents tool of a course managed by the authenticated teacher.',
+    )]
+    public function createCourseIllustration(
+        int $courseId,
+        string $title,
+        string $topic,
+        ?string $prompt = null,
+        ?string $language = null,
+        ?string $provider = null,
+        bool $publish = true,
+    ): array {
+        try {
+            return $this->doCreateCourseIllustration(
+                $courseId,
+                $title,
+                $topic,
+                $prompt,
+                $language,
+                $provider,
+                $publish,
+            );
+        } catch (ToolCallException $exception) {
+            throw $exception;
+        } catch (
+            InvalidArgumentException
+            | RuntimeException
+            | AccessDeniedException $exception
+        ) {
+            throw new ToolCallException($exception->getMessage());
+        } catch (Throwable) {
+            throw new ToolCallException(
+                'The illustration could not be created because of an unexpected server error. Check the Chamilo log for technical details.'
+            );
+        }
+    }
+
+    /**
+     * @return array{
+     *     created: true,
+     *     illustration: array{
+     *         document_id: int,
+     *         resource_node_id: int,
+     *         parent_resource_node_id: int,
+     *         title: string,
+     *         file_name: string|null,
+     *         topic: string,
+     *         prompt: string,
+     *         provider_used: string,
+     *         revised_prompt: string|null,
+     *         published: bool,
+     *         ai_assisted: true,
+     *         content_type: string|null,
+     *         size: int|null,
+     *         content_url: string
+     *     }
+     * }
+     */
+    private function doCreateCourseIllustration(
+        int $courseId,
+        string $title,
+        string $topic,
+        ?string $prompt,
+        ?string $language,
+        ?string $provider,
+        bool $publish,
+    ): array {
+        if ($courseId <= 0) {
+            throw new InvalidArgumentException(
+                'The course ID must be a positive integer.'
+            );
+        }
+
+        $user = $this->security->getUser();
+        if (!$user instanceof User || null === $user->getId()) {
+            throw new AccessDeniedException(
+                'An authenticated Chamilo user is required.'
+            );
+        }
+
+        $accessUrl = $this->accessUrlHelper->getCurrent();
+        if (null === $accessUrl) {
+            throw new RuntimeException(
+                'The current Chamilo access URL could not be resolved.'
+            );
+        }
+
+        $course = $this->courseRelUserRepository
+            ->findTeacherCourseForUserAndAccessUrl(
+                $user,
+                $accessUrl,
+                $courseId,
+            );
+
+        if (null === $course) {
+            throw new AccessDeniedException(
+                'The course was not found or is not managed by the authenticated teacher.'
+            );
+        }
+
+        if (
+            !$this->aiFeatureAccessHelper->isFeatureEnabledForCourse(
+                'image_generator',
+                $courseId,
+            )
+        ) {
+            throw new AccessDeniedException(
+                'Image generation is not enabled for this course.'
+            );
+        }
+
+        $title = trim(strip_tags($title));
+        if ('' === $title) {
+            throw new InvalidArgumentException(
+                'The illustration title is required.'
+            );
+        }
+
+        if (mb_strlen($title) > 180) {
+            throw new InvalidArgumentException(
+                'The illustration title cannot be longer than 180 characters.'
+            );
+        }
+
+        $topic = trim(strip_tags($topic));
+        if ('' === $topic) {
+            throw new InvalidArgumentException(
+                'The illustration topic is required.'
+            );
+        }
+
+        if (mb_strlen($topic) > 1_000) {
+            throw new InvalidArgumentException(
+                'The illustration topic cannot be longer than 1000 characters.'
+            );
+        }
+
+        $prompt = null !== $prompt ? trim($prompt) : '';
+        if ('' === $prompt) {
+            $prompt = $topic;
+        }
+
+        if (mb_strlen($prompt) > self::MAX_PROMPT_LENGTH) {
+            throw new InvalidArgumentException(
+                'The image prompt cannot be longer than 4000 characters.'
+            );
+        }
+
+        $language = null !== $language ? trim($language) : '';
+        if ('' === $language) {
+            $language = $course->getCourseLanguage();
+        }
+
+        if (!preg_match('/^[a-zA-Z0-9_-]{1,20}$/', $language)) {
+            throw new InvalidArgumentException(
+                'The image language code is invalid.'
+            );
+        }
+
+        $availableProviders = $this->aiProviderFactory
+            ->getProvidersForType('image');
+
+        if ([] === $availableProviders) {
+            throw new RuntimeException(
+                'No AI providers are configured for image generation.'
+            );
+        }
+
+        $provider = null !== $provider ? trim($provider) : '';
+        if ('' === $provider) {
+            $provider = (string) $availableProviders[0];
+        }
+
+        if (!\in_array($provider, $availableProviders, true)) {
+            throw new InvalidArgumentException(
+                'The selected AI image provider is not available.'
+            );
+        }
+
+        $this->quotaGuard->assertCanRequest(
+            $user,
+            $provider,
+            'image',
+        );
+
+        $imageProvider = $this->aiProviderFactory
+            ->getProvider($provider, 'image');
+
+        if (!$imageProvider instanceof AiImageProviderInterface) {
+            throw new RuntimeException(
+                'The selected provider does not support image generation.'
+            );
+        }
+
+        $generatedResult = $imageProvider->generateImage(
+            $prompt,
+            'document_image_generate',
+            [
+                'language' => $language,
+                'n' => 1,
+                'cid' => $courseId,
+            ],
+        );
+
+        if (null === $generatedResult || [] === $generatedResult) {
+            throw new RuntimeException(
+                'The AI provider returned an empty image.'
+            );
+        }
+
+        if (
+            \is_string($generatedResult)
+            && str_starts_with(
+                strtolower(trim($generatedResult)),
+                'error:',
+            )
+        ) {
+            throw new RuntimeException(trim(substr($generatedResult, 6)));
+        }
+
+        $document = $this->mediaStorage->storeGeneratedImage(
+            $course,
+            $courseId,
+            $title,
+            $topic,
+            $generatedResult,
+            $language,
+            $publish,
+        );
+
+        $documentId = (int) ($document->getIid() ?? 0);
+        $resourceNode = $document->getResourceNode();
+        $resourceNodeId = (int) ($resourceNode?->getId() ?? 0);
+
+        if ($documentId <= 0 || $resourceNodeId <= 0) {
+            throw new RuntimeException(
+                'Chamilo created an incomplete illustration resource.'
+            );
+        }
+
+        $resourceFile = $resourceNode?->getFirstResourceFile();
+        $fileName = $resourceFile instanceof ResourceFile
+            ? ($resourceFile->getOriginalName() ?: $resourceFile->getTitle())
+            : null;
+        $revisedPrompt = \is_array($generatedResult)
+            && isset($generatedResult['revised_prompt'])
+            && \is_string($generatedResult['revised_prompt'])
+                ? trim($generatedResult['revised_prompt'])
+                : null;
+
+        $this->aiDisclosureHelper->logAudit(
+            targetKey: 'course:'.$courseId.':document_image:'.$documentId,
+            userId: (int) $user->getId(),
+            meta: [
+                'feature' => 'image_generator',
+                'mode' => 'generated_and_saved',
+                'provider' => $provider,
+                'tool' => 'document_image_generate',
+                'prompt_hash' => sha1($prompt),
+                'document_id' => $documentId,
+            ],
+            courseId: $courseId,
+        );
+
+        return [
+            'created' => true,
+            'illustration' => [
+                'document_id' => $documentId,
+                'resource_node_id' => $resourceNodeId,
+                'parent_resource_node_id' => (int) ($resourceNode?->getParent()?->getId() ?? 0),
+                'title' => $document->getTitle(),
+                'file_name' => $fileName,
+                'topic' => $topic,
+                'prompt' => $prompt,
+                'provider_used' => $provider,
+                'revised_prompt' => '' !== (string) $revisedPrompt
+                    ? $revisedPrompt
+                    : null,
+                'published' => $publish,
+                'ai_assisted' => true,
+                'content_type' => $resourceFile instanceof ResourceFile
+                    ? $resourceFile->getMimeType()
+                    : null,
+                'size' => $resourceFile instanceof ResourceFile
+                    ? $resourceFile->getSize()
+                    : null,
+                'content_url' => $this->documentRepository->getResourceFileUrl(
+                    $document,
+                    ['cid' => $courseId],
+                ),
+            ],
+        ];
+    }
+}

--- a/src/CoreBundle/Mcp/CreateCourseLearningPathTool.php
+++ b/src/CoreBundle/Mcp/CreateCourseLearningPathTool.php
@@ -1,0 +1,69 @@
+<?php
+
+/* For licensing terms, see /license.txt */
+
+declare(strict_types=1);
+
+namespace Chamilo\CoreBundle\Mcp;
+
+use Chamilo\CoreBundle\Service\LearningPath\McpCourseLearningPathCreator;
+use Chamilo\CoreBundle\Service\Mcp\McpTeacherCourseContext;
+use InvalidArgumentException;
+use Mcp\Capability\Attribute\McpTool;
+use Mcp\Exception\ToolCallException;
+use RuntimeException;
+use Symfony\Component\Security\Core\Exception\AccessDeniedException;
+use Throwable;
+
+final readonly class CreateCourseLearningPathTool
+{
+    public function __construct(
+        private McpTeacherCourseContext $courseContext,
+        private McpCourseLearningPathCreator $learningPathCreator,
+    ) {}
+
+    /**
+     * @return array{created: true, learning_path: array<string, mixed>}
+     */
+    #[McpTool(
+        name: 'create_course_learning_path',
+        description: 'Create an AI-assisted learning path in a base course with a requested number of HTML pages and a single-answer mini-test after every page. The learning path is a draft unless publish is true.',
+    )]
+    public function createCourseLearningPath(
+        int $courseId,
+        string $topic,
+        int $pageCount,
+        int $wordsPerPage,
+        int $questionsPerQuiz = 2,
+        ?string $provider = null,
+        bool $publish = false,
+    ): array {
+        try {
+            $context = $this->courseContext->resolve($courseId);
+
+            return [
+                'created' => true,
+                'learning_path' => $this->learningPathCreator->create(
+                    $context['course'],
+                    $context['user'],
+                    $topic,
+                    $pageCount,
+                    $wordsPerPage,
+                    $questionsPerQuiz,
+                    $provider,
+                    $publish,
+                ),
+            ];
+        } catch (ToolCallException $exception) {
+            throw $exception;
+        } catch (AccessDeniedException|InvalidArgumentException|RuntimeException $exception) {
+            throw new ToolCallException($exception->getMessage());
+        } catch (Throwable $throwable) {
+            throw new ToolCallException(
+                'The learning path could not be created because of an unexpected server error. Check the Chamilo log for technical details.',
+                0,
+                $throwable,
+            );
+        }
+    }
+}

--- a/src/CoreBundle/Mcp/CreateCourseLearningPathTool.php
+++ b/src/CoreBundle/Mcp/CreateCourseLearningPathTool.php
@@ -59,11 +59,7 @@ final readonly class CreateCourseLearningPathTool
         } catch (AccessDeniedException|InvalidArgumentException|RuntimeException $exception) {
             throw new ToolCallException($exception->getMessage());
         } catch (Throwable $throwable) {
-            throw new ToolCallException(
-                'The learning path could not be created because of an unexpected server error. Check the Chamilo log for technical details.',
-                0,
-                $throwable,
-            );
+            throw new ToolCallException('The learning path could not be created because of an unexpected server error. Check the Chamilo log for technical details.', 0, $throwable);
         }
     }
 }

--- a/src/CoreBundle/Mcp/CreateCourseTestTool.php
+++ b/src/CoreBundle/Mcp/CreateCourseTestTool.php
@@ -11,6 +11,7 @@ use Chamilo\CoreBundle\Entity\User;
 use Chamilo\CoreBundle\Helpers\AccessUrlHelper;
 use Chamilo\CoreBundle\Repository\CourseRelUserRepository;
 use Chamilo\CoreBundle\Service\Exercise\AiCourseTestGenerator;
+use Chamilo\CoreBundle\Service\Mcp\McpCourseAiFeatureManager;
 use Chamilo\CourseBundle\Entity\CDocument;
 use Chamilo\CourseBundle\Repository\CDocumentRepository;
 use InvalidArgumentException;
@@ -32,6 +33,7 @@ final readonly class CreateCourseTestTool
         private CourseRelUserRepository $courseRelUserRepository,
         private CDocumentRepository $documentRepository,
         private AiCourseTestGenerator $testGenerator,
+        private McpCourseAiFeatureManager $courseAiFeatureManager,
     ) {}
 
     /**
@@ -68,18 +70,21 @@ final readonly class CreateCourseTestTool
         bool $publish = false,
     ): array {
         try {
+            $result = $this->doCreateCourseTest(
+                $courseId,
+                $title,
+                $questionCount,
+                $topicDescription,
+                $documentId,
+                $language,
+                $provider,
+                $publish,
+            );
+
             return [
                 'created' => true,
-                'test' => $this->doCreateCourseTest(
-                    $courseId,
-                    $title,
-                    $questionCount,
-                    $topicDescription,
-                    $documentId,
-                    $language,
-                    $provider,
-                    $publish,
-                ),
+                'course_features_enabled' => $result['course_features_enabled'],
+                'test' => $result['test'],
             ];
         } catch (ToolCallException $exception) {
             throw $exception;
@@ -143,6 +148,13 @@ final readonly class CreateCourseTestTool
             throw new AccessDeniedException('The course was not found or is not managed by the authenticated teacher.');
         }
 
+        $enabledFeatures = $this->courseAiFeatureManager->ensureEnabled(
+            $course,
+            $user,
+            'exercise_generator',
+            'create_course_test',
+        );
+
         $title = trim(strip_tags($title));
         if ('' === $title) {
             throw new InvalidArgumentException('The test title is required.');
@@ -165,19 +177,22 @@ final readonly class CreateCourseTestTool
                 throw new InvalidArgumentException('The topic description cannot be longer than 20000 characters.');
             }
 
-            return $this->testGenerator->createTest(
-                $course,
-                $user,
-                $title,
-                $questionCount,
-                'topic',
-                $title,
-                $topicDescription,
-                null,
-                $language,
-                $provider,
-                $publish,
-            );
+            return [
+                'course_features_enabled' => $enabledFeatures,
+                'test' => $this->testGenerator->createTest(
+                    $course,
+                    $user,
+                    $title,
+                    $questionCount,
+                    'topic',
+                    $title,
+                    $topicDescription,
+                    null,
+                    $language,
+                    $provider,
+                    $publish,
+                ),
+            ];
         }
 
         $document = $this->documentRepository->find($documentId);
@@ -196,18 +211,21 @@ final readonly class CreateCourseTestTool
 
         $sourceText = $this->testGenerator->getDocumentSource($document);
 
-        return $this->testGenerator->createTest(
-            $course,
-            $user,
-            $title,
-            $questionCount,
-            'document',
-            trim(strip_tags((string) $document->getTitle())),
-            $sourceText,
-            $documentId,
-            $language,
-            $provider,
-            $publish,
-        );
+        return [
+            'course_features_enabled' => $enabledFeatures,
+            'test' => $this->testGenerator->createTest(
+                $course,
+                $user,
+                $title,
+                $questionCount,
+                'document',
+                trim(strip_tags((string) $document->getTitle())),
+                $sourceText,
+                $documentId,
+                $language,
+                $provider,
+                $publish,
+            ),
+        ];
     }
 }

--- a/src/CoreBundle/Mcp/CreateCourseTestTool.php
+++ b/src/CoreBundle/Mcp/CreateCourseTestTool.php
@@ -1,0 +1,213 @@
+<?php
+
+/* For licensing terms, see /license.txt */
+
+declare(strict_types=1);
+
+namespace Chamilo\CoreBundle\Mcp;
+
+use Chamilo\CoreBundle\Entity\ResourceLink;
+use Chamilo\CoreBundle\Entity\User;
+use Chamilo\CoreBundle\Helpers\AccessUrlHelper;
+use Chamilo\CoreBundle\Repository\CourseRelUserRepository;
+use Chamilo\CoreBundle\Service\Exercise\AiCourseTestGenerator;
+use Chamilo\CourseBundle\Entity\CDocument;
+use Chamilo\CourseBundle\Repository\CDocumentRepository;
+use InvalidArgumentException;
+use Mcp\Capability\Attribute\McpTool;
+use Mcp\Exception\ToolCallException;
+use RuntimeException;
+use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\Security\Core\Exception\AccessDeniedException;
+use Throwable;
+
+final readonly class CreateCourseTestTool
+{
+    private const MAX_TITLE_LENGTH = 255;
+    private const MAX_TOPIC_LENGTH = 20_000;
+
+    public function __construct(
+        private Security $security,
+        private AccessUrlHelper $accessUrlHelper,
+        private CourseRelUserRepository $courseRelUserRepository,
+        private CDocumentRepository $documentRepository,
+        private AiCourseTestGenerator $testGenerator,
+    ) {}
+
+    /**
+     * @return array{
+     *     created: true,
+     *     test: array{
+     *         quiz_id: int,
+     *         resource_node_id: int,
+     *         title: string,
+     *         question_count: int,
+     *         question_type: 'unique_answer',
+     *         total_score: float,
+     *         published: bool,
+     *         provider_used: string,
+     *         ai_assisted: true,
+     *         source: array{type: 'topic'|'document', document_id: int|null, title: string},
+     *         questions: list<array{question_id: int, title: string, score: float}>,
+     *         content_url: string
+     *     }
+     * }
+     */
+    #[McpTool(
+        name: 'create_course_test',
+        description: 'Create an AI-assisted test with single-answer multiple-choice questions in a course managed by the authenticated teacher. Use exactly one source: a detailed topic description or an editable HTML document from the same course. Tests are drafts unless publish is true.',
+    )]
+    public function createCourseTest(
+        int $courseId,
+        string $title,
+        int $questionCount,
+        ?string $topicDescription = null,
+        ?int $documentId = null,
+        ?string $language = null,
+        ?string $provider = null,
+        bool $publish = false,
+    ): array {
+        try {
+            return [
+                'created' => true,
+                'test' => $this->doCreateCourseTest(
+                    $courseId,
+                    $title,
+                    $questionCount,
+                    $topicDescription,
+                    $documentId,
+                    $language,
+                    $provider,
+                    $publish,
+                ),
+            ];
+        } catch (ToolCallException $exception) {
+            throw $exception;
+        } catch (AccessDeniedException|InvalidArgumentException|RuntimeException $exception) {
+            throw new ToolCallException($exception->getMessage());
+        } catch (Throwable $throwable) {
+            throw new ToolCallException(
+                'The course test could not be created because of an unexpected server error. Check the Chamilo log for technical details.',
+                0,
+                $throwable,
+            );
+        }
+    }
+
+    /**
+     * @return array{
+     *     quiz_id: int,
+     *     resource_node_id: int,
+     *     title: string,
+     *     question_count: int,
+     *     question_type: 'unique_answer',
+     *     total_score: float,
+     *     published: bool,
+     *     provider_used: string,
+     *     ai_assisted: true,
+     *     source: array{type: 'topic'|'document', document_id: int|null, title: string},
+     *     questions: list<array{question_id: int, title: string, score: float}>,
+     *     content_url: string
+     * }
+     */
+    private function doCreateCourseTest(
+        int $courseId,
+        string $title,
+        int $questionCount,
+        ?string $topicDescription,
+        ?int $documentId,
+        ?string $language,
+        ?string $provider,
+        bool $publish,
+    ): array {
+        if ($courseId <= 0) {
+            throw new InvalidArgumentException('The course ID must be a positive integer.');
+        }
+
+        $user = $this->security->getUser();
+        if (!$user instanceof User || null === $user->getId()) {
+            throw new AccessDeniedException('An authenticated Chamilo user is required.');
+        }
+
+        $accessUrl = $this->accessUrlHelper->getCurrent();
+        if (null === $accessUrl) {
+            throw new RuntimeException('The current Chamilo access URL could not be resolved.');
+        }
+
+        $course = $this->courseRelUserRepository->findTeacherCourseForUserAndAccessUrl(
+            $user,
+            $accessUrl,
+            $courseId,
+        );
+        if (null === $course) {
+            throw new AccessDeniedException('The course was not found or is not managed by the authenticated teacher.');
+        }
+
+        $title = trim(strip_tags($title));
+        if ('' === $title) {
+            throw new InvalidArgumentException('The test title is required.');
+        }
+        if (mb_strlen($title) > self::MAX_TITLE_LENGTH) {
+            throw new InvalidArgumentException('The test title cannot be longer than 255 characters.');
+        }
+
+        $topicDescription = null !== $topicDescription ? trim($topicDescription) : '';
+        $documentId = null !== $documentId ? $documentId : 0;
+        $hasTopic = '' !== $topicDescription;
+        $hasDocument = $documentId > 0;
+
+        if ($hasTopic === $hasDocument) {
+            throw new InvalidArgumentException('Provide exactly one test source: topicDescription or documentId.');
+        }
+
+        if ($hasTopic) {
+            if (mb_strlen($topicDescription) > self::MAX_TOPIC_LENGTH) {
+                throw new InvalidArgumentException('The topic description cannot be longer than 20000 characters.');
+            }
+
+            return $this->testGenerator->createTest(
+                $course,
+                $user,
+                $title,
+                $questionCount,
+                'topic',
+                $title,
+                $topicDescription,
+                null,
+                $language,
+                $provider,
+                $publish,
+            );
+        }
+
+        $document = $this->documentRepository->find($documentId);
+        if (!$document instanceof CDocument) {
+            throw new InvalidArgumentException('The source document was not found.');
+        }
+
+        $documentLink = $document->getResourceNode()?->getResourceLinkByContext($course, null, null);
+        if (!$documentLink instanceof ResourceLink) {
+            throw new AccessDeniedException('The source document does not belong to the selected course.');
+        }
+
+        if (!$document->getResourceNode()?->hasEditableTextContent()) {
+            throw new InvalidArgumentException('The source document must be an editable HTML document.');
+        }
+
+        $sourceText = $this->testGenerator->getDocumentSource($document);
+
+        return $this->testGenerator->createTest(
+            $course,
+            $user,
+            $title,
+            $questionCount,
+            'document',
+            trim(strip_tags((string) $document->getTitle())),
+            $sourceText,
+            $documentId,
+            $language,
+            $provider,
+            $publish,
+        );
+    }
+}

--- a/src/CoreBundle/Mcp/CreateCourseTestTool.php
+++ b/src/CoreBundle/Mcp/CreateCourseTestTool.php
@@ -91,11 +91,7 @@ final readonly class CreateCourseTestTool
         } catch (AccessDeniedException|InvalidArgumentException|RuntimeException $exception) {
             throw new ToolCallException($exception->getMessage());
         } catch (Throwable $throwable) {
-            throw new ToolCallException(
-                'The course test could not be created because of an unexpected server error. Check the Chamilo log for technical details.',
-                0,
-                $throwable,
-            );
+            throw new ToolCallException('The course test could not be created because of an unexpected server error. Check the Chamilo log for technical details.', 0, $throwable);
         }
     }
 

--- a/src/CoreBundle/Mcp/CreateCourseTool.php
+++ b/src/CoreBundle/Mcp/CreateCourseTool.php
@@ -1,0 +1,136 @@
+<?php
+
+/* For licensing terms, see /license.txt */
+
+declare(strict_types=1);
+
+namespace Chamilo\CoreBundle\Mcp;
+
+use Chamilo\CoreBundle\Entity\Course;
+use Chamilo\CoreBundle\Entity\User;
+use Chamilo\CoreBundle\Helpers\CourseHelper;
+use Doctrine\ORM\EntityManagerInterface;
+use InvalidArgumentException;
+use Mcp\Capability\Attribute\McpTool;
+use RuntimeException;
+use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+use Symfony\Component\Security\Core\Exception\AccessDeniedException;
+
+final readonly class CreateCourseTool
+{
+    public function __construct(
+        private Security $security,
+        private CourseHelper $courseHelper,
+        private EntityManagerInterface $entityManager,
+        private UrlGeneratorInterface $urlGenerator,
+    ) {}
+
+    /**
+     * @return array{
+     *     created: true,
+     *     course: array{
+     *         course_id: int,
+     *         title: string,
+     *         code: string,
+     *         visual_code: string|null,
+     *         language: string,
+     *         visibility: int,
+     *         url: string
+     *     }
+     * }
+     */
+    #[McpTool(
+        name: 'create_course',
+        description: 'Create a Chamilo course for the authenticated teacher using the platform course-creation rules.',
+    )]
+    public function createCourse(
+        string $title,
+        ?string $code = null,
+        ?string $language = null,
+    ): array {
+        $user = $this->security->getUser();
+
+        if (!$user instanceof User || null === $user->getId()) {
+            throw new AccessDeniedException('An authenticated Chamilo user is required.');
+        }
+
+        if (
+            !$this->security->isGranted('ROLE_TEACHER')
+            && !$this->security->isGranted('ROLE_ADMIN')
+        ) {
+            throw new AccessDeniedException('Only teachers and administrators can create courses.');
+        }
+
+        $title = trim($title);
+        if ('' === $title) {
+            throw new InvalidArgumentException('The course title is required.');
+        }
+
+        if (mb_strlen($title) > 250) {
+            throw new InvalidArgumentException('The course title cannot be longer than 250 characters.');
+        }
+
+        $code = null !== $code ? trim($code) : null;
+        if ('' === $code) {
+            $code = null;
+        }
+
+        if (null !== $code && mb_strlen($code) > CourseHelper::MAX_COURSE_LENGTH_CODE) {
+            throw new InvalidArgumentException(
+                \sprintf(
+                    'The course code cannot be longer than %d characters.',
+                    CourseHelper::MAX_COURSE_LENGTH_CODE
+                )
+            );
+        }
+
+        $language = null !== $language ? trim($language) : null;
+        if ('' === $language) {
+            $language = null;
+        }
+
+        if (null !== $language && mb_strlen($language) > 20) {
+            throw new InvalidArgumentException('The course language code cannot be longer than 20 characters.');
+        }
+
+        $params = [
+            'title' => $title,
+            'exemplary_content' => false,
+        ];
+
+        if (null !== $code) {
+            $params['wanted_code'] = $code;
+        }
+
+        if (null !== $language) {
+            $params['course_language'] = $language;
+        }
+
+        /** @var Course|null $course */
+        $course = $this->entityManager->wrapInTransaction(
+            fn (): ?Course => $this->courseHelper->createCourse($params)
+        );
+
+        if (!$course instanceof Course || null === $course->getId()) {
+            throw new RuntimeException('Chamilo could not create the course.');
+        }
+
+        return [
+            'created' => true,
+            'course' => [
+                'course_id' => $course->getId(),
+                'title' => $course->getTitle(),
+                'code' => $course->getCode(),
+                'visual_code' => $course->getVisualCode(),
+                'language' => $course->getCourseLanguage(),
+                'visibility' => $course->getVisibility(),
+                'url' => $this->urlGenerator->generate(
+                    'chamilo_core_course_home',
+                    ['cid' => $course->getId()],
+                    UrlGeneratorInterface::ABSOLUTE_URL
+                ),
+            ],
+        ];
+    }
+}

--- a/src/CoreBundle/Mcp/CreateCourseTool.php
+++ b/src/CoreBundle/Mcp/CreateCourseTool.php
@@ -7,8 +7,11 @@ declare(strict_types=1);
 namespace Chamilo\CoreBundle\Mcp;
 
 use Chamilo\CoreBundle\Entity\Course;
+use Chamilo\CoreBundle\Entity\Language;
 use Chamilo\CoreBundle\Entity\User;
 use Chamilo\CoreBundle\Helpers\CourseHelper;
+use Chamilo\CoreBundle\Repository\LanguageRepository;
+use Chamilo\CoreBundle\Settings\SettingsManager;
 use Doctrine\ORM\EntityManagerInterface;
 use InvalidArgumentException;
 use Mcp\Capability\Attribute\McpTool;
@@ -23,6 +26,8 @@ final readonly class CreateCourseTool
         private Security $security,
         private CourseHelper $courseHelper,
         private EntityManagerInterface $entityManager,
+        private LanguageRepository $languageRepository,
+        private SettingsManager $settingsManager,
         private UrlGeneratorInterface $urlGenerator,
     ) {}
 
@@ -80,19 +85,12 @@ final readonly class CreateCourseTool
             throw new InvalidArgumentException(
                 \sprintf(
                     'The course code cannot be longer than %d characters.',
-                    CourseHelper::MAX_COURSE_LENGTH_CODE
+                    CourseHelper::MAX_COURSE_LENGTH_CODE,
                 )
             );
         }
 
-        $language = null !== $language ? trim($language) : null;
-        if ('' === $language) {
-            $language = null;
-        }
-
-        if (null !== $language && mb_strlen($language) > 20) {
-            throw new InvalidArgumentException('The course language code cannot be longer than 20 characters.');
-        }
+        $language = $this->resolveCourseLanguage($language);
 
         $params = [
             'title' => $title,
@@ -103,9 +101,7 @@ final readonly class CreateCourseTool
             $params['wanted_code'] = $code;
         }
 
-        if (null !== $language) {
-            $params['course_language'] = $language;
-        }
+        $params['course_language'] = $language;
 
         /** @var Course|null $course */
         $course = $this->entityManager->wrapInTransaction(
@@ -128,9 +124,139 @@ final readonly class CreateCourseTool
                 'url' => $this->urlGenerator->generate(
                     'chamilo_core_course_home',
                     ['cid' => $course->getId()],
-                    UrlGeneratorInterface::ABSOLUTE_URL
+                    UrlGeneratorInterface::ABSOLUTE_URL,
                 ),
             ],
         ];
+    }
+
+    private function resolveCourseLanguage(?string $requestedLanguage): string
+    {
+        $requestedLanguage = null !== $requestedLanguage
+            ? trim($requestedLanguage)
+            : '';
+
+        $usesPlatformDefault = '' === $requestedLanguage;
+
+        if ($usesPlatformDefault) {
+            $requestedLanguage = trim((string) $this->settingsManager->getSetting(
+                'language.platform_language',
+                true,
+            ));
+
+            if ('' === $requestedLanguage) {
+                $requestedLanguage = trim((string) $this->settingsManager->getSetting(
+                    'language.platformLanguage',
+                ));
+            }
+        }
+
+        if ('' === $requestedLanguage) {
+            throw new RuntimeException(
+                'Chamilo has no valid platform language configured for course creation.'
+            );
+        }
+
+        if (mb_strlen($requestedLanguage) > 255) {
+            throw new InvalidArgumentException(
+                'The course language identifier cannot be longer than 255 characters.'
+            );
+        }
+
+        $normalizedIdentifier = mb_strtolower(str_replace(
+            '-',
+            '_',
+            $requestedLanguage,
+        ));
+
+        $language = $this->findLanguageByIdentifier(
+            $normalizedIdentifier,
+            !$usesPlatformDefault,
+        );
+
+        if (null === $language) {
+            $language = $this->findLanguageByIsoPrefix($normalizedIdentifier);
+        }
+
+        if (null === $language) {
+            throw new InvalidArgumentException(
+                \sprintf(
+                    'The course language "%s" is not available in Chamilo. Use an available ISO code or language name.',
+                    $requestedLanguage,
+                )
+            );
+        }
+
+        return $language->getIsocode();
+    }
+
+    private function findLanguageByIdentifier(
+        string $identifier,
+        bool $requireAvailable,
+    ): ?Language {
+        $queryBuilder = $this->languageRepository->createQueryBuilder('language');
+
+        $queryBuilder
+            ->andWhere(
+                $queryBuilder->expr()->orX(
+                    'LOWER(language.isocode) = :identifier',
+                    'LOWER(language.englishName) = :identifier',
+                    'LOWER(language.originalName) = :identifier',
+                )
+            )
+            ->setParameter('identifier', $identifier)
+            ->addSelect(
+                'CASE WHEN LOWER(language.isocode) = :identifier THEN 0 ELSE 1 END AS HIDDEN identifierPriority'
+            )
+            ->orderBy('identifierPriority', 'ASC')
+            ->addOrderBy('language.isocode', 'ASC')
+            ->setMaxResults(1)
+        ;
+
+        if ($requireAvailable) {
+            $queryBuilder
+                ->andWhere('language.available = :available')
+                ->setParameter('available', true)
+            ;
+        }
+
+        $result = $queryBuilder->getQuery()->getResult();
+
+        return $result[0] ?? null;
+    }
+
+    private function findLanguageByIsoPrefix(
+        string $identifier,
+    ): ?Language {
+        $baseIso = explode('_', $identifier, 2)[0];
+
+        if (1 !== preg_match('/^[a-z]{2,3}$/', $baseIso)) {
+            return null;
+        }
+
+        $queryBuilder = $this->languageRepository->createQueryBuilder('language');
+
+        $queryBuilder
+            ->andWhere('language.available = :available')
+            ->andWhere(
+                $queryBuilder->expr()->orX(
+                    'LOWER(language.isocode) = :baseIso',
+                    'LOWER(language.isocode) LIKE :isoPrefix',
+                )
+            )
+            ->setParameter('available', true)
+            ->setParameter('baseIso', $baseIso)
+            ->setParameter('isoPrefix', $baseIso.'_%')
+            ->addSelect(
+                'CASE WHEN LOWER(language.isocode) = :baseIso THEN 0 ELSE 1 END AS HIDDEN isoPriority'
+            )
+            ->orderBy('isoPriority', 'ASC')
+            ->addOrderBy('language.isocode', 'ASC')
+            ->setMaxResults(1)
+        ;
+
+        $result = $queryBuilder->getQuery()->getResult();
+
+        return $result[0] ?? null;
     }
 }

--- a/src/CoreBundle/Mcp/CreateCourseTool.php
+++ b/src/CoreBundle/Mcp/CreateCourseTool.php
@@ -82,12 +82,7 @@ final readonly class CreateCourseTool
         }
 
         if (null !== $code && mb_strlen($code) > CourseHelper::MAX_COURSE_LENGTH_CODE) {
-            throw new InvalidArgumentException(
-                \sprintf(
-                    'The course code cannot be longer than %d characters.',
-                    CourseHelper::MAX_COURSE_LENGTH_CODE,
-                )
-            );
+            throw new InvalidArgumentException(\sprintf('The course code cannot be longer than %d characters.', CourseHelper::MAX_COURSE_LENGTH_CODE));
         }
 
         $language = $this->resolveCourseLanguage($language);
@@ -152,15 +147,11 @@ final readonly class CreateCourseTool
         }
 
         if ('' === $requestedLanguage) {
-            throw new RuntimeException(
-                'Chamilo has no valid platform language configured for course creation.'
-            );
+            throw new RuntimeException('Chamilo has no valid platform language configured for course creation.');
         }
 
         if (mb_strlen($requestedLanguage) > 255) {
-            throw new InvalidArgumentException(
-                'The course language identifier cannot be longer than 255 characters.'
-            );
+            throw new InvalidArgumentException('The course language identifier cannot be longer than 255 characters.');
         }
 
         $normalizedIdentifier = mb_strtolower(str_replace(
@@ -179,12 +170,7 @@ final readonly class CreateCourseTool
         }
 
         if (null === $language) {
-            throw new InvalidArgumentException(
-                \sprintf(
-                    'The course language "%s" is not available in Chamilo. Use an available ISO code or language name.',
-                    $requestedLanguage,
-                )
-            );
+            throw new InvalidArgumentException(\sprintf('The course language "%s" is not available in Chamilo. Use an available ISO code or language name.', $requestedLanguage));
         }
 
         return $language->getIsocode();

--- a/src/CoreBundle/Mcp/CreateTrainingSatisfactionSurveyTool.php
+++ b/src/CoreBundle/Mcp/CreateTrainingSatisfactionSurveyTool.php
@@ -1,0 +1,67 @@
+<?php
+
+/* For licensing terms, see /license.txt */
+
+declare(strict_types=1);
+
+namespace Chamilo\CoreBundle\Mcp;
+
+use Chamilo\CoreBundle\Service\Mcp\McpTeacherCourseContext;
+use Chamilo\CoreBundle\Service\Survey\TrainingSatisfactionSurveyCreator;
+use InvalidArgumentException;
+use Mcp\Capability\Attribute\McpTool;
+use Mcp\Exception\ToolCallException;
+use RuntimeException;
+use Symfony\Component\Security\Core\Exception\AccessDeniedException;
+use Throwable;
+
+final readonly class CreateTrainingSatisfactionSurveyTool
+{
+    public function __construct(
+        private McpTeacherCourseContext $courseContext,
+        private TrainingSatisfactionSurveyCreator $surveyCreator,
+    ) {}
+
+    /**
+     * @return array{created: true, survey: array<string, mixed>}
+     */
+    #[McpTool(
+        name: 'create_training_satisfaction_survey',
+        description: 'Create a seven-question training satisfaction survey in a base course managed by the authenticated teacher. The survey is a draft unless publish is true.',
+    )]
+    public function createTrainingSatisfactionSurvey(
+        int $courseId,
+        string $title,
+        ?string $language = null,
+        ?string $provider = null,
+        bool $publish = false,
+        bool $anonymous = true,
+    ): array {
+        try {
+            $context = $this->courseContext->resolve($courseId);
+
+            return [
+                'created' => true,
+                'survey' => $this->surveyCreator->create(
+                    $context['course'],
+                    $context['user'],
+                    $title,
+                    $language,
+                    $provider,
+                    $publish,
+                    $anonymous,
+                ),
+            ];
+        } catch (ToolCallException $exception) {
+            throw $exception;
+        } catch (AccessDeniedException|InvalidArgumentException|RuntimeException $exception) {
+            throw new ToolCallException($exception->getMessage());
+        } catch (Throwable $throwable) {
+            throw new ToolCallException(
+                'The satisfaction survey could not be created because of an unexpected server error. Check the Chamilo log for technical details.',
+                0,
+                $throwable,
+            );
+        }
+    }
+}

--- a/src/CoreBundle/Mcp/CreateTrainingSatisfactionSurveyTool.php
+++ b/src/CoreBundle/Mcp/CreateTrainingSatisfactionSurveyTool.php
@@ -57,11 +57,7 @@ final readonly class CreateTrainingSatisfactionSurveyTool
         } catch (AccessDeniedException|InvalidArgumentException|RuntimeException $exception) {
             throw new ToolCallException($exception->getMessage());
         } catch (Throwable $throwable) {
-            throw new ToolCallException(
-                'The satisfaction survey could not be created because of an unexpected server error. Check the Chamilo log for technical details.',
-                0,
-                $throwable,
-            );
+            throw new ToolCallException('The satisfaction survey could not be created because of an unexpected server error. Check the Chamilo log for technical details.', 0, $throwable);
         }
     }
 }

--- a/src/CoreBundle/Mcp/CurrentUserTool.php
+++ b/src/CoreBundle/Mcp/CurrentUserTool.php
@@ -1,0 +1,50 @@
+<?php
+
+/* For licensing terms, see /license.txt */
+
+declare(strict_types=1);
+
+namespace Chamilo\CoreBundle\Mcp;
+
+use Chamilo\CoreBundle\Entity\User;
+use Mcp\Capability\Attribute\McpTool;
+use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\Security\Core\Exception\AccessDeniedException;
+
+final readonly class CurrentUserTool
+{
+    public function __construct(
+        private Security $security,
+    ) {}
+
+    /**
+     * @return array{
+     *     user_id: int,
+     *     username: string,
+     *     full_name: string,
+     *     roles: list<string>
+     * }
+     */
+    #[McpTool(
+        name: 'get_current_user',
+        description: 'Return the identity and roles of the authenticated Chamilo user.',
+    )]
+    public function getCurrentUser(): array
+    {
+        $user = $this->security->getUser();
+
+        if (!$user instanceof User || null === $user->getId()) {
+            throw new AccessDeniedException('An authenticated Chamilo user is required.');
+        }
+
+        $roles = $user->getRoles();
+        sort($roles);
+
+        return [
+            'user_id' => $user->getId(),
+            'username' => $user->getUsername(),
+            'full_name' => $user->getFullName(),
+            'roles' => $roles,
+        ];
+    }
+}

--- a/src/CoreBundle/Mcp/FindRecentCourseForumActivityTool.php
+++ b/src/CoreBundle/Mcp/FindRecentCourseForumActivityTool.php
@@ -47,11 +47,7 @@ final readonly class FindRecentCourseForumActivityTool
         } catch (AccessDeniedException|InvalidArgumentException|RuntimeException $exception) {
             throw new ToolCallException($exception->getMessage());
         } catch (Throwable $throwable) {
-            throw new ToolCallException(
-                'The forum activity could not be searched because of an unexpected server error. Check the Chamilo log for technical details.',
-                0,
-                $throwable,
-            );
+            throw new ToolCallException('The forum activity could not be searched because of an unexpected server error. Check the Chamilo log for technical details.', 0, $throwable);
         }
     }
 }

--- a/src/CoreBundle/Mcp/FindRecentCourseForumActivityTool.php
+++ b/src/CoreBundle/Mcp/FindRecentCourseForumActivityTool.php
@@ -1,0 +1,57 @@
+<?php
+
+/* For licensing terms, see /license.txt */
+
+declare(strict_types=1);
+
+namespace Chamilo\CoreBundle\Mcp;
+
+use Chamilo\CoreBundle\Service\Forum\RecentCourseForumActivityProvider;
+use Chamilo\CoreBundle\Service\Mcp\McpTeacherCourseContext;
+use InvalidArgumentException;
+use Mcp\Capability\Attribute\McpTool;
+use Mcp\Exception\ToolCallException;
+use RuntimeException;
+use Symfony\Component\Security\Core\Exception\AccessDeniedException;
+use Throwable;
+
+final readonly class FindRecentCourseForumActivityTool
+{
+    public function __construct(
+        private McpTeacherCourseContext $courseContext,
+        private RecentCourseForumActivityProvider $activityProvider,
+    ) {}
+
+    /**
+     * @return array<string, mixed>
+     */
+    #[McpTool(
+        name: 'find_recent_course_forum_activity',
+        description: 'Find visible recent forum posts related to a topic in a base course managed by the authenticated teacher.',
+    )]
+    public function findRecentCourseForumActivity(
+        int $courseId,
+        string $topic,
+        int $days = 30,
+    ): array {
+        try {
+            $context = $this->courseContext->resolve($courseId);
+
+            return $this->activityProvider->provide(
+                $context['course'],
+                $topic,
+                $days,
+            );
+        } catch (ToolCallException $exception) {
+            throw $exception;
+        } catch (AccessDeniedException|InvalidArgumentException|RuntimeException $exception) {
+            throw new ToolCallException($exception->getMessage());
+        } catch (Throwable $throwable) {
+            throw new ToolCallException(
+                'The forum activity could not be searched because of an unexpected server error. Check the Chamilo log for technical details.',
+                0,
+                $throwable,
+            );
+        }
+    }
+}

--- a/src/CoreBundle/Mcp/GetCourseTestResponseStatusTool.php
+++ b/src/CoreBundle/Mcp/GetCourseTestResponseStatusTool.php
@@ -65,11 +65,7 @@ final readonly class GetCourseTestResponseStatusTool
         } catch (AccessDeniedException|InvalidArgumentException|RuntimeException $exception) {
             throw new ToolCallException($exception->getMessage());
         } catch (Throwable $throwable) {
-            throw new ToolCallException(
-                'The course test response status could not be loaded because of an unexpected server error. Check the Chamilo log for technical details.',
-                0,
-                $throwable,
-            );
+            throw new ToolCallException('The course test response status could not be loaded because of an unexpected server error. Check the Chamilo log for technical details.', 0, $throwable);
         }
     }
 

--- a/src/CoreBundle/Mcp/GetCourseTestResponseStatusTool.php
+++ b/src/CoreBundle/Mcp/GetCourseTestResponseStatusTool.php
@@ -1,0 +1,138 @@
+<?php
+
+/* For licensing terms, see /license.txt */
+
+declare(strict_types=1);
+
+namespace Chamilo\CoreBundle\Mcp;
+
+use Chamilo\CoreBundle\Entity\ResourceLink;
+use Chamilo\CoreBundle\Entity\User;
+use Chamilo\CoreBundle\Helpers\AccessUrlHelper;
+use Chamilo\CoreBundle\Repository\CourseRelUserRepository;
+use Chamilo\CoreBundle\Service\Exercise\CourseTestResponseStatusProvider;
+use Chamilo\CourseBundle\Entity\CQuiz;
+use Chamilo\CourseBundle\Repository\CQuizRepository;
+use InvalidArgumentException;
+use Mcp\Capability\Attribute\McpTool;
+use Mcp\Exception\ToolCallException;
+use RuntimeException;
+use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\Security\Core\Exception\AccessDeniedException;
+use Throwable;
+
+final readonly class GetCourseTestResponseStatusTool
+{
+    public function __construct(
+        private Security $security,
+        private AccessUrlHelper $accessUrlHelper,
+        private CourseRelUserRepository $courseRelUserRepository,
+        private CQuizRepository $quizRepository,
+        private CourseTestResponseStatusProvider $statusProvider,
+    ) {}
+
+    /**
+     * @return array{
+     *     scope: 'base_course',
+     *     course: array{course_id: int, title: string},
+     *     test: array{quiz_id: int, title: string},
+     *     students: array{
+     *         total_students: int,
+     *         answered_students: int,
+     *         pending_students: int,
+     *         in_progress_students: int,
+     *         not_started_students: int,
+     *         response_rate_percent: float
+     *     },
+     *     attempts: array{
+     *         completed_attempts: int,
+     *         incomplete_attempts: int,
+     *         considered_attempts: int,
+     *         ignored_non_student_attempts: int
+     *     }
+     * }
+     */
+    #[McpTool(
+        name: 'get_course_test_response_status',
+        description: 'Return response status for a test in a base course managed by the authenticated teacher. Answered students have at least one completed attempt. Students with only incomplete attempts remain pending and are reported as in progress.',
+    )]
+    public function getCourseTestResponseStatus(int $courseId, int $testId): array
+    {
+        try {
+            return $this->doGetCourseTestResponseStatus($courseId, $testId);
+        } catch (ToolCallException $exception) {
+            throw $exception;
+        } catch (AccessDeniedException|InvalidArgumentException|RuntimeException $exception) {
+            throw new ToolCallException($exception->getMessage());
+        } catch (Throwable $throwable) {
+            throw new ToolCallException(
+                'The course test response status could not be loaded because of an unexpected server error. Check the Chamilo log for technical details.',
+                0,
+                $throwable,
+            );
+        }
+    }
+
+    /**
+     * @return array{
+     *     scope: 'base_course',
+     *     course: array{course_id: int, title: string},
+     *     test: array{quiz_id: int, title: string},
+     *     students: array{
+     *         total_students: int,
+     *         answered_students: int,
+     *         pending_students: int,
+     *         in_progress_students: int,
+     *         not_started_students: int,
+     *         response_rate_percent: float
+     *     },
+     *     attempts: array{
+     *         completed_attempts: int,
+     *         incomplete_attempts: int,
+     *         considered_attempts: int,
+     *         ignored_non_student_attempts: int
+     *     }
+     * }
+     */
+    private function doGetCourseTestResponseStatus(int $courseId, int $testId): array
+    {
+        if ($courseId <= 0) {
+            throw new InvalidArgumentException('The course ID must be a positive integer.');
+        }
+
+        if ($testId <= 0) {
+            throw new InvalidArgumentException('The test ID must be a positive integer.');
+        }
+
+        $user = $this->security->getUser();
+        if (!$user instanceof User || null === $user->getId()) {
+            throw new AccessDeniedException('An authenticated Chamilo user is required.');
+        }
+
+        $accessUrl = $this->accessUrlHelper->getCurrent();
+        if (null === $accessUrl) {
+            throw new RuntimeException('The current Chamilo access URL could not be resolved.');
+        }
+
+        $course = $this->courseRelUserRepository->findTeacherCourseForUserAndAccessUrl(
+            $user,
+            $accessUrl,
+            $courseId,
+        );
+        if (null === $course) {
+            throw new AccessDeniedException('The course was not found or is not managed by the authenticated teacher.');
+        }
+
+        $quiz = $this->quizRepository->find($testId);
+        if (!$quiz instanceof CQuiz) {
+            throw new InvalidArgumentException('The test was not found.');
+        }
+
+        $quizLink = $quiz->getResourceNode()?->getResourceLinkByContext($course, null, null);
+        if (!$quizLink instanceof ResourceLink) {
+            throw new AccessDeniedException('The test does not belong to the selected base course.');
+        }
+
+        return $this->statusProvider->getBaseCourseStatus($course, $quiz);
+    }
+}

--- a/src/CoreBundle/Mcp/GetUserCourseTestScoreTool.php
+++ b/src/CoreBundle/Mcp/GetUserCourseTestScoreTool.php
@@ -1,0 +1,57 @@
+<?php
+
+/* For licensing terms, see /license.txt */
+
+declare(strict_types=1);
+
+namespace Chamilo\CoreBundle\Mcp;
+
+use Chamilo\CoreBundle\Service\Exercise\UserCourseTestScoreProvider;
+use Chamilo\CoreBundle\Service\Mcp\McpTeacherCourseContext;
+use InvalidArgumentException;
+use Mcp\Capability\Attribute\McpTool;
+use Mcp\Exception\ToolCallException;
+use RuntimeException;
+use Symfony\Component\Security\Core\Exception\AccessDeniedException;
+use Throwable;
+
+final readonly class GetUserCourseTestScoreTool
+{
+    public function __construct(
+        private McpTeacherCourseContext $courseContext,
+        private UserCourseTestScoreProvider $scoreProvider,
+    ) {}
+
+    /**
+     * @return array<string, mixed>
+     */
+    #[McpTool(
+        name: 'get_user_course_test_score',
+        description: 'Return the latest and best completed scores of a direct base-course student for a test managed by the authenticated teacher.',
+    )]
+    public function getUserCourseTestScore(
+        int $courseId,
+        int $testId,
+        string $userIdentifier,
+    ): array {
+        try {
+            $context = $this->courseContext->resolve($courseId);
+
+            return $this->scoreProvider->provide(
+                $context['course'],
+                $testId,
+                $userIdentifier,
+            );
+        } catch (ToolCallException $exception) {
+            throw $exception;
+        } catch (AccessDeniedException|InvalidArgumentException|RuntimeException $exception) {
+            throw new ToolCallException($exception->getMessage());
+        } catch (Throwable $throwable) {
+            throw new ToolCallException(
+                'The test score could not be loaded because of an unexpected server error. Check the Chamilo log for technical details.',
+                0,
+                $throwable,
+            );
+        }
+    }
+}

--- a/src/CoreBundle/Mcp/GetUserCourseTestScoreTool.php
+++ b/src/CoreBundle/Mcp/GetUserCourseTestScoreTool.php
@@ -47,11 +47,7 @@ final readonly class GetUserCourseTestScoreTool
         } catch (AccessDeniedException|InvalidArgumentException|RuntimeException $exception) {
             throw new ToolCallException($exception->getMessage());
         } catch (Throwable $throwable) {
-            throw new ToolCallException(
-                'The test score could not be loaded because of an unexpected server error. Check the Chamilo log for technical details.',
-                0,
-                $throwable,
-            );
+            throw new ToolCallException('The test score could not be loaded because of an unexpected server error. Check the Chamilo log for technical details.', 0, $throwable);
         }
     }
 }

--- a/src/CoreBundle/Mcp/IllustrateDocumentParagraphTool.php
+++ b/src/CoreBundle/Mcp/IllustrateDocumentParagraphTool.php
@@ -1,0 +1,308 @@
+<?php
+
+/* For licensing terms, see /license.txt */
+
+declare(strict_types=1);
+
+namespace Chamilo\CoreBundle\Mcp;
+
+use Chamilo\CoreBundle\Entity\User;
+use Chamilo\CoreBundle\Helpers\AccessUrlHelper;
+use Chamilo\CoreBundle\Repository\CourseRelUserRepository;
+use Chamilo\CoreBundle\Service\Document\DocumentParagraphMediaEmbedder;
+use Chamilo\CourseBundle\Entity\CDocument;
+use Chamilo\CourseBundle\Repository\CDocumentRepository;
+use InvalidArgumentException;
+use Mcp\Capability\Attribute\McpTool;
+use Mcp\Exception\ToolCallException;
+use RuntimeException;
+use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\Security\Core\Exception\AccessDeniedException;
+use Throwable;
+
+use const PATHINFO_EXTENSION;
+
+final readonly class IllustrateDocumentParagraphTool
+{
+    public function __construct(
+        private Security $security,
+        private AccessUrlHelper $accessUrlHelper,
+        private CourseRelUserRepository $courseRelUserRepository,
+        private CDocumentRepository $documentRepository,
+        private DocumentParagraphMediaEmbedder $mediaEmbedder,
+    ) {}
+
+    /**
+     * @return array{
+     *     updated: bool,
+     *     already_present: bool,
+     *     document: array{
+     *         document_id: int,
+     *         title: string,
+     *         paragraph_number: int,
+     *         paragraphs_total: int,
+     *         paragraph_preview: string,
+     *         content_url: string
+     *     },
+     *     media: array{
+     *         document_id: int,
+     *         title: string,
+     *         type: 'image'|'video',
+     *         content_url: string
+     *     },
+     *     placement: 'before'|'after'
+     * }
+     */
+    #[McpTool(
+        name: 'illustrate_document_paragraph',
+        description: 'Insert an existing image or video from the same course Documents tool before or after a selected paragraph in an editable HTML document.',
+    )]
+    public function illustrateDocumentParagraph(
+        int $courseId,
+        int $documentId,
+        int $mediaDocumentId,
+        ?int $paragraphNumber = null,
+        ?string $paragraphText = null,
+        ?string $altText = null,
+        ?string $caption = null,
+        string $placement = 'after',
+    ): array {
+        try {
+            return $this->doIllustrateDocumentParagraph(
+                $courseId,
+                $documentId,
+                $mediaDocumentId,
+                $paragraphNumber,
+                $paragraphText,
+                $altText,
+                $caption,
+                $placement,
+            );
+        } catch (ToolCallException $exception) {
+            throw $exception;
+        } catch (AccessDeniedException|InvalidArgumentException|RuntimeException $exception) {
+            throw new ToolCallException($exception->getMessage());
+        } catch (Throwable $throwable) {
+            throw new ToolCallException('The paragraph could not be illustrated because of an unexpected server error. Check the Chamilo log for technical details.', 0, $throwable);
+        }
+    }
+
+    /**
+     * @return array{
+     *     updated: bool,
+     *     already_present: bool,
+     *     document: array{
+     *         document_id: int,
+     *         title: string,
+     *         paragraph_number: int,
+     *         paragraphs_total: int,
+     *         paragraph_preview: string,
+     *         content_url: string
+     *     },
+     *     media: array{
+     *         document_id: int,
+     *         title: string,
+     *         type: 'image'|'video',
+     *         content_url: string
+     *     },
+     *     placement: 'before'|'after'
+     * }
+     */
+    private function doIllustrateDocumentParagraph(
+        int $courseId,
+        int $documentId,
+        int $mediaDocumentId,
+        ?int $paragraphNumber,
+        ?string $paragraphText,
+        ?string $altText,
+        ?string $caption,
+        string $placement,
+    ): array {
+        if ($courseId <= 0) {
+            throw new InvalidArgumentException('The course ID must be a positive integer.');
+        }
+
+        if ($documentId <= 0) {
+            throw new InvalidArgumentException('The target document ID must be a positive integer.');
+        }
+
+        if ($mediaDocumentId <= 0) {
+            throw new InvalidArgumentException('The media document ID must be a positive integer.');
+        }
+
+        if ($documentId === $mediaDocumentId) {
+            throw new InvalidArgumentException('The target document and media document must be different.');
+        }
+
+        $placement = strtolower(trim($placement));
+        if (!\in_array($placement, ['before', 'after'], true)) {
+            throw new InvalidArgumentException('The placement must be "before" or "after".');
+        }
+
+        $user = $this->security->getUser();
+        if (!$user instanceof User || null === $user->getId()) {
+            throw new AccessDeniedException('An authenticated Chamilo user is required.');
+        }
+
+        $accessUrl = $this->accessUrlHelper->getCurrent();
+        if (null === $accessUrl) {
+            throw new RuntimeException('The current Chamilo access URL could not be resolved.');
+        }
+
+        $course = $this->courseRelUserRepository->findTeacherCourseForUserAndAccessUrl(
+            $user,
+            $accessUrl,
+            $courseId,
+        );
+
+        if (null === $course) {
+            throw new AccessDeniedException('The course was not found or is not managed by the authenticated teacher.');
+        }
+
+        $document = $this->documentRepository->find($documentId);
+        if (!$document instanceof CDocument) {
+            throw new InvalidArgumentException('The target document was not found.');
+        }
+
+        $mediaDocument = $this->documentRepository->find($mediaDocumentId);
+        if (!$mediaDocument instanceof CDocument) {
+            throw new InvalidArgumentException('The media document was not found.');
+        }
+
+        $this->assertDocumentBelongsToCourse(
+            $document,
+            $courseId,
+            'target document',
+        );
+        $this->assertDocumentBelongsToCourse(
+            $mediaDocument,
+            $courseId,
+            'media document',
+        );
+        $this->assertEditableHtmlDocument($document);
+        $mediaType = $this->assertImageOrVideoDocument($mediaDocument);
+
+        $result = $this->mediaEmbedder->embed(
+            $document,
+            $mediaDocument,
+            $courseId,
+            (int) $user->getId(),
+            $paragraphNumber,
+            $paragraphText,
+            $altText,
+            $caption,
+            $placement,
+        );
+
+        return [
+            'updated' => $result['updated'],
+            'already_present' => $result['already_present'],
+            'document' => [
+                'document_id' => (int) $document->getIid(),
+                'title' => $document->getTitle(),
+                'paragraph_number' => $result['paragraph_number'],
+                'paragraphs_total' => $result['paragraphs_total'],
+                'paragraph_preview' => $result['paragraph_preview'],
+                'content_url' => $this->documentRepository
+                    ->getResourceFileUrl(
+                        $document,
+                        ['cid' => $courseId],
+                    ),
+            ],
+            'media' => [
+                'document_id' => (int) $mediaDocument->getIid(),
+                'title' => $mediaDocument->getTitle(),
+                'type' => $mediaType,
+                'content_url' => $result['media_url'],
+            ],
+            'placement' => $placement,
+        ];
+    }
+
+    private function assertDocumentBelongsToCourse(
+        CDocument $document,
+        int $courseId,
+        string $label,
+    ): void {
+        $resourceNode = $document->getResourceNode();
+        if (null === $resourceNode) {
+            throw new AccessDeniedException(ucfirst($label).' has no resource node.');
+        }
+
+        foreach ($resourceNode->getResourceLinks() as $resourceLink) {
+            $linkedCourse = $resourceLink->getCourse();
+
+            if (
+                null !== $linkedCourse
+                && (int) $linkedCourse->getId() === $courseId
+            ) {
+                return;
+            }
+        }
+
+        throw new AccessDeniedException(ucfirst($label).' does not belong to the selected course.');
+    }
+
+    private function assertEditableHtmlDocument(
+        CDocument $document,
+    ): void {
+        if ('file' !== $document->getFiletype()) {
+            throw new InvalidArgumentException('The target document must be a file.');
+        }
+
+        if ($document->getReadonly()) {
+            throw new AccessDeniedException('The target document is read-only.');
+        }
+
+        $resourceFile = $document->getResourceNode()?->getFirstResourceFile();
+
+        if (null === $resourceFile) {
+            throw new InvalidArgumentException('The target document has no stored file.');
+        }
+
+        $mimeType = strtolower(trim((string) $resourceFile->getMimeType()));
+        $fileName = strtolower(
+            (string) (
+                $resourceFile->getOriginalName()
+                ?: $resourceFile->getTitle()
+            )
+        );
+        $extension = pathinfo($fileName, PATHINFO_EXTENSION);
+
+        if (
+            'text/html' !== $mimeType
+            && !\in_array($extension, ['html', 'htm'], true)
+        ) {
+            throw new InvalidArgumentException('The target document must be an editable HTML file.');
+        }
+    }
+
+    /**
+     * @return 'image'|'video'
+     */
+    private function assertImageOrVideoDocument(
+        CDocument $document,
+    ): string {
+        if ('file' !== $document->getFiletype()) {
+            throw new InvalidArgumentException('The media document must be a file.');
+        }
+
+        $resourceFile = $document->getResourceNode()?->getFirstResourceFile();
+
+        if (null === $resourceFile) {
+            throw new InvalidArgumentException('The media document has no stored file.');
+        }
+
+        $mimeType = strtolower(trim((string) $resourceFile->getMimeType()));
+
+        if (str_starts_with($mimeType, 'image/')) {
+            return 'image';
+        }
+
+        if (str_starts_with($mimeType, 'video/')) {
+            return 'video';
+        }
+
+        throw new InvalidArgumentException('The media document must contain an image or video file.');
+    }
+}

--- a/src/CoreBundle/Mcp/ReviewCourseQualityTool.php
+++ b/src/CoreBundle/Mcp/ReviewCourseQualityTool.php
@@ -1,0 +1,58 @@
+<?php
+
+/* For licensing terms, see /license.txt */
+
+declare(strict_types=1);
+
+namespace Chamilo\CoreBundle\Mcp;
+
+use Chamilo\CoreBundle\Service\Course\McpCourseQualityReviewer;
+use Chamilo\CoreBundle\Service\Mcp\McpTeacherCourseContext;
+use InvalidArgumentException;
+use Mcp\Capability\Attribute\McpTool;
+use Mcp\Exception\ToolCallException;
+use RuntimeException;
+use Symfony\Component\Security\Core\Exception\AccessDeniedException;
+use Throwable;
+
+final readonly class ReviewCourseQualityTool
+{
+    public function __construct(
+        private McpTeacherCourseContext $courseContext,
+        private McpCourseQualityReviewer $courseReviewer,
+    ) {}
+
+    /**
+     * @return array<string, mixed>
+     */
+    #[McpTool(
+        name: 'review_course_quality',
+        description: 'Analyze a teacher-owned base course, including published, pending and draft learning paths, full readable document text, tests, assignments and surveys, and return concise evidence-based improvement recommendations.',
+    )]
+    public function reviewCourseQuality(
+        int $courseId,
+        ?string $focus = null,
+        ?string $provider = null,
+    ): array {
+        try {
+            $context = $this->courseContext->resolve($courseId);
+
+            return $this->courseReviewer->review(
+                $context['course'],
+                $context['user'],
+                $focus,
+                $provider,
+            );
+        } catch (ToolCallException $exception) {
+            throw $exception;
+        } catch (AccessDeniedException|InvalidArgumentException|RuntimeException $exception) {
+            throw new ToolCallException($exception->getMessage());
+        } catch (Throwable $throwable) {
+            throw new ToolCallException(
+                'The course review could not be generated because of an unexpected server error. Check the Chamilo log for technical details.',
+                0,
+                $throwable,
+            );
+        }
+    }
+}

--- a/src/CoreBundle/Mcp/ReviewCourseQualityTool.php
+++ b/src/CoreBundle/Mcp/ReviewCourseQualityTool.php
@@ -48,11 +48,7 @@ final readonly class ReviewCourseQualityTool
         } catch (AccessDeniedException|InvalidArgumentException|RuntimeException $exception) {
             throw new ToolCallException($exception->getMessage());
         } catch (Throwable $throwable) {
-            throw new ToolCallException(
-                'The course review could not be generated because of an unexpected server error. Check the Chamilo log for technical details.',
-                0,
-                $throwable,
-            );
+            throw new ToolCallException('The course review could not be generated because of an unexpected server error. Check the Chamilo log for technical details.', 0, $throwable);
         }
     }
 }

--- a/src/CoreBundle/Mcp/TeacherCoursesTool.php
+++ b/src/CoreBundle/Mcp/TeacherCoursesTool.php
@@ -1,0 +1,72 @@
+<?php
+
+/* For licensing terms, see /license.txt */
+
+declare(strict_types=1);
+
+namespace Chamilo\CoreBundle\Mcp;
+
+use Chamilo\CoreBundle\Entity\User;
+use Chamilo\CoreBundle\Helpers\AccessUrlHelper;
+use Chamilo\CoreBundle\Repository\CourseRelUserRepository;
+use Mcp\Capability\Attribute\McpTool;
+use RuntimeException;
+use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\Security\Core\Exception\AccessDeniedException;
+
+final readonly class TeacherCoursesTool
+{
+    public function __construct(
+        private Security $security,
+        private AccessUrlHelper $accessUrlHelper,
+        private CourseRelUserRepository $courseRelUserRepository,
+    ) {}
+
+    /**
+     * @return array{
+     *     count: int,
+     *     courses: list<array{
+     *         course_id: int,
+     *         title: string,
+     *         code: string,
+     *         visual_code: string|null,
+     *         visibility: int
+     *     }>
+     * }
+     */
+    #[McpTool(
+        name: 'list_my_teacher_courses',
+        description: 'List courses the authenticated Chamilo user manages as a teacher on the current portal.',
+    )]
+    public function listMyTeacherCourses(): array
+    {
+        $user = $this->security->getUser();
+
+        if (!$user instanceof User || null === $user->getId()) {
+            throw new AccessDeniedException('An authenticated Chamilo user is required.');
+        }
+
+        $accessUrl = $this->accessUrlHelper->getCurrent();
+        if (null === $accessUrl) {
+            throw new RuntimeException('The current Chamilo access URL could not be resolved.');
+        }
+
+        $rows = $this->courseRelUserRepository->findTeacherCoursesForUserAndAccessUrl($user, $accessUrl);
+        $courses = [];
+
+        foreach ($rows as $row) {
+            $courses[] = [
+                'course_id' => (int) $row['id'],
+                'title' => (string) $row['title'],
+                'code' => (string) $row['code'],
+                'visual_code' => null === $row['visualCode'] ? null : (string) $row['visualCode'],
+                'visibility' => (int) $row['visibility'],
+            ];
+        }
+
+        return [
+            'count' => \count($courses),
+            'courses' => $courses,
+        ];
+    }
+}

--- a/src/CoreBundle/Migrations/Schema/V210/Version20260723133000.php
+++ b/src/CoreBundle/Migrations/Schema/V210/Version20260723133000.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+/* For licensing terms, see /license.txt */
+
+namespace Chamilo\CoreBundle\Migrations\Schema\V210;
+
+use Chamilo\CoreBundle\Migrations\AbstractMigrationChamilo;
+use Doctrine\DBAL\Schema\Schema;
+
+final class Version20260723133000 extends AbstractMigrationChamilo
+{
+    public function getDescription(): string
+    {
+        return 'Secure personal MCP API keys by portal and add revocation and usage metadata.';
+    }
+
+    public function up(Schema $schema): void
+    {
+        if (!$schema->hasTable('user_api_key')) {
+            return;
+        }
+
+        $table = $schema->getTable('user_api_key');
+
+        $this->addSql('ALTER TABLE user_api_key CHANGE api_key api_key VARCHAR(64) NOT NULL');
+
+        if (!$table->hasColumn('access_url_id')) {
+            $this->addSql('ALTER TABLE user_api_key ADD access_url_id INT DEFAULT NULL');
+        }
+        if (!$table->hasColumn('key_prefix')) {
+            $this->addSql('ALTER TABLE user_api_key ADD key_prefix VARCHAR(32) DEFAULT NULL');
+        }
+        if (!$table->hasColumn('last_used_at')) {
+            $this->addSql("ALTER TABLE user_api_key ADD last_used_at DATETIME DEFAULT NULL COMMENT '(DC2Type:datetime)'");
+        }
+        if (!$table->hasColumn('revoked_at')) {
+            $this->addSql("ALTER TABLE user_api_key ADD revoked_at DATETIME DEFAULT NULL COMMENT '(DC2Type:datetime)'");
+        }
+
+        if (!$table->hasIndex('idx_user_api_key_mcp_lookup')) {
+            $this->addSql('CREATE INDEX idx_user_api_key_mcp_lookup ON user_api_key (api_service, api_key, access_url_id, revoked_at)');
+        }
+        if (!$table->hasIndex('uniq_user_api_key_service_url')) {
+            $this->addSql('CREATE UNIQUE INDEX uniq_user_api_key_service_url ON user_api_key (user_id, api_service, access_url_id)');
+        }
+        if (!$table->hasForeignKey('FK_USER_API_KEY_ACCESS_URL')) {
+            $this->addSql('ALTER TABLE user_api_key ADD CONSTRAINT FK_USER_API_KEY_ACCESS_URL FOREIGN KEY (access_url_id) REFERENCES access_url (id) ON DELETE CASCADE');
+        }
+    }
+
+    public function down(Schema $schema): void
+    {
+        if (!$schema->hasTable('user_api_key')) {
+            return;
+        }
+
+        $table = $schema->getTable('user_api_key');
+
+        if ($table->hasForeignKey('FK_USER_API_KEY_ACCESS_URL')) {
+            $this->addSql('ALTER TABLE user_api_key DROP FOREIGN KEY FK_USER_API_KEY_ACCESS_URL');
+        }
+        if ($table->hasIndex('uniq_user_api_key_service_url')) {
+            $this->addSql('DROP INDEX uniq_user_api_key_service_url ON user_api_key');
+        }
+        if ($table->hasIndex('idx_user_api_key_mcp_lookup')) {
+            $this->addSql('DROP INDEX idx_user_api_key_mcp_lookup ON user_api_key');
+        }
+        if ($table->hasColumn('revoked_at')) {
+            $this->addSql('ALTER TABLE user_api_key DROP revoked_at');
+        }
+        if ($table->hasColumn('last_used_at')) {
+            $this->addSql('ALTER TABLE user_api_key DROP last_used_at');
+        }
+        if ($table->hasColumn('key_prefix')) {
+            $this->addSql('ALTER TABLE user_api_key DROP key_prefix');
+        }
+        if ($table->hasColumn('access_url_id')) {
+            $this->addSql('ALTER TABLE user_api_key DROP access_url_id');
+        }
+
+        // Keep VARCHAR(64): legacy key generation already creates 64-character values.
+    }
+}

--- a/src/CoreBundle/Repository/CourseRelUserRepository.php
+++ b/src/CoreBundle/Repository/CourseRelUserRepository.php
@@ -7,6 +7,7 @@ declare(strict_types=1);
 namespace Chamilo\CoreBundle\Repository;
 
 use Chamilo\CoreBundle\Entity\AccessUrl;
+use Chamilo\CoreBundle\Entity\Course;
 use Chamilo\CoreBundle\Entity\CourseRelUser;
 use Chamilo\CoreBundle\Entity\User;
 use Chamilo\CourseBundle\Entity\CLp;
@@ -55,6 +56,52 @@ class CourseRelUserRepository extends ServiceEntityRepository
         ;
 
         return $courses;
+    }
+
+    /**
+     * Returns a course only when the user manages it as a teacher in the given access URL.
+     */
+    public function findTeacherCourseForUserAndAccessUrl(
+        User $user,
+        AccessUrl $accessUrl,
+        int $courseId,
+    ): ?Course {
+        /** @var CourseRelUser|null $relation */
+        $relation = $this->createQueryBuilder('cru')
+            ->addSelect('course')
+            ->innerJoin('cru.course', 'course')
+            ->innerJoin('course.urls', 'urlRelation')
+            ->andWhere('cru.user = :user')
+            ->andWhere('cru.status = :teacherStatus')
+            ->andWhere('course.id = :courseId')
+            ->andWhere('urlRelation.url = :accessUrl')
+            ->setParameter('user', $user)
+            ->setParameter('teacherStatus', CourseRelUser::TEACHER)
+            ->setParameter('courseId', $courseId)
+            ->setParameter('accessUrl', $accessUrl)
+            ->setMaxResults(1)
+            ->getQuery()
+            ->getOneOrNullResult()
+        ;
+
+        return $relation?->getCourse();
+    }
+
+    /**
+     * Counts users directly registered as students in the base course.
+     */
+    public function countDirectStudentsForCourse(Course $course): int
+    {
+        return (int) $this->createQueryBuilder('cru')
+            ->select('COUNT(DISTINCT student.id)')
+            ->innerJoin('cru.user', 'student')
+            ->andWhere('cru.course = :course')
+            ->andWhere('cru.status = :studentStatus')
+            ->setParameter('course', $course)
+            ->setParameter('studentStatus', CourseRelUser::STUDENT)
+            ->getQuery()
+            ->getSingleScalarResult()
+        ;
     }
 
     /**

--- a/src/CoreBundle/Repository/CourseRelUserRepository.php
+++ b/src/CoreBundle/Repository/CourseRelUserRepository.php
@@ -6,6 +6,7 @@ declare(strict_types=1);
 
 namespace Chamilo\CoreBundle\Repository;
 
+use Chamilo\CoreBundle\Entity\AccessUrl;
 use Chamilo\CoreBundle\Entity\CourseRelUser;
 use Chamilo\CoreBundle\Entity\User;
 use Chamilo\CourseBundle\Entity\CLp;
@@ -18,6 +19,42 @@ class CourseRelUserRepository extends ServiceEntityRepository
     public function __construct(ManagerRegistry $registry)
     {
         parent::__construct($registry, CourseRelUser::class);
+    }
+
+    /**
+     * Returns courses managed by the user as a teacher in the given access URL.
+     *
+     * @return list<array{
+     *     id: int,
+     *     title: string,
+     *     code: string,
+     *     visualCode: string|null,
+     *     visibility: int
+     * }>
+     */
+    public function findTeacherCoursesForUserAndAccessUrl(User $user, AccessUrl $accessUrl): array
+    {
+        /** @var list<array{id: int, title: string, code: string, visualCode: string|null, visibility: int}> $courses */
+        $courses = $this->createQueryBuilder('cru')
+            ->select(
+                'DISTINCT course.id AS id, course.title AS title, course.code AS code, '
+                .'course.visualCode AS visualCode, course.visibility AS visibility'
+            )
+            ->innerJoin('cru.course', 'course')
+            ->innerJoin('course.urls', 'urlRelation')
+            ->andWhere('cru.user = :user')
+            ->andWhere('cru.status = :teacherStatus')
+            ->andWhere('urlRelation.url = :accessUrl')
+            ->setParameter('user', $user)
+            ->setParameter('teacherStatus', CourseRelUser::TEACHER)
+            ->setParameter('accessUrl', $accessUrl)
+            ->orderBy('course.title', 'ASC')
+            ->addOrderBy('course.id', 'ASC')
+            ->getQuery()
+            ->getArrayResult()
+        ;
+
+        return $courses;
     }
 
     /**

--- a/src/CoreBundle/Repository/CourseRelUserRepository.php
+++ b/src/CoreBundle/Repository/CourseRelUserRepository.php
@@ -36,7 +36,7 @@ class CourseRelUserRepository extends ServiceEntityRepository
     public function findTeacherCoursesForUserAndAccessUrl(User $user, AccessUrl $accessUrl): array
     {
         /** @var list<array{id: int, title: string, code: string, visualCode: string|null, visibility: int}> $courses */
-        $courses = $this->createQueryBuilder('cru')
+        return $this->createQueryBuilder('cru')
             ->select(
                 'DISTINCT course.id AS id, course.title AS title, course.code AS code, '
                 .'course.visualCode AS visualCode, course.visibility AS visibility'
@@ -54,8 +54,6 @@ class CourseRelUserRepository extends ServiceEntityRepository
             ->getQuery()
             ->getArrayResult()
         ;
-
-        return $courses;
     }
 
     /**

--- a/src/CoreBundle/Repository/UserApiKeyRepository.php
+++ b/src/CoreBundle/Repository/UserApiKeyRepository.php
@@ -1,0 +1,81 @@
+<?php
+
+/* For licensing terms, see /license.txt */
+
+declare(strict_types=1);
+
+namespace Chamilo\CoreBundle\Repository;
+
+use Chamilo\CoreBundle\Entity\UserApiKey;
+use DateTime;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @extends ServiceEntityRepository<UserApiKey>
+ */
+final class UserApiKeyRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, UserApiKey::class);
+    }
+
+    public function findForUserAndAccessUrl(int $userId, int $accessUrlId, string $service): ?UserApiKey
+    {
+        return $this->createQueryBuilder('apiKey')
+            ->andWhere('apiKey.userId = :userId')
+            ->andWhere('apiKey.accessUrlId = :accessUrlId')
+            ->andWhere('apiKey.apiService = :service')
+            ->setParameter('userId', $userId)
+            ->setParameter('accessUrlId', $accessUrlId)
+            ->setParameter('service', $service)
+            ->setMaxResults(1)
+            ->getQuery()
+            ->getOneOrNullResult()
+        ;
+    }
+
+    public function findActiveByHashAndAccessUrl(
+        string $hash,
+        int $accessUrlId,
+        string $service,
+        DateTime $now,
+    ): ?UserApiKey {
+        return $this->createQueryBuilder('apiKey')
+            ->andWhere('apiKey.apiKey = :hash')
+            ->andWhere('apiKey.accessUrlId = :accessUrlId')
+            ->andWhere('apiKey.apiService = :service')
+            ->andWhere('apiKey.revokedAt IS NULL')
+            ->andWhere('(apiKey.validityStartDate IS NULL OR apiKey.validityStartDate <= :now)')
+            ->andWhere('(apiKey.validityEndDate IS NULL OR apiKey.validityEndDate > :now)')
+            ->setParameter('hash', $hash)
+            ->setParameter('accessUrlId', $accessUrlId)
+            ->setParameter('service', $service)
+            ->setParameter('now', $now)
+            ->setMaxResults(1)
+            ->getQuery()
+            ->getOneOrNullResult()
+        ;
+    }
+
+    public function touchLastUsed(UserApiKey $apiKey, DateTime $now): void
+    {
+        $lastUsedAt = $apiKey->getLastUsedAt();
+        if (null !== $lastUsedAt && $lastUsedAt->getTimestamp() > $now->getTimestamp() - 300) {
+            return;
+        }
+
+        $this->createQueryBuilder('apiKey')
+            ->update()
+            ->set('apiKey.lastUsedAt', ':now')
+            ->andWhere('apiKey.id = :id')
+            ->setParameter('now', $now)
+            ->setParameter('id', $apiKey->getId())
+            ->getQuery()
+            ->execute()
+        ;
+
+        $apiKey->setLastUsedAt($now);
+    }
+}

--- a/src/CoreBundle/Security/Authenticator/McpBearerAuthenticator.php
+++ b/src/CoreBundle/Security/Authenticator/McpBearerAuthenticator.php
@@ -1,0 +1,166 @@
+<?php
+
+/* For licensing terms, see /license.txt */
+
+declare(strict_types=1);
+
+namespace Chamilo\CoreBundle\Security\Authenticator;
+
+use Chamilo\CoreBundle\Entity\AccessUrl;
+use Chamilo\CoreBundle\Entity\User;
+use Chamilo\CoreBundle\Entity\UserApiKey;
+use Chamilo\CoreBundle\Helpers\AccessUrlHelper;
+use Chamilo\CoreBundle\Repository\Node\AccessUrlRepository;
+use Chamilo\CoreBundle\Repository\Node\UserRepository;
+use Chamilo\CoreBundle\Repository\UserApiKeyRepository;
+use Chamilo\CoreBundle\Service\Mcp\McpApiKeyManager;
+use DateTime;
+use Exception;
+use Lexik\Bundle\JWTAuthenticationBundle\Services\JWTTokenManagerInterface;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\RateLimiter\RateLimiterFactory;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Exception\AuthenticationException;
+use Symfony\Component\Security\Core\Exception\CustomUserMessageAuthenticationException;
+use Symfony\Component\Security\Http\Authenticator\AbstractAuthenticator;
+use Symfony\Component\Security\Http\Authenticator\Passport\Badge\UserBadge;
+use Symfony\Component\Security\Http\Authenticator\Passport\Passport;
+use Symfony\Component\Security\Http\Authenticator\Passport\SelfValidatingPassport;
+use Symfony\Component\Security\Http\EntryPoint\AuthenticationEntryPointInterface;
+
+final class McpBearerAuthenticator extends AbstractAuthenticator implements AuthenticationEntryPointInterface
+{
+    public function __construct(
+        private readonly UserApiKeyRepository $apiKeyRepository,
+        private readonly UserRepository $userRepository,
+        private readonly AccessUrlHelper $accessUrlHelper,
+        private readonly AccessUrlRepository $accessUrlRepository,
+        private readonly JWTTokenManagerInterface $jwtManager,
+        private readonly RateLimiterFactory $mcpAuthenticationLimiter,
+    ) {}
+
+    public function supports(Request $request): ?bool
+    {
+        return '/mcp' === rtrim($request->getPathInfo(), '/')
+            && str_starts_with((string) $request->headers->get('Authorization', ''), 'Bearer ');
+    }
+
+    public function authenticate(Request $request): Passport
+    {
+        $limiter = $this->mcpAuthenticationLimiter->create((string) $request->getClientIp());
+        if (!$limiter->consume()->isAccepted()) {
+            throw new CustomUserMessageAuthenticationException('Too many MCP authentication attempts.');
+        }
+
+        $authorization = (string) $request->headers->get('Authorization', '');
+        $bearer = trim(substr($authorization, 7));
+        if ('' === $bearer || mb_strlen($bearer) > 4096) {
+            throw new CustomUserMessageAuthenticationException('Missing or invalid MCP bearer credential.');
+        }
+
+        if (McpApiKeyManager::isMcpKey($bearer)) {
+            return $this->authenticateApiKey($request, $bearer);
+        }
+
+        return $this->authenticateJwt($request, $bearer);
+    }
+
+    public function onAuthenticationSuccess(Request $request, TokenInterface $token, string $firewallName): ?Response
+    {
+        return null;
+    }
+
+    public function onAuthenticationFailure(Request $request, AuthenticationException $exception): ?Response
+    {
+        return new JsonResponse(
+            ['message' => $exception->getMessageKey()],
+            Response::HTTP_UNAUTHORIZED,
+        );
+    }
+
+    public function start(Request $request, ?AuthenticationException $authException = null): Response
+    {
+        return new JsonResponse(
+            ['message' => 'MCP authentication credentials are required.'],
+            Response::HTTP_UNAUTHORIZED,
+        );
+    }
+
+    private function authenticateApiKey(Request $request, string $plainKey): SelfValidatingPassport
+    {
+        $accessUrl = $this->resolveAccessUrl();
+        $now = new DateTime();
+        $hash = hash('sha256', $plainKey);
+        $apiKey = $this->apiKeyRepository->findActiveByHashAndAccessUrl(
+            $hash,
+            (int) $accessUrl->getId(),
+            McpApiKeyManager::SERVICE,
+            $now,
+        );
+
+        if (!$apiKey instanceof UserApiKey || !hash_equals($apiKey->getApiKey(), $hash)) {
+            throw new CustomUserMessageAuthenticationException('Invalid or revoked MCP API key.');
+        }
+
+        $user = $this->userRepository->find($apiKey->getUserId());
+        $this->assertUserCanAuthenticate($user, $accessUrl);
+        $this->apiKeyRepository->touchLastUsed($apiKey, $now);
+
+        $request->attributes->set('_chamilo_mcp_auth_source', 'api_key');
+
+        return new SelfValidatingPassport(
+            new UserBadge((string) $user->getId(), static fn (): User => $user),
+        );
+    }
+
+    private function authenticateJwt(Request $request, string $jwt): SelfValidatingPassport
+    {
+        try {
+            $payload = $this->jwtManager->parse($jwt);
+            $username = $payload['username'] ?? $payload['sub'] ?? null;
+            if (!\is_string($username) || '' === trim($username)) {
+                throw new Exception('JWT username claim is missing.');
+            }
+        } catch (Exception) {
+            throw new CustomUserMessageAuthenticationException('Invalid or expired MCP JWT.');
+        }
+
+        $user = $this->userRepository->findOneBy(['username' => $username]);
+        $accessUrl = $this->resolveAccessUrl();
+        $this->assertUserCanAuthenticate($user, $accessUrl);
+
+        $request->attributes->set('_chamilo_mcp_auth_source', 'jwt');
+
+        return new SelfValidatingPassport(
+            new UserBadge((string) $user->getId(), static fn (): User => $user),
+        );
+    }
+
+    private function resolveAccessUrl(): AccessUrl
+    {
+        $accessUrl = $this->accessUrlHelper->getCurrent();
+        if (!$accessUrl instanceof AccessUrl || null === $accessUrl->getId()) {
+            throw new CustomUserMessageAuthenticationException('The current Chamilo portal could not be resolved.');
+        }
+
+        return $accessUrl;
+    }
+
+    private function assertUserCanAuthenticate(?User $user, AccessUrl $accessUrl): void
+    {
+        if (!$user instanceof User || User::ACTIVE !== $user->getActive()) {
+            throw new CustomUserMessageAuthenticationException('The MCP user account is inactive.');
+        }
+
+        $expirationDate = $user->getExpirationDate();
+        if (null !== $expirationDate && $expirationDate <= new DateTime()) {
+            throw new CustomUserMessageAuthenticationException('The MCP user account has expired.');
+        }
+
+        if (!$this->accessUrlRepository->isUrlActiveForUser($accessUrl, $user)) {
+            throw new CustomUserMessageAuthenticationException('The MCP user is not active on this Chamilo portal.');
+        }
+    }
+}

--- a/src/CoreBundle/Service/Ai/AiRequestQuotaGuard.php
+++ b/src/CoreBundle/Service/Ai/AiRequestQuotaGuard.php
@@ -10,6 +10,7 @@ use Chamilo\CoreBundle\Entity\AiRequests;
 use Chamilo\CoreBundle\Entity\User;
 use Chamilo\CoreBundle\Settings\SettingsManager;
 use DateTimeImmutable;
+use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\EntityManagerInterface;
 use RuntimeException;
 
@@ -63,15 +64,7 @@ final readonly class AiRequestQuotaGuard
             );
 
             if ($dailyUsed + $reservedTokens > $dailyLimit) {
-                throw new RuntimeException(
-                    sprintf(
-                        'The daily AI token limit for provider "%s" has been reached (used: %d, reserved for this request: %d, limit: %d).',
-                        $provider,
-                        $dailyUsed,
-                        $reservedTokens,
-                        $dailyLimit,
-                    )
-                );
+                throw new RuntimeException(\sprintf('The daily AI token limit for provider "%s" has been reached (used: %d, reserved for this request: %d, limit: %d).', $provider, $dailyUsed, $reservedTokens, $dailyLimit));
             }
         }
 
@@ -83,15 +76,7 @@ final readonly class AiRequestQuotaGuard
             );
 
             if ($monthlyUsed + $reservedTokens > $monthlyLimit) {
-                throw new RuntimeException(
-                    sprintf(
-                        'The monthly AI token limit for provider "%s" has been reached (used: %d, reserved for this request: %d, limit: %d).',
-                        $provider,
-                        $monthlyUsed,
-                        $reservedTokens,
-                        $monthlyLimit,
-                    )
-                );
+                throw new RuntimeException(\sprintf('The monthly AI token limit for provider "%s" has been reached (used: %d, reserved for this request: %d, limit: %d).', $provider, $monthlyUsed, $reservedTokens, $monthlyLimit));
             }
         }
     }
@@ -154,9 +139,13 @@ final readonly class AiRequestQuotaGuard
             ->andWhere('aiRequest.userId = :userId')
             ->andWhere('aiRequest.aiProvider = :provider')
             ->andWhere('aiRequest.requestedAt >= :start')
-            ->setParameter('userId', $userId)
-            ->setParameter('provider', $provider)
-            ->setParameter('start', $start)
+            ->setParameter('userId', $userId, Types::INTEGER)
+            ->setParameter('provider', $provider, Types::STRING)
+            ->setParameter(
+                'start',
+                $start,
+                Types::DATETIME_IMMUTABLE,
+            )
             ->getQuery()
             ->getSingleScalarResult()
         ;

--- a/src/CoreBundle/Service/Ai/AiRequestQuotaGuard.php
+++ b/src/CoreBundle/Service/Ai/AiRequestQuotaGuard.php
@@ -1,0 +1,166 @@
+<?php
+
+/* For licensing terms, see /license.txt */
+
+declare(strict_types=1);
+
+namespace Chamilo\CoreBundle\Service\Ai;
+
+use Chamilo\CoreBundle\Entity\AiRequests;
+use Chamilo\CoreBundle\Entity\User;
+use Chamilo\CoreBundle\Settings\SettingsManager;
+use DateTimeImmutable;
+use Doctrine\ORM\EntityManagerInterface;
+use RuntimeException;
+
+final readonly class AiRequestQuotaGuard
+{
+    public function __construct(
+        private SettingsManager $settingsManager,
+        private EntityManagerInterface $entityManager,
+    ) {}
+
+    public function assertCanRequest(
+        User $user,
+        string $provider,
+        string $serviceType,
+    ): void {
+        $userId = (int) ($user->getId() ?? 0);
+        if ($userId <= 0) {
+            throw new RuntimeException('An authenticated Chamilo user is required.');
+        }
+
+        $provider = trim($provider);
+        $serviceType = trim($serviceType);
+        $config = $this->readProvidersConfig();
+
+        if (
+            '' === $provider
+            || !isset($config[$provider])
+            || !\is_array($config[$provider])
+        ) {
+            return;
+        }
+
+        $providerConfig = $config[$provider];
+        $dailyLimit = max(0, (int) ($providerConfig['daily_token_limit'] ?? 0));
+        $monthlyLimit = max(0, (int) ($providerConfig['monthly_token_limit'] ?? 0));
+
+        if ($dailyLimit <= 0 && $monthlyLimit <= 0) {
+            return;
+        }
+
+        $reservedTokens = $this->getConfiguredRequestTokenCost(
+            $providerConfig,
+            $serviceType,
+        );
+
+        if ($dailyLimit > 0) {
+            $dailyUsed = $this->getTokensUsedSince(
+                $userId,
+                $provider,
+                new DateTimeImmutable('today'),
+            );
+
+            if ($dailyUsed + $reservedTokens > $dailyLimit) {
+                throw new RuntimeException(
+                    sprintf(
+                        'The daily AI token limit for provider "%s" has been reached (used: %d, reserved for this request: %d, limit: %d).',
+                        $provider,
+                        $dailyUsed,
+                        $reservedTokens,
+                        $dailyLimit,
+                    )
+                );
+            }
+        }
+
+        if ($monthlyLimit > 0) {
+            $monthlyUsed = $this->getTokensUsedSince(
+                $userId,
+                $provider,
+                new DateTimeImmutable('first day of this month 00:00:00'),
+            );
+
+            if ($monthlyUsed + $reservedTokens > $monthlyLimit) {
+                throw new RuntimeException(
+                    sprintf(
+                        'The monthly AI token limit for provider "%s" has been reached (used: %d, reserved for this request: %d, limit: %d).',
+                        $provider,
+                        $monthlyUsed,
+                        $reservedTokens,
+                        $monthlyLimit,
+                    )
+                );
+            }
+        }
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function readProvidersConfig(): array
+    {
+        $raw = $this->settingsManager->getSetting(
+            'ai_helpers.ai_providers',
+            true,
+        );
+
+        if (\is_array($raw)) {
+            return $raw;
+        }
+
+        if (!\is_string($raw) || '' === trim($raw)) {
+            return [];
+        }
+
+        $decoded = json_decode($raw, true);
+
+        return \is_array($decoded) ? $decoded : [];
+    }
+
+    /**
+     * @param array<string, mixed> $providerConfig
+     */
+    private function getConfiguredRequestTokenCost(
+        array $providerConfig,
+        string $serviceType,
+    ): int {
+        $typeConfig = $providerConfig[$serviceType] ?? [];
+        if (!\is_array($typeConfig)) {
+            $typeConfig = [];
+        }
+
+        $configuredCost = $typeConfig['token_cost']
+            ?? $typeConfig['estimated_token_cost']
+            ?? $providerConfig['token_cost']
+            ?? $providerConfig['estimated_token_cost']
+            ?? $typeConfig['max_tokens']
+            ?? $typeConfig['max_output_tokens']
+            ?? 0;
+
+        return max(0, (int) $configuredCost);
+    }
+
+    private function getTokensUsedSince(
+        int $userId,
+        string $provider,
+        DateTimeImmutable $start,
+    ): int {
+        $value = $this->entityManager
+            ->createQueryBuilder()
+            ->select('COALESCE(SUM(aiRequest.totalTokens), 0)')
+            ->from(AiRequests::class, 'aiRequest')
+            ->andWhere('aiRequest.userId = :userId')
+            ->andWhere('aiRequest.aiProvider = :provider')
+            ->andWhere('aiRequest.requestedAt >= :start')
+            ->setParameter('userId', $userId)
+            ->setParameter('provider', $provider)
+            ->setParameter('start', $start)
+            ->getQuery()
+            ->getSingleScalarResult()
+        ;
+
+        return (int) $value;
+    }
+}

--- a/src/CoreBundle/Service/Ai/GeneratedMediaStorageService.php
+++ b/src/CoreBundle/Service/Ai/GeneratedMediaStorageService.php
@@ -15,6 +15,7 @@ use Chamilo\CoreBundle\Repository\Node\CourseRepository;
 use Chamilo\CourseBundle\Entity\CDocument;
 use Chamilo\CourseBundle\Repository\CDocumentRepository;
 use Doctrine\ORM\EntityManager;
+use finfo;
 use InvalidArgumentException;
 use RuntimeException;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
@@ -23,9 +24,13 @@ use Symfony\Component\HttpKernel\KernelInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
+use const DNS_A;
+use const DNS_AAAA;
+use const FILEINFO_MIME_TYPE;
 use const FILTER_FLAG_NO_PRIV_RANGE;
 use const FILTER_FLAG_NO_RES_RANGE;
 use const FILTER_VALIDATE_IP;
+use const JSON_THROW_ON_ERROR;
 
 final readonly class GeneratedMediaStorageService
 {
@@ -70,9 +75,7 @@ final readonly class GeneratedMediaStorageService
 
         $detectedMimeType = $this->detectImageMimeType($binary);
         if (!isset(self::IMAGE_EXTENSIONS[$detectedMimeType])) {
-            throw new RuntimeException(
-                'The generated file is not a supported image.'
-            );
+            throw new RuntimeException('The generated file is not a supported image.');
         }
 
         $extension = self::IMAGE_EXTENSIONS[$detectedMimeType];
@@ -80,17 +83,13 @@ final readonly class GeneratedMediaStorageService
         $temporaryPath = tempnam(sys_get_temp_dir(), 'chamilo_mcp_image_');
 
         if (false === $temporaryPath) {
-            throw new RuntimeException(
-                'A temporary file for the generated image could not be created.'
-            );
+            throw new RuntimeException('A temporary file for the generated image could not be created.');
         }
 
         try {
             $writtenBytes = file_put_contents($temporaryPath, $binary);
             if (false === $writtenBytes || $writtenBytes <= 0) {
-                throw new RuntimeException(
-                    'The generated image could not be written to temporary storage.'
-                );
+                throw new RuntimeException('The generated image could not be written to temporary storage.');
             }
 
             if (
@@ -98,9 +97,7 @@ final readonly class GeneratedMediaStorageService
                 && !str_starts_with($declaredMimeType, 'image/')
                 && 'application/octet-stream' !== $declaredMimeType
             ) {
-                throw new RuntimeException(
-                    'The AI provider returned an invalid image content type.'
-                );
+                throw new RuntimeException('The AI provider returned an invalid image content type.');
             }
 
             $uploadedFile = new UploadedFile(
@@ -116,7 +113,7 @@ final readonly class GeneratedMediaStorageService
                 : ResourceLink::VISIBILITY_DRAFT;
 
             /** @var CDocument $document */
-            $document = $this->entityManager->wrapInTransaction(
+            return $this->entityManager->wrapInTransaction(
                 function () use (
                     $course,
                     $courseId,
@@ -127,9 +124,7 @@ final readonly class GeneratedMediaStorageService
                 ): CDocument {
                     $courseResourceNode = $course->getResourceNode();
                     if (null === $courseResourceNode || null === $courseResourceNode->getId()) {
-                        throw new RuntimeException(
-                            'The course resource node could not be resolved.'
-                        );
+                        throw new RuntimeException('The course resource node could not be resolved.');
                     }
 
                     $request = Request::create(
@@ -165,8 +160,6 @@ final readonly class GeneratedMediaStorageService
                     );
                 }
             );
-
-            return $document;
         } finally {
             if (is_file($temporaryPath)) {
                 @unlink($temporaryPath);
@@ -185,9 +178,7 @@ final readonly class GeneratedMediaStorageService
         if (\is_string($generatedResult)) {
             $value = trim($generatedResult);
             if ('' === $value) {
-                throw new RuntimeException(
-                    'The AI provider returned an empty image.'
-                );
+                throw new RuntimeException('The AI provider returned an empty image.');
             }
 
             if (preg_match('#^https://#i', $value)) {
@@ -233,9 +224,7 @@ final readonly class GeneratedMediaStorageService
             return $this->fetchRemoteImage($url);
         }
 
-        throw new RuntimeException(
-            'The AI provider did not return usable image content.'
-        );
+        throw new RuntimeException('The AI provider did not return usable image content.');
     }
 
     private function decodeBase64Image(string $content): string
@@ -243,9 +232,7 @@ final readonly class GeneratedMediaStorageService
         if (str_starts_with($content, 'data:')) {
             $commaPosition = strpos($content, ',');
             if (false === $commaPosition) {
-                throw new InvalidArgumentException(
-                    'The generated image data URI is invalid.'
-                );
+                throw new InvalidArgumentException('The generated image data URI is invalid.');
             }
 
             $content = substr($content, $commaPosition + 1);
@@ -257,15 +244,11 @@ final readonly class GeneratedMediaStorageService
         );
 
         if (false === $binary || '' === $binary) {
-            throw new RuntimeException(
-                'The AI provider returned invalid base64 image content.'
-            );
+            throw new RuntimeException('The AI provider returned invalid base64 image content.');
         }
 
         if (\strlen($binary) > self::MAX_IMAGE_BYTES) {
-            throw new RuntimeException(
-                'The generated image exceeds the maximum allowed size.'
-            );
+            throw new RuntimeException('The generated image exceeds the maximum allowed size.');
         }
 
         return $binary;
@@ -277,9 +260,7 @@ final readonly class GeneratedMediaStorageService
     private function fetchRemoteImage(string $url): array
     {
         if (!$this->isSafeRemoteUrl($url)) {
-            throw new RuntimeException(
-                'The remote image URL is not allowed.'
-            );
+            throw new RuntimeException('The remote image URL is not allowed.');
         }
 
         $response = $this->httpClient->request('GET', $url, [
@@ -289,9 +270,7 @@ final readonly class GeneratedMediaStorageService
 
         $statusCode = $response->getStatusCode();
         if ($statusCode < 200 || $statusCode >= 300) {
-            throw new RuntimeException(
-                'The remote image could not be downloaded.'
-            );
+            throw new RuntimeException('The remote image could not be downloaded.');
         }
 
         $headers = $response->getHeaders(false);
@@ -302,16 +281,12 @@ final readonly class GeneratedMediaStorageService
             && is_numeric($length)
             && (int) $length > self::MAX_IMAGE_BYTES
         ) {
-            throw new RuntimeException(
-                'The remote image exceeds the maximum allowed size.'
-            );
+            throw new RuntimeException('The remote image exceeds the maximum allowed size.');
         }
 
         $binary = $response->getContent(false);
         if ('' === $binary || \strlen($binary) > self::MAX_IMAGE_BYTES) {
-            throw new RuntimeException(
-                'The remote image content is empty or too large.'
-            );
+            throw new RuntimeException('The remote image content is empty or too large.');
         }
 
         $contentType = $headers['content-type'][0] ?? 'application/octet-stream';
@@ -368,7 +343,7 @@ final readonly class GeneratedMediaStorageService
 
     private function detectImageMimeType(string $binary): string
     {
-        $fileInfo = new \finfo(FILEINFO_MIME_TYPE);
+        $fileInfo = new finfo(FILEINFO_MIME_TYPE);
         $mimeType = $fileInfo->buffer($binary);
 
         return \is_string($mimeType)

--- a/src/CoreBundle/Service/Ai/GeneratedMediaStorageService.php
+++ b/src/CoreBundle/Service/Ai/GeneratedMediaStorageService.php
@@ -1,0 +1,401 @@
+<?php
+
+/* For licensing terms, see /license.txt */
+
+declare(strict_types=1);
+
+namespace Chamilo\CoreBundle\Service\Ai;
+
+use Chamilo\CoreBundle\Controller\Api\CreateDocumentFileAction;
+use Chamilo\CoreBundle\Entity\Course;
+use Chamilo\CoreBundle\Entity\ResourceLink;
+use Chamilo\CoreBundle\Helpers\AiDisclosureHelper;
+use Chamilo\CoreBundle\Helpers\CourseHelper;
+use Chamilo\CoreBundle\Repository\Node\CourseRepository;
+use Chamilo\CourseBundle\Entity\CDocument;
+use Chamilo\CourseBundle\Repository\CDocumentRepository;
+use Doctrine\ORM\EntityManager;
+use InvalidArgumentException;
+use RuntimeException;
+use Symfony\Component\HttpFoundation\File\UploadedFile;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\KernelInterface;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+use const FILTER_FLAG_NO_PRIV_RANGE;
+use const FILTER_FLAG_NO_RES_RANGE;
+use const FILTER_VALIDATE_IP;
+
+final readonly class GeneratedMediaStorageService
+{
+    private const MAX_IMAGE_BYTES = 10_485_760;
+
+    /**
+     * @var array<string, string>
+     */
+    private const IMAGE_EXTENSIONS = [
+        'image/gif' => 'gif',
+        'image/jpeg' => 'jpg',
+        'image/png' => 'png',
+        'image/webp' => 'webp',
+        'image/avif' => 'avif',
+    ];
+
+    public function __construct(
+        private HttpClientInterface $httpClient,
+        private CDocumentRepository $documentRepository,
+        private CreateDocumentFileAction $createDocumentFileAction,
+        private EntityManager $entityManager,
+        private KernelInterface $kernel,
+        private TranslatorInterface $translator,
+        private CourseRepository $courseRepository,
+        private CourseHelper $courseHelper,
+        private AiDisclosureHelper $aiDisclosureHelper,
+    ) {}
+
+    /**
+     * @param array<string, mixed>|string $generatedResult
+     */
+    public function storeGeneratedImage(
+        Course $course,
+        int $courseId,
+        string $title,
+        string $topic,
+        array|string $generatedResult,
+        ?string $language,
+        bool $publish,
+    ): CDocument {
+        [$binary, $declaredMimeType] = $this->resolveImageBinary($generatedResult);
+
+        $detectedMimeType = $this->detectImageMimeType($binary);
+        if (!isset(self::IMAGE_EXTENSIONS[$detectedMimeType])) {
+            throw new RuntimeException(
+                'The generated file is not a supported image.'
+            );
+        }
+
+        $extension = self::IMAGE_EXTENSIONS[$detectedMimeType];
+        $fileName = $this->buildSafeFileName($title, $extension);
+        $temporaryPath = tempnam(sys_get_temp_dir(), 'chamilo_mcp_image_');
+
+        if (false === $temporaryPath) {
+            throw new RuntimeException(
+                'A temporary file for the generated image could not be created.'
+            );
+        }
+
+        try {
+            $writtenBytes = file_put_contents($temporaryPath, $binary);
+            if (false === $writtenBytes || $writtenBytes <= 0) {
+                throw new RuntimeException(
+                    'The generated image could not be written to temporary storage.'
+                );
+            }
+
+            if (
+                '' !== $declaredMimeType
+                && !str_starts_with($declaredMimeType, 'image/')
+                && 'application/octet-stream' !== $declaredMimeType
+            ) {
+                throw new RuntimeException(
+                    'The AI provider returned an invalid image content type.'
+                );
+            }
+
+            $uploadedFile = new UploadedFile(
+                $temporaryPath,
+                $fileName,
+                $detectedMimeType,
+                null,
+                true,
+            );
+
+            $visibility = $publish
+                ? ResourceLink::VISIBILITY_PUBLISHED
+                : ResourceLink::VISIBILITY_DRAFT;
+
+            /** @var CDocument $document */
+            $document = $this->entityManager->wrapInTransaction(
+                function () use (
+                    $course,
+                    $courseId,
+                    $topic,
+                    $language,
+                    $visibility,
+                    $uploadedFile,
+                ): CDocument {
+                    $courseResourceNode = $course->getResourceNode();
+                    if (null === $courseResourceNode || null === $courseResourceNode->getId()) {
+                        throw new RuntimeException(
+                            'The course resource node could not be resolved.'
+                        );
+                    }
+
+                    $request = Request::create(
+                        '/api/documents?cid='.$courseId,
+                        'POST',
+                        [
+                            'filetype' => 'file',
+                            'comment' => $topic,
+                            'parentResourceNodeId' => (int) $courseResourceNode->getId(),
+                            'resourceLinkList' => json_encode(
+                                [['visibility' => $visibility]],
+                                JSON_THROW_ON_ERROR,
+                            ),
+                            'fileExistsOption' => 'rename',
+                            'language' => $language ?? '',
+                            'ai_assisted' => '1',
+                        ],
+                        [],
+                        ['uploadFile' => $uploadedFile],
+                        [],
+                        '',
+                    );
+
+                    return ($this->createDocumentFileAction)(
+                        $request,
+                        $this->documentRepository,
+                        $this->entityManager,
+                        $this->kernel,
+                        $this->translator,
+                        $this->courseRepository,
+                        $this->courseHelper,
+                        $this->aiDisclosureHelper,
+                    );
+                }
+            );
+
+            return $document;
+        } finally {
+            if (is_file($temporaryPath)) {
+                @unlink($temporaryPath);
+            }
+        }
+    }
+
+    /**
+     * @param array<string, mixed>|string $generatedResult
+     *
+     * @return array{0: string, 1: string}
+     */
+    private function resolveImageBinary(
+        array|string $generatedResult,
+    ): array {
+        if (\is_string($generatedResult)) {
+            $value = trim($generatedResult);
+            if ('' === $value) {
+                throw new RuntimeException(
+                    'The AI provider returned an empty image.'
+                );
+            }
+
+            if (preg_match('#^https://#i', $value)) {
+                return $this->fetchRemoteImage($value);
+            }
+
+            return [
+                $this->decodeBase64Image($value),
+                'image/png',
+            ];
+        }
+
+        if (
+            isset($generatedResult['error'])
+            && \is_string($generatedResult['error'])
+            && '' !== trim($generatedResult['error'])
+        ) {
+            throw new RuntimeException(trim($generatedResult['error']));
+        }
+
+        $isBase64 = (bool) ($generatedResult['is_base64'] ?? false);
+        $content = isset($generatedResult['content'])
+            && \is_string($generatedResult['content'])
+                ? trim($generatedResult['content'])
+                : '';
+        $url = isset($generatedResult['url'])
+            && \is_string($generatedResult['url'])
+                ? trim($generatedResult['url'])
+                : '';
+        $contentType = isset($generatedResult['content_type'])
+            && \is_string($generatedResult['content_type'])
+                ? $this->normalizeMimeType($generatedResult['content_type'])
+                : 'image/png';
+
+        if ($isBase64 && '' !== $content) {
+            return [
+                $this->decodeBase64Image($content),
+                $contentType,
+            ];
+        }
+
+        if ('' !== $url) {
+            return $this->fetchRemoteImage($url);
+        }
+
+        throw new RuntimeException(
+            'The AI provider did not return usable image content.'
+        );
+    }
+
+    private function decodeBase64Image(string $content): string
+    {
+        if (str_starts_with($content, 'data:')) {
+            $commaPosition = strpos($content, ',');
+            if (false === $commaPosition) {
+                throw new InvalidArgumentException(
+                    'The generated image data URI is invalid.'
+                );
+            }
+
+            $content = substr($content, $commaPosition + 1);
+        }
+
+        $binary = base64_decode(
+            preg_replace('/\s+/', '', $content) ?? '',
+            true,
+        );
+
+        if (false === $binary || '' === $binary) {
+            throw new RuntimeException(
+                'The AI provider returned invalid base64 image content.'
+            );
+        }
+
+        if (\strlen($binary) > self::MAX_IMAGE_BYTES) {
+            throw new RuntimeException(
+                'The generated image exceeds the maximum allowed size.'
+            );
+        }
+
+        return $binary;
+    }
+
+    /**
+     * @return array{0: string, 1: string}
+     */
+    private function fetchRemoteImage(string $url): array
+    {
+        if (!$this->isSafeRemoteUrl($url)) {
+            throw new RuntimeException(
+                'The remote image URL is not allowed.'
+            );
+        }
+
+        $response = $this->httpClient->request('GET', $url, [
+            'headers' => ['Accept' => 'image/*'],
+            'max_redirects' => 0,
+        ]);
+
+        $statusCode = $response->getStatusCode();
+        if ($statusCode < 200 || $statusCode >= 300) {
+            throw new RuntimeException(
+                'The remote image could not be downloaded.'
+            );
+        }
+
+        $headers = $response->getHeaders(false);
+        $length = $headers['content-length'][0] ?? null;
+
+        if (
+            null !== $length
+            && is_numeric($length)
+            && (int) $length > self::MAX_IMAGE_BYTES
+        ) {
+            throw new RuntimeException(
+                'The remote image exceeds the maximum allowed size.'
+            );
+        }
+
+        $binary = $response->getContent(false);
+        if ('' === $binary || \strlen($binary) > self::MAX_IMAGE_BYTES) {
+            throw new RuntimeException(
+                'The remote image content is empty or too large.'
+            );
+        }
+
+        $contentType = $headers['content-type'][0] ?? 'application/octet-stream';
+
+        return [
+            $binary,
+            $this->normalizeMimeType((string) $contentType),
+        ];
+    }
+
+    private function isSafeRemoteUrl(string $url): bool
+    {
+        $parts = parse_url($url);
+        if (!\is_array($parts)) {
+            return false;
+        }
+
+        if ('https' !== strtolower((string) ($parts['scheme'] ?? ''))) {
+            return false;
+        }
+
+        $host = strtolower((string) ($parts['host'] ?? ''));
+        if (
+            '' === $host
+            || \in_array($host, ['localhost', '127.0.0.1', '::1'], true)
+        ) {
+            return false;
+        }
+
+        $records = dns_get_record($host, DNS_A | DNS_AAAA);
+        if (false === $records || [] === $records) {
+            return false;
+        }
+
+        foreach ($records as $record) {
+            $ip = $record['ip'] ?? $record['ipv6'] ?? null;
+            if (!\is_string($ip) || !filter_var($ip, FILTER_VALIDATE_IP)) {
+                return false;
+            }
+
+            if (
+                !filter_var(
+                    $ip,
+                    FILTER_VALIDATE_IP,
+                    FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE,
+                )
+            ) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private function detectImageMimeType(string $binary): string
+    {
+        $fileInfo = new \finfo(FILEINFO_MIME_TYPE);
+        $mimeType = $fileInfo->buffer($binary);
+
+        return \is_string($mimeType)
+            ? $this->normalizeMimeType($mimeType)
+            : '';
+    }
+
+    private function normalizeMimeType(string $mimeType): string
+    {
+        return strtolower(trim(explode(';', $mimeType, 2)[0]));
+    }
+
+    private function buildSafeFileName(
+        string $title,
+        string $extension,
+    ): string {
+        $name = trim(strip_tags($title));
+        $name = preg_replace('/[\/\\\\\x00-\x1F\x7F]+/u', '_', $name) ?? '';
+        $name = preg_replace('/\s+/u', ' ', $name) ?? '';
+        $name = trim($name, " .\t\n\r\0\x0B");
+
+        if ('' === $name) {
+            $name = 'generated_illustration';
+        }
+
+        $name = mb_substr($name, 0, 180);
+
+        return $name.'.'.$extension;
+    }
+}

--- a/src/CoreBundle/Service/Assignment/McpCourseAssignmentCreator.php
+++ b/src/CoreBundle/Service/Assignment/McpCourseAssignmentCreator.php
@@ -14,6 +14,7 @@ use Chamilo\CourseBundle\Entity\CStudentPublicationAssignment;
 use Chamilo\CourseBundle\Repository\CStudentPublicationRepository;
 use DateTime;
 use InvalidArgumentException;
+use Security;
 
 final readonly class McpCourseAssignmentCreator
 {
@@ -39,18 +40,18 @@ final readonly class McpCourseAssignmentCreator
         if ('' === $title) {
             throw new InvalidArgumentException('The assignment title is required.');
         }
-        if (255 < mb_strlen($title)) {
+        if (mb_strlen($title) > 255) {
             throw new InvalidArgumentException('The assignment title cannot be longer than 255 characters.');
         }
-        if (2_000_000 < mb_strlen($description)) {
+        if (mb_strlen($description) > 2_000_000) {
             throw new InvalidArgumentException('The assignment description is too large.');
         }
 
-        $description = (string) \Security::remove_XSS($description);
+        $description = (string) Security::remove_XSS($description);
         if ('' === trim(strip_tags($description))) {
             throw new InvalidArgumentException('The assignment description is required.');
         }
-        if (0.0 >= $maximumScore || 100000.0 < $maximumScore) {
+        if ($maximumScore <= 0.0 || $maximumScore > 100000.0) {
             throw new InvalidArgumentException('The maximum score must be greater than zero and no greater than 100000.');
         }
         if (!\in_array($submissionMode, [0, 1, 2], true)) {

--- a/src/CoreBundle/Service/Assignment/McpCourseAssignmentCreator.php
+++ b/src/CoreBundle/Service/Assignment/McpCourseAssignmentCreator.php
@@ -1,0 +1,106 @@
+<?php
+
+/* For licensing terms, see /license.txt */
+
+declare(strict_types=1);
+
+namespace Chamilo\CoreBundle\Service\Assignment;
+
+use Chamilo\CoreBundle\Entity\Course;
+use Chamilo\CoreBundle\Entity\ResourceLink;
+use Chamilo\CoreBundle\Entity\User;
+use Chamilo\CourseBundle\Entity\CStudentPublication;
+use Chamilo\CourseBundle\Entity\CStudentPublicationAssignment;
+use Chamilo\CourseBundle\Repository\CStudentPublicationRepository;
+use DateTime;
+use InvalidArgumentException;
+
+final readonly class McpCourseAssignmentCreator
+{
+    public function __construct(
+        private CStudentPublicationRepository $publicationRepository,
+    ) {}
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function create(
+        Course $course,
+        User $user,
+        string $title,
+        string $description,
+        float $maximumScore,
+        bool $publish,
+        int $submissionMode,
+    ): array {
+        $title = trim(strip_tags($title));
+        $description = trim($description);
+
+        if ('' === $title) {
+            throw new InvalidArgumentException('The assignment title is required.');
+        }
+        if (255 < mb_strlen($title)) {
+            throw new InvalidArgumentException('The assignment title cannot be longer than 255 characters.');
+        }
+        if (2_000_000 < mb_strlen($description)) {
+            throw new InvalidArgumentException('The assignment description is too large.');
+        }
+
+        $description = (string) \Security::remove_XSS($description);
+        if ('' === trim(strip_tags($description))) {
+            throw new InvalidArgumentException('The assignment description is required.');
+        }
+        if (0.0 >= $maximumScore || 100000.0 < $maximumScore) {
+            throw new InvalidArgumentException('The maximum score must be greater than zero and no greater than 100000.');
+        }
+        if (!\in_array($submissionMode, [0, 1, 2], true)) {
+            throw new InvalidArgumentException('The submission mode must be 0, 1 or 2.');
+        }
+
+        $visibility = $publish
+            ? ResourceLink::VISIBILITY_PUBLISHED
+            : ResourceLink::VISIBILITY_DRAFT;
+
+        $publication = (new CStudentPublication())
+            ->setTitle($title)
+            ->setDescription($description)
+            ->setUser($user)
+            ->setAuthor($user->getFullName())
+            ->setSentDate(new DateTime())
+            ->setQualification($maximumScore)
+            ->setWeight(0.0)
+            ->setAllowTextAssignment($submissionMode)
+            ->setFiletype('folder')
+            ->setActive(1)
+            ->setAccepted(true)
+            ->setPostGroupId(0)
+            ->setQualificatorId(0)
+            ->setParent($course)
+            ->addCourseLink($course, null, null, $visibility)
+        ;
+
+        $assignment = (new CStudentPublicationAssignment())
+            ->setPublication($publication)
+            ->setEnableQualification(true)
+            ->setEventCalendarId(0)
+        ;
+        $publication->setAssignment($assignment);
+
+        $this->publicationRepository->create($publication);
+
+        return [
+            'assignment_id' => (int) $publication->getIid(),
+            'resource_node_id' => (int) $publication->getResourceNode()?->getId(),
+            'title' => $publication->getTitle(),
+            'description' => $publication->getDescription(),
+            'maximum_score' => $publication->getQualification(),
+            'submission_mode' => $publication->getAllowTextAssignment(),
+            'published' => $publish,
+            'content_url' => '/resources/assignment/'
+                .(int) $course->getResourceNode()?->getId()
+                .'/submission/'
+                .(int) $publication->getIid()
+                .'?cid='.(int) $course->getId(),
+        ];
+    }
+}

--- a/src/CoreBundle/Service/Course/McpCourseQualityReviewer.php
+++ b/src/CoreBundle/Service/Course/McpCourseQualityReviewer.php
@@ -24,7 +24,6 @@ use Chamilo\CourseBundle\Entity\CSurvey;
 use Doctrine\DBAL\ArrayParameterType;
 use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\EntityManagerInterface;
-use RuntimeException;
 
 final readonly class McpCourseQualityReviewer
 {
@@ -44,8 +43,7 @@ final readonly class McpCourseQualityReviewer
         User $user,
         ?string $focus,
         ?string $provider,
-    ): array
-    {
+    ): array {
         $enabledFeatures = $this->courseAiFeatureManager->ensureEnabled(
             $course,
             $user,
@@ -55,7 +53,7 @@ final readonly class McpCourseQualityReviewer
 
         $providerName = $this->aiService->resolveProvider($user, $provider);
         $teacherPrompt = trim(strip_tags((string) $focus));
-        if (5000 < mb_strlen($teacherPrompt)) {
+        if (mb_strlen($teacherPrompt) > 5000) {
             $teacherPrompt = mb_substr($teacherPrompt, 0, 5000);
         }
         if ('' === $teacherPrompt) {
@@ -152,8 +150,7 @@ final readonly class McpCourseQualityReviewer
         string $resourceClass,
         Course $course,
         bool $excludeFolders = false,
-    ): array
-    {
+    ): array {
         return [
             'total' => $this->countResources($resourceClass, $course, $excludeFolders, null),
             'published' => $this->countResources(
@@ -185,8 +182,7 @@ final readonly class McpCourseQualityReviewer
         Course $course,
         bool $excludeFolders,
         ?int $visibility,
-    ): int
-    {
+    ): int {
         $queryBuilder = $this->entityManager->createQueryBuilder()
             ->select('COUNT(DISTINCT resource.iid)')
             ->from($resourceClass, 'resource')

--- a/src/CoreBundle/Service/Course/McpCourseQualityReviewer.php
+++ b/src/CoreBundle/Service/Course/McpCourseQualityReviewer.php
@@ -1,0 +1,249 @@
+<?php
+
+/* For licensing terms, see /license.txt */
+
+declare(strict_types=1);
+
+namespace Chamilo\CoreBundle\Service\Course;
+
+use Chamilo\CoreBundle\AiProvider\AiCourseAnalyzerService;
+use Chamilo\CoreBundle\Entity\AbstractResource;
+use Chamilo\CoreBundle\Entity\Course;
+use Chamilo\CoreBundle\Entity\ResourceLink;
+use Chamilo\CoreBundle\Entity\User;
+use Chamilo\CoreBundle\Helpers\AiDisclosureHelper;
+use Chamilo\CoreBundle\Service\Mcp\McpCourseAiFeatureManager;
+use Chamilo\CoreBundle\Service\Mcp\McpTextAiService;
+use Chamilo\CourseBundle\Entity\CDocument;
+use Chamilo\CourseBundle\Entity\CForum;
+use Chamilo\CourseBundle\Entity\CForumPost;
+use Chamilo\CourseBundle\Entity\CLp;
+use Chamilo\CourseBundle\Entity\CQuiz;
+use Chamilo\CourseBundle\Entity\CStudentPublication;
+use Chamilo\CourseBundle\Entity\CSurvey;
+use Doctrine\DBAL\ArrayParameterType;
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\EntityManagerInterface;
+use RuntimeException;
+
+final readonly class McpCourseQualityReviewer
+{
+    public function __construct(
+        private McpTextAiService $aiService,
+        private AiDisclosureHelper $aiDisclosureHelper,
+        private McpCourseAiFeatureManager $courseAiFeatureManager,
+        private AiCourseAnalyzerService $courseAnalyzer,
+        private EntityManagerInterface $entityManager,
+    ) {}
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function review(
+        Course $course,
+        User $user,
+        ?string $focus,
+        ?string $provider,
+    ): array
+    {
+        $enabledFeatures = $this->courseAiFeatureManager->ensureEnabled(
+            $course,
+            $user,
+            'course_analyser',
+            'review_course_quality',
+        );
+
+        $providerName = $this->aiService->resolveProvider($user, $provider);
+        $teacherPrompt = trim(strip_tags((string) $focus));
+        if (5000 < mb_strlen($teacherPrompt)) {
+            $teacherPrompt = mb_substr($teacherPrompt, 0, 5000);
+        }
+        if ('' === $teacherPrompt) {
+            $teacherPrompt = 'Review this course as an instructional designer. Separate verified observations from recommendations. Identify the highest-impact improvements for structure, clarity, assessment, learner engagement and feedback.';
+        }
+
+        $inventoryByVisibility = [
+            'documents' => $this->summarizeResources(CDocument::class, $course, true),
+            'tests' => $this->summarizeResources(CQuiz::class, $course),
+            'learning_paths' => $this->summarizeResources(CLp::class, $course),
+            'surveys' => $this->summarizeResources(CSurvey::class, $course),
+            'assignments' => $this->summarizeResources(CStudentPublication::class, $course),
+            'forums' => $this->summarizeResources(CForum::class, $course),
+            'forum_posts' => $this->summarizeResources(CForumPost::class, $course),
+        ];
+        $inventory = [
+            'documents' => $inventoryByVisibility['documents']['total'],
+            'tests' => $inventoryByVisibility['tests']['total'],
+            'learning_paths' => $inventoryByVisibility['learning_paths']['total'],
+            'surveys' => $inventoryByVisibility['surveys']['total'],
+            'assignments' => $inventoryByVisibility['assignments']['total'],
+            'forums' => $inventoryByVisibility['forums']['total'],
+            'forum_posts' => $inventoryByVisibility['forum_posts']['total'],
+            'visible_forum_posts' => $inventoryByVisibility['forum_posts']['published'],
+        ];
+
+        $teacherPrompt .= "\n\nVerified base-course inventory for teacher review. Draft and pending resources are intentional work in progress and must still be analyzed:"
+            ."\n- Documents: ".$this->formatInventorySummary($inventoryByVisibility['documents'])
+            ."\n- Tests: ".$this->formatInventorySummary($inventoryByVisibility['tests'])
+            ."\n- Learning paths: ".$this->formatInventorySummary($inventoryByVisibility['learning_paths'])
+            ."\n- Surveys: ".$this->formatInventorySummary($inventoryByVisibility['surveys'])
+            ."\n- Assignments: ".$this->formatInventorySummary($inventoryByVisibility['assignments'])
+            ."\n- Forums: ".$this->formatInventorySummary($inventoryByVisibility['forums'])
+            ."\n- Forum posts: ".$this->formatInventorySummary($inventoryByVisibility['forum_posts']);
+
+        $result = $this->courseAnalyzer->analyze(
+            course: $course,
+            session: null,
+            teacherPrompt: $teacherPrompt,
+            provider: $providerName,
+            includeStandaloneDocuments: true,
+            includeStandaloneExercises: true,
+            includeDraftResources: true,
+        );
+
+        $this->aiDisclosureHelper->logAudit(
+            targetKey: 'course:'.(int) $course->getId().':mcp_quality_review',
+            userId: (int) $user->getId(),
+            meta: [
+                'feature' => 'mcp_course_quality_review',
+                'provider' => $providerName,
+                'inventory' => $inventory,
+                'inventory_by_visibility' => $inventoryByVisibility,
+                'include_draft_resources' => true,
+                'content_analysis' => $result['payloadStats'] ?? [],
+                'response_mode' => $result['responseMode'] ?? 'full',
+                'response_repaired' => $result['responseRepaired'] ?? false,
+            ],
+            courseId: (int) $course->getId(),
+            sessionId: 0,
+        );
+
+        return [
+            'scope' => 'base_course',
+            'course' => [
+                'course_id' => (int) $course->getId(),
+                'title' => $course->getTitle(),
+            ],
+            'provider_used' => $providerName,
+            'course_features_enabled' => $enabledFeatures,
+            'inventory' => $inventory,
+            'inventory_by_visibility' => $inventoryByVisibility,
+            'content_analysis' => $result['payloadStats'] ?? [],
+            'analysis_generation' => [
+                'structured_response' => \is_array($result['structuredResponse']),
+                'response_mode' => $result['responseMode'] ?? 'full',
+                'response_repaired' => $result['responseRepaired'] ?? false,
+                'raw_response_length' => $result['rawResponseLength'] ?? 0,
+            ],
+            'analysis' => $result['structuredResponse'],
+            'raw_analysis' => null === $result['structuredResponse']
+                ? mb_substr((string) $result['rawResponse'], 0, 30000)
+                : null,
+            'analysis_scope' => $result['payload']['analysisScope'] ?? null,
+        ];
+    }
+
+    /**
+     * @param class-string<AbstractResource> $resourceClass
+     *
+     * @return array{total:int,published:int,pending:int,drafts:int}
+     */
+    private function summarizeResources(
+        string $resourceClass,
+        Course $course,
+        bool $excludeFolders = false,
+    ): array
+    {
+        return [
+            'total' => $this->countResources($resourceClass, $course, $excludeFolders, null),
+            'published' => $this->countResources(
+                $resourceClass,
+                $course,
+                $excludeFolders,
+                ResourceLink::VISIBILITY_PUBLISHED,
+            ),
+            'pending' => $this->countResources(
+                $resourceClass,
+                $course,
+                $excludeFolders,
+                ResourceLink::VISIBILITY_PENDING,
+            ),
+            'drafts' => $this->countResources(
+                $resourceClass,
+                $course,
+                $excludeFolders,
+                ResourceLink::VISIBILITY_DRAFT,
+            ),
+        ];
+    }
+
+    /**
+     * @param class-string<AbstractResource> $resourceClass
+     */
+    private function countResources(
+        string $resourceClass,
+        Course $course,
+        bool $excludeFolders,
+        ?int $visibility,
+    ): int
+    {
+        $queryBuilder = $this->entityManager->createQueryBuilder()
+            ->select('COUNT(DISTINCT resource.iid)')
+            ->from($resourceClass, 'resource')
+            ->innerJoin('resource.resourceNode', 'node')
+            ->innerJoin('node.resourceLinks', 'resourceLink')
+            ->andWhere('resourceLink.course = :courseId')
+            ->andWhere('resourceLink.session IS NULL')
+            ->andWhere('resourceLink.group IS NULL')
+            ->setParameter('courseId', (int) $course->getId(), Types::INTEGER)
+        ;
+
+        if (null !== $visibility) {
+            $queryBuilder
+                ->andWhere('resourceLink.visibility = :visibility')
+                ->setParameter('visibility', $visibility, Types::INTEGER)
+            ;
+        } else {
+            $queryBuilder
+                ->andWhere('resourceLink.visibility IN (:reviewVisibilities)')
+                ->setParameter('reviewVisibilities', [
+                    ResourceLink::VISIBILITY_DRAFT,
+                    ResourceLink::VISIBILITY_PENDING,
+                    ResourceLink::VISIBILITY_PUBLISHED,
+                ], ArrayParameterType::INTEGER)
+            ;
+        }
+
+        if ($excludeFolders && CDocument::class === $resourceClass) {
+            $queryBuilder->andWhere('resource.filetype != :folderType')
+                ->setParameter('folderType', 'folder', Types::STRING)
+            ;
+        }
+
+        if (CStudentPublication::class === $resourceClass) {
+            $queryBuilder->andWhere('resource.publicationParent IS NULL');
+        }
+
+        if (CForumPost::class === $resourceClass) {
+            $queryBuilder->andWhere('resource.visible = :visible')
+                ->setParameter('visible', true, Types::BOOLEAN)
+            ;
+        }
+
+        return (int) $queryBuilder->getQuery()->getSingleScalarResult();
+    }
+
+    /**
+     * @param array{total:int,published:int,pending:int,drafts:int} $summary
+     */
+    private function formatInventorySummary(array $summary): string
+    {
+        return \sprintf(
+            '%d total (%d published, %d pending, %d drafts)',
+            $summary['total'],
+            $summary['published'],
+            $summary['pending'],
+            $summary['drafts'],
+        );
+    }
+}

--- a/src/CoreBundle/Service/Document/DocumentParagraphMediaEmbedder.php
+++ b/src/CoreBundle/Service/Document/DocumentParagraphMediaEmbedder.php
@@ -1,0 +1,584 @@
+<?php
+
+/* For licensing terms, see /license.txt */
+
+declare(strict_types=1);
+
+namespace Chamilo\CoreBundle\Service\Document;
+
+use Chamilo\CoreBundle\Cache\DocumentListCacheInvalidator;
+use Chamilo\CoreBundle\Entity\ResourceFile;
+use Chamilo\CoreBundle\Helpers\AiDisclosureHelper;
+use Chamilo\CoreBundle\Helpers\ResourceHelper;
+use Chamilo\CoreBundle\Repository\ResourceNodeRepository;
+use Chamilo\CourseBundle\Entity\CDocument;
+use Chamilo\CourseBundle\Repository\CDocumentRepository;
+use DateTime;
+use Doctrine\ORM\EntityManager;
+use DOMDocument;
+use DOMElement;
+use DOMNode;
+use DOMXPath;
+use InvalidArgumentException;
+use RuntimeException;
+use Throwable;
+
+use const ENT_HTML5;
+use const ENT_QUOTES;
+use const LIBXML_HTML_NODEFDTD;
+use const LIBXML_HTML_NOIMPLIED;
+use const LIBXML_NOERROR;
+use const LIBXML_NONET;
+use const LIBXML_NOWARNING;
+use const XML_PI_NODE;
+
+final readonly class DocumentParagraphMediaEmbedder
+{
+    private const WRAPPER_ID = '__chamilo_mcp_document_fragment__';
+
+    public function __construct(
+        private CDocumentRepository $documentRepository,
+        private ResourceNodeRepository $resourceNodeRepository,
+        private EntityManager $entityManager,
+        private DocumentListCacheInvalidator $cacheInvalidator,
+        private ResourceHelper $resourceHelper,
+        private AiDisclosureHelper $aiDisclosureHelper,
+    ) {}
+
+    /**
+     * @return array{
+     *     updated: bool,
+     *     already_present: bool,
+     *     paragraph_number: int,
+     *     paragraphs_total: int,
+     *     paragraph_preview: string,
+     *     media_type: 'image'|'video',
+     *     media_url: string
+     * }
+     */
+    public function embed(
+        CDocument $document,
+        CDocument $mediaDocument,
+        int $courseId,
+        int $userId,
+        ?int $paragraphNumber,
+        ?string $paragraphText,
+        ?string $altText,
+        ?string $caption,
+        string $placement,
+    ): array {
+        $originalHtml = $this->documentRepository->getResourceFileContent($document);
+        if ('' === trim($originalHtml)) {
+            throw new RuntimeException('The target HTML document is empty.');
+        }
+
+        $mediaResourceNode = $mediaDocument->getResourceNode();
+        $mediaResourceFile = $mediaResourceNode?->getFirstResourceFile();
+        if (!$mediaResourceFile instanceof ResourceFile) {
+            throw new RuntimeException('The media document has no stored file.');
+        }
+
+        $mimeType = strtolower(trim((string) $mediaResourceFile->getMimeType()));
+        $mediaType = $this->resolveMediaType($mimeType);
+        $mediaUrl = $this->documentRepository->getResourceFileUrl(
+            $mediaDocument,
+            ['cid' => $courseId],
+        );
+
+        if ('' === trim($mediaUrl)) {
+            throw new RuntimeException('The media URL could not be generated.');
+        }
+
+        [$dom, $scope, $isFullDocument] = $this->parseHtml($originalHtml);
+        $xpath = new DOMXPath($dom);
+        $paragraphs = $this->findParagraphs($xpath, $scope);
+
+        if ([] === $paragraphs) {
+            throw new InvalidArgumentException('The target document does not contain HTML paragraph elements.');
+        }
+
+        [$targetParagraph, $resolvedParagraphNumber] = $this->resolveParagraph(
+            $paragraphs,
+            $paragraphNumber,
+            $paragraphText,
+        );
+
+        $paragraphPreview = $this->preview(
+            $this->normalizeText($targetParagraph->textContent),
+        );
+
+        $mediaDocumentId = (int) ($mediaDocument->getIid() ?? 0);
+        if ($mediaDocumentId <= 0) {
+            throw new RuntimeException('The media document identifier is invalid.');
+        }
+
+        if ($this->hasMediaAlreadyEmbedded($xpath, $scope, $mediaDocumentId)) {
+            return [
+                'updated' => false,
+                'already_present' => true,
+                'paragraph_number' => $resolvedParagraphNumber,
+                'paragraphs_total' => \count($paragraphs),
+                'paragraph_preview' => $paragraphPreview,
+                'media_type' => $mediaType,
+                'media_url' => $mediaUrl,
+            ];
+        }
+
+        $figure = $this->buildFigure(
+            $dom,
+            $mediaDocument,
+            $mediaResourceFile,
+            $mediaType,
+            $mediaUrl,
+            $altText,
+            $caption,
+        );
+
+        $this->insertFigure($targetParagraph, $figure, $placement);
+
+        $updatedHtml = $this->serializeHtml($dom, $scope, $isFullDocument);
+        if ('' === trim($updatedHtml)) {
+            throw new RuntimeException('The updated HTML document is empty.');
+        }
+
+        $this->writeDocument(
+            $document,
+            $originalHtml,
+            $updatedHtml,
+        );
+
+        $documentId = (int) ($document->getIid() ?? 0);
+        $this->aiDisclosureHelper->markAiAssistedExtraField(
+            'document',
+            $documentId,
+            true,
+        );
+        $this->aiDisclosureHelper->logAudit(
+            targetKey: 'course:'.$courseId.':document:'.$documentId.':paragraph_media',
+            userId: $userId,
+            meta: [
+                'feature' => 'document_paragraph_media',
+                'mode' => 'embedded_existing_course_media',
+                'paragraph_number' => $resolvedParagraphNumber,
+                'media_document_id' => $mediaDocumentId,
+                'media_type' => $mediaType,
+                'placement' => $placement,
+            ],
+            courseId: $courseId,
+        );
+
+        return [
+            'updated' => true,
+            'already_present' => false,
+            'paragraph_number' => $resolvedParagraphNumber,
+            'paragraphs_total' => \count($paragraphs),
+            'paragraph_preview' => $paragraphPreview,
+            'media_type' => $mediaType,
+            'media_url' => $mediaUrl,
+        ];
+    }
+
+    /**
+     * @return array{0: DOMDocument, 1: DOMElement|null, 2: bool}
+     */
+    private function parseHtml(string $html): array
+    {
+        $dom = new DOMDocument('1.0', 'UTF-8');
+        $previous = libxml_use_internal_errors(true);
+        $isFullDocument = (bool) preg_match('/<!doctype\s+html|<html\b/i', $html);
+
+        try {
+            if ($isFullDocument) {
+                $loaded = $dom->loadHTML(
+                    '<?xml encoding="UTF-8">'.$html,
+                    LIBXML_NONET | LIBXML_NOERROR | LIBXML_NOWARNING,
+                );
+                $scope = $dom->getElementsByTagName('body')->item(0);
+                if (!$scope instanceof DOMElement) {
+                    $scope = null;
+                }
+            } else {
+                $loaded = $dom->loadHTML(
+                    '<?xml encoding="UTF-8"><div id="'.self::WRAPPER_ID.'">'.$html.'</div>',
+                    LIBXML_NONET
+                    | LIBXML_NOERROR
+                    | LIBXML_NOWARNING
+                    | LIBXML_HTML_NOIMPLIED
+                    | LIBXML_HTML_NODEFDTD,
+                );
+
+                $xpath = new DOMXPath($dom);
+                $scopeNode = $xpath->query('//*[@id="'.self::WRAPPER_ID.'"]')?->item(0);
+                $scope = $scopeNode instanceof DOMElement ? $scopeNode : null;
+            }
+        } finally {
+            libxml_clear_errors();
+            libxml_use_internal_errors($previous);
+        }
+
+        if (!$loaded) {
+            throw new InvalidArgumentException('The target document contains invalid HTML.');
+        }
+
+        $this->removeXmlProcessingInstructions($dom);
+
+        if (!$isFullDocument && !$scope instanceof DOMElement) {
+            throw new RuntimeException('The target HTML fragment could not be prepared for editing.');
+        }
+
+        return [$dom, $scope, $isFullDocument];
+    }
+
+    /**
+     * @return DOMElement[]
+     */
+    private function findParagraphs(
+        DOMXPath $xpath,
+        ?DOMElement $scope,
+    ): array {
+        $nodeList = $scope instanceof DOMElement
+            ? $xpath->query('.//p', $scope)
+            : $xpath->query('//p');
+
+        if (false === $nodeList) {
+            return [];
+        }
+
+        $paragraphs = [];
+        foreach ($nodeList as $node) {
+            if ($node instanceof DOMElement) {
+                $paragraphs[] = $node;
+            }
+        }
+
+        return $paragraphs;
+    }
+
+    /**
+     * @param DOMElement[] $paragraphs
+     *
+     * @return array{0: DOMElement, 1: int}
+     */
+    private function resolveParagraph(
+        array $paragraphs,
+        ?int $paragraphNumber,
+        ?string $paragraphText,
+    ): array {
+        $paragraphText = null !== $paragraphText
+            ? $this->normalizeText($paragraphText)
+            : '';
+
+        if (null !== $paragraphNumber) {
+            if ($paragraphNumber <= 0 || $paragraphNumber > \count($paragraphs)) {
+                throw new InvalidArgumentException(\sprintf('The paragraph number must be between 1 and %d.', \count($paragraphs)));
+            }
+
+            $paragraph = $paragraphs[$paragraphNumber - 1];
+
+            if (
+                '' !== $paragraphText
+                && !str_contains(
+                    mb_strtolower($this->normalizeText($paragraph->textContent)),
+                    mb_strtolower($paragraphText),
+                )
+            ) {
+                throw new InvalidArgumentException(\sprintf('Paragraph %d does not contain the expected text. Actual paragraph: "%s".', $paragraphNumber, $this->preview($this->normalizeText($paragraph->textContent))));
+            }
+
+            return [$paragraph, $paragraphNumber];
+        }
+
+        if ('' === $paragraphText) {
+            throw new InvalidArgumentException('Provide paragraphNumber, paragraphText, or both.');
+        }
+
+        $matches = [];
+        $needle = mb_strtolower($paragraphText);
+
+        foreach ($paragraphs as $index => $paragraph) {
+            $paragraphContent = mb_strtolower(
+                $this->normalizeText($paragraph->textContent),
+            );
+
+            if (str_contains($paragraphContent, $needle)) {
+                $matches[] = [
+                    'paragraph' => $paragraph,
+                    'number' => $index + 1,
+                ];
+            }
+        }
+
+        if ([] === $matches) {
+            throw new InvalidArgumentException('No paragraph contains the supplied paragraphText.');
+        }
+
+        if (\count($matches) > 1) {
+            throw new InvalidArgumentException('More than one paragraph contains paragraphText. Provide paragraphNumber to disambiguate.');
+        }
+
+        return [
+            $matches[0]['paragraph'],
+            $matches[0]['number'],
+        ];
+    }
+
+    private function buildFigure(
+        DOMDocument $dom,
+        CDocument $mediaDocument,
+        ResourceFile $mediaResourceFile,
+        string $mediaType,
+        string $mediaUrl,
+        ?string $altText,
+        ?string $caption,
+    ): DOMElement {
+        $mediaDocumentId = (int) ($mediaDocument->getIid() ?? 0);
+        $figure = $dom->createElement('figure');
+        $figure->setAttribute('class', 'document-paragraph-media');
+        $figure->setAttribute(
+            'data-chamilo-mcp-media-document-id',
+            (string) $mediaDocumentId,
+        );
+
+        $accessibleText = $this->normalizeText(
+            null !== $altText && '' !== trim($altText)
+                ? $altText
+                : $mediaDocument->getTitle(),
+        );
+
+        if (mb_strlen($accessibleText) > 500) {
+            throw new InvalidArgumentException('The media alternative text cannot be longer than 500 characters.');
+        }
+
+        if ('image' === $mediaType) {
+            $media = $dom->createElement('img');
+            $media->setAttribute('src', $mediaUrl);
+            $media->setAttribute('alt', $accessibleText);
+            $media->setAttribute('loading', 'lazy');
+            $media->setAttribute('decoding', 'async');
+        } else {
+            $media = $dom->createElement('video');
+            $media->setAttribute('controls', 'controls');
+            $media->setAttribute('preload', 'metadata');
+            $media->setAttribute('aria-label', $accessibleText);
+
+            $source = $dom->createElement('source');
+            $source->setAttribute('src', $mediaUrl);
+            $source->setAttribute(
+                'type',
+                (string) $mediaResourceFile->getMimeType(),
+            );
+            $media->appendChild($source);
+            $media->appendChild(
+                $dom->createTextNode(
+                    'Your browser does not support embedded video.'
+                )
+            );
+        }
+
+        $media->setAttribute(
+            'style',
+            'display:block;max-width:100%;height:auto;margin:0 auto;',
+        );
+        $figure->appendChild($media);
+
+        $caption = null !== $caption
+            ? $this->normalizeText($caption)
+            : '';
+
+        if (mb_strlen($caption) > 1_000) {
+            throw new InvalidArgumentException('The media caption cannot be longer than 1000 characters.');
+        }
+
+        if ('' !== $caption) {
+            $figcaption = $dom->createElement('figcaption');
+            $figcaption->appendChild($dom->createTextNode($caption));
+            $figure->appendChild($figcaption);
+        }
+
+        return $figure;
+    }
+
+    private function insertFigure(
+        DOMElement $paragraph,
+        DOMElement $figure,
+        string $placement,
+    ): void {
+        $parent = $paragraph->parentNode;
+        if (!$parent instanceof DOMNode) {
+            throw new RuntimeException('The target paragraph cannot receive an illustration.');
+        }
+
+        if ('before' === $placement) {
+            $parent->insertBefore($figure, $paragraph);
+
+            return;
+        }
+
+        $nextSibling = $paragraph->nextSibling;
+        if ($nextSibling instanceof DOMNode) {
+            $parent->insertBefore($figure, $nextSibling);
+
+            return;
+        }
+
+        $parent->appendChild($figure);
+    }
+
+    private function hasMediaAlreadyEmbedded(
+        DOMXPath $xpath,
+        ?DOMElement $scope,
+        int $mediaDocumentId,
+    ): bool {
+        $query = './/*[@data-chamilo-mcp-media-document-id="'
+            .$mediaDocumentId
+            .'"]';
+
+        $matches = $scope instanceof DOMElement
+            ? $xpath->query($query, $scope)
+            : $xpath->query(substr($query, 1));
+
+        return false !== $matches && $matches->length > 0;
+    }
+
+    private function serializeHtml(
+        DOMDocument $dom,
+        ?DOMElement $scope,
+        bool $isFullDocument,
+    ): string {
+        if ($isFullDocument) {
+            $html = $dom->saveHTML();
+
+            return \is_string($html) ? trim($html) : '';
+        }
+
+        if (!$scope instanceof DOMElement) {
+            return '';
+        }
+
+        $html = '';
+        foreach ($scope->childNodes as $childNode) {
+            $part = $dom->saveHTML($childNode);
+            if (\is_string($part)) {
+                $html .= $part;
+            }
+        }
+
+        return trim($html);
+    }
+
+    private function writeDocument(
+        CDocument $document,
+        string $originalHtml,
+        string $updatedHtml,
+    ): void {
+        $resourceNode = $document->getResourceNode();
+        if (null === $resourceNode) {
+            throw new RuntimeException('The target document resource node is missing.');
+        }
+
+        $resourceFile = $resourceNode->getFirstResourceFile();
+        if (!$resourceFile instanceof ResourceFile) {
+            throw new RuntimeException('The target document resource file is missing.');
+        }
+
+        $filename = $this->resourceNodeRepository->getFilename($resourceFile);
+        if (!\is_string($filename) || '' === trim($filename)) {
+            throw new RuntimeException('The target document storage path is missing.');
+        }
+
+        $filesystem = $this->resourceNodeRepository->getFileSystem();
+
+        try {
+            $this->entityManager->wrapInTransaction(
+                function () use (
+                    $document,
+                    $resourceNode,
+                    $resourceFile,
+                    $filesystem,
+                    $filename,
+                    $updatedHtml,
+                ): void {
+                    $filesystem->write($filename, $updatedHtml);
+
+                    $resourceNode->setContent($updatedHtml);
+                    $resourceNode->setUpdatedAt(new DateTime());
+                    $resourceFile
+                        ->setSize(\strlen($updatedHtml))
+                        ->setMimeType('text/html')
+                    ;
+
+                    $this->entityManager->persist($document);
+                    $this->entityManager->persist($resourceNode);
+                    $this->entityManager->persist($resourceFile);
+                }
+            );
+        } catch (Throwable $throwable) {
+            try {
+                $filesystem->write($filename, $originalHtml);
+            } catch (Throwable) {
+                // Keep the original exception. The log will contain the storage failure.
+            }
+
+            throw new RuntimeException('The illustrated document could not be stored.', 0, $throwable);
+        }
+
+        $this->cacheInvalidator->invalidate();
+
+        try {
+            $this->resourceHelper->createAndSaveResourceEvent(
+                $resourceNode,
+                'edition',
+            );
+        } catch (Throwable) {
+            // Tracking must not turn a completed document update into a tool failure.
+        }
+    }
+
+    private function resolveMediaType(string $mimeType): string
+    {
+        if (str_starts_with($mimeType, 'image/')) {
+            return 'image';
+        }
+
+        if (str_starts_with($mimeType, 'video/')) {
+            return 'video';
+        }
+
+        throw new InvalidArgumentException('The media document must contain an image or video file.');
+    }
+
+    private function removeXmlProcessingInstructions(
+        DOMDocument $dom,
+    ): void {
+        $nodesToRemove = [];
+        foreach ($dom->childNodes as $childNode) {
+            if (XML_PI_NODE === $childNode->nodeType) {
+                $nodesToRemove[] = $childNode;
+            }
+        }
+
+        foreach ($nodesToRemove as $childNode) {
+            $dom->removeChild($childNode);
+        }
+    }
+
+    private function normalizeText(string $text): string
+    {
+        $text = html_entity_decode(
+            strip_tags($text),
+            ENT_QUOTES | ENT_HTML5,
+            'UTF-8',
+        );
+
+        return trim((string) preg_replace('/\s+/u', ' ', $text));
+    }
+
+    private function preview(string $text): string
+    {
+        if (mb_strlen($text) <= 180) {
+            return $text;
+        }
+
+        return rtrim(mb_substr($text, 0, 177)).'...';
+    }
+}

--- a/src/CoreBundle/Service/Exercise/AiCourseTestGenerator.php
+++ b/src/CoreBundle/Service/Exercise/AiCourseTestGenerator.php
@@ -146,11 +146,7 @@ final readonly class AiCourseTestGenerator
         }
 
         if ($questionCount < self::MIN_QUESTION_COUNT || $questionCount > self::MAX_QUESTION_COUNT) {
-            throw new InvalidArgumentException(\sprintf(
-                'The question count must be between %d and %d.',
-                self::MIN_QUESTION_COUNT,
-                self::MAX_QUESTION_COUNT,
-            ));
+            throw new InvalidArgumentException(\sprintf('The question count must be between %d and %d.', self::MIN_QUESTION_COUNT, self::MAX_QUESTION_COUNT));
         }
 
         $sourceText = $this->normalizeSourceText($sourceText);
@@ -217,11 +213,7 @@ final readonly class AiCourseTestGenerator
         } catch (Throwable $exception) {
             error_log('[AI][mcp_course_test] Question generation failed: '.$exception->getMessage());
 
-            throw new RuntimeException(
-                'The AI model could not generate the requested test: '.$exception->getMessage(),
-                0,
-                $exception,
-            );
+            throw new RuntimeException('The AI model could not generate the requested test: '.$exception->getMessage(), 0, $exception);
         } finally {
             $this->redactGeneratedRequestLogs(
                 (int) $user->getId(),
@@ -542,7 +534,7 @@ PROMPT;
 
         $questions = [];
 
-        foreach (array_slice(array_values($rawQuestions), 0, $questionCount) as $rawQuestion) {
+        foreach (\array_slice(array_values($rawQuestions), 0, $questionCount) as $rawQuestion) {
             if (!\is_array($rawQuestion)) {
                 return null;
             }
@@ -587,7 +579,7 @@ PROMPT;
             return $correct;
         }
 
-        if (\is_numeric($correct)) {
+        if (is_numeric($correct)) {
             $numeric = (int) $correct;
             if ($numeric >= 0 && $numeric <= 3) {
                 return $numeric;
@@ -599,7 +591,7 @@ PROMPT;
 
         $correctText = $this->oneLine((string) $correct);
         if (preg_match('/^[A-D]$/i', $correctText)) {
-            return ord(strtoupper($correctText)) - ord('A');
+            return \ord(strtoupper($correctText)) - \ord('A');
         }
 
         foreach ($answers as $index => $answer) {

--- a/src/CoreBundle/Service/Exercise/AiCourseTestGenerator.php
+++ b/src/CoreBundle/Service/Exercise/AiCourseTestGenerator.php
@@ -1,0 +1,695 @@
+<?php
+
+/* For licensing terms, see /license.txt */
+
+declare(strict_types=1);
+
+namespace Chamilo\CoreBundle\Service\Exercise;
+
+use Chamilo\CoreBundle\AiProvider\AiChatCompletionClientInterface;
+use Chamilo\CoreBundle\AiProvider\AiProviderFactory;
+use Chamilo\CoreBundle\Entity\AiRequests;
+use Chamilo\CoreBundle\Entity\Course;
+use Chamilo\CoreBundle\Entity\ResourceLink;
+use Chamilo\CoreBundle\Entity\User;
+use Chamilo\CoreBundle\Helpers\AiDisclosureHelper;
+use Chamilo\CoreBundle\Helpers\AiFeatureAccessHelper;
+use Chamilo\CoreBundle\Service\Ai\AiRequestQuotaGuard;
+use Chamilo\CourseBundle\Entity\CDocument;
+use Chamilo\CourseBundle\Entity\CQuiz;
+use Chamilo\CourseBundle\Entity\CQuizAnswer;
+use Chamilo\CourseBundle\Entity\CQuizQuestion;
+use Chamilo\CourseBundle\Entity\CQuizRelQuestion;
+use Chamilo\CourseBundle\Repository\CDocumentRepository;
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\EntityManagerInterface;
+use InvalidArgumentException;
+use RuntimeException;
+use Throwable;
+
+use const ENT_HTML5;
+use const ENT_QUOTES;
+
+final readonly class AiCourseTestGenerator
+{
+    private const MAX_GENERATED_LENGTH = 100_000;
+    private const MAX_QUESTION_COUNT = 20;
+    private const MAX_SOURCE_LENGTH = 20_000;
+    private const MIN_QUESTION_COUNT = 1;
+    private const QUESTION_TYPE_UNIQUE_ANSWER = 1;
+    private const TOTAL_SCORE = 20.0;
+
+    public function __construct(
+        private AiFeatureAccessHelper $aiFeatureAccessHelper,
+        private AiProviderFactory $aiProviderFactory,
+        private AiChatCompletionClientInterface $aiChatCompletionClient,
+        private AiRequestQuotaGuard $quotaGuard,
+        private AiDisclosureHelper $aiDisclosureHelper,
+        private CDocumentRepository $documentRepository,
+        private EntityManagerInterface $entityManager,
+    ) {}
+
+    /**
+     * @return array{
+     *     quiz_id: int,
+     *     resource_node_id: int,
+     *     title: string,
+     *     question_count: int,
+     *     question_type: 'unique_answer',
+     *     total_score: float,
+     *     published: bool,
+     *     provider_used: string,
+     *     ai_assisted: true,
+     *     source: array{type: 'topic'|'document', document_id: int|null, title: string},
+     *     questions: list<array{question_id: int, title: string, score: float}>,
+     *     content_url: string
+     * }
+     */
+    public function createTest(
+        Course $course,
+        User $user,
+        string $title,
+        int $questionCount,
+        string $sourceType,
+        string $sourceTitle,
+        string $sourceText,
+        ?int $documentId,
+        ?string $language,
+        ?string $requestedProvider,
+        bool $publish,
+    ): array {
+        $courseId = (int) $course->getId();
+        if (!$this->aiFeatureAccessHelper->isFeatureEnabledForCourse('exercise_generator', $courseId)) {
+            throw new RuntimeException('AI exercise generation is not enabled for this course.');
+        }
+
+        if ($questionCount < self::MIN_QUESTION_COUNT || $questionCount > self::MAX_QUESTION_COUNT) {
+            throw new InvalidArgumentException(\sprintf(
+                'The question count must be between %d and %d.',
+                self::MIN_QUESTION_COUNT,
+                self::MAX_QUESTION_COUNT,
+            ));
+        }
+
+        $sourceText = $this->normalizeSourceText($sourceText);
+        if ('' === $sourceText) {
+            throw new InvalidArgumentException('The test source content is empty.');
+        }
+
+        $providerName = $this->resolveProviderName($requestedProvider);
+        $this->quotaGuard->assertCanRequest($user, $providerName, 'text');
+
+        $language = $this->normalizeLanguage($language, (string) $course->getCourseLanguage());
+        $requestMarker = 'MCP_COURSE_TEST_REQUEST:'.hash(
+            'sha256',
+            $courseId.'|'.$title.'|'.$sourceType.'|'.$sourceText.'|'.microtime(true),
+        );
+        $lastRequestId = $this->getLastAiRequestId((int) $user->getId());
+
+        try {
+            $generated = $this->requestAiken(
+                $providerName,
+                (string) $course->getTitle(),
+                $title,
+                $sourceType,
+                $sourceTitle,
+                $sourceText,
+                $questionCount,
+                $language,
+                $requestMarker,
+            );
+            $questions = $this->tryParseAiken($generated, $questionCount);
+
+            if (null === $questions) {
+                $repaired = $this->requestAiken(
+                    $providerName,
+                    (string) $course->getTitle(),
+                    $title,
+                    $sourceType,
+                    $sourceTitle,
+                    $sourceText,
+                    $questionCount,
+                    $language,
+                    $requestMarker,
+                    $generated,
+                );
+                $questions = $this->tryParseAiken($repaired, $questionCount);
+            }
+        } catch (Throwable $exception) {
+            error_log('[AI][mcp_course_test] Question generation failed: '.$exception->getMessage());
+
+            throw new RuntimeException('The AI model could not generate the requested test.', 0, $exception);
+        } finally {
+            $this->redactGeneratedRequestLogs(
+                (int) $user->getId(),
+                $lastRequestId,
+                $providerName,
+                $requestMarker,
+                $sourceType,
+                $sourceTitle,
+                $sourceText,
+            );
+        }
+
+        if (null === $questions) {
+            throw new RuntimeException('The AI model did not return the requested number of valid questions.');
+        }
+
+        $created = $this->persistTest(
+            $course,
+            $user,
+            $title,
+            $questions,
+            $publish,
+        );
+
+        $quizId = $created['quiz_id'];
+        $this->markAiAssisted($quizId, $created['questions']);
+        $this->aiDisclosureHelper->logAudit(
+            targetKey: 'exercise:'.$quizId,
+            userId: (int) $user->getId(),
+            meta: [
+                'feature' => 'mcp_course_test',
+                'mode' => 'generated',
+                'provider' => $providerName,
+                'source_type' => $sourceType,
+                'source_title' => mb_substr($this->oneLine($sourceTitle), 0, 200),
+                'source_sha256' => hash('sha256', $sourceText),
+                'source_length' => mb_strlen($sourceText),
+                'question_count' => $questionCount,
+                'question_type' => 'unique_answer',
+                'published' => $publish,
+            ],
+            courseId: $courseId,
+            sessionId: 0,
+        );
+
+        return [
+            'quiz_id' => $quizId,
+            'resource_node_id' => $created['resource_node_id'],
+            'title' => $title,
+            'question_count' => $questionCount,
+            'question_type' => 'unique_answer',
+            'total_score' => self::TOTAL_SCORE,
+            'published' => $publish,
+            'provider_used' => $providerName,
+            'ai_assisted' => true,
+            'source' => [
+                'type' => $sourceType,
+                'document_id' => $documentId,
+                'title' => $sourceTitle,
+            ],
+            'questions' => $created['questions'],
+            'content_url' => '/main/exercise/overview.php?cid='.$courseId.'&exerciseId='.$quizId,
+        ];
+    }
+
+    public function getDocumentSource(CDocument $document): string
+    {
+        try {
+            $content = (string) $this->documentRepository->getResourceFileContent($document);
+        } catch (Throwable) {
+            $content = '';
+        }
+
+        if ('' === trim($content)) {
+            $content = (string) ($document->getResourceNode()?->getContent() ?? '');
+        }
+
+        return $this->normalizeSourceText($content);
+    }
+
+    private function resolveProviderName(?string $requestedProvider): string
+    {
+        $providerNames = array_values(array_filter(array_map(
+            static fn (mixed $providerName): string => trim((string) $providerName),
+            $this->aiProviderFactory->getProvidersForType('text'),
+        )));
+
+        if ([] === $providerNames) {
+            throw new RuntimeException('No AI text provider is configured.');
+        }
+
+        $requestedProvider = null !== $requestedProvider ? trim($requestedProvider) : '';
+        if ('' === $requestedProvider) {
+            return $providerNames[0];
+        }
+
+        if (!\in_array($requestedProvider, $providerNames, true)) {
+            throw new InvalidArgumentException('The selected AI text provider is not available.');
+        }
+
+        return $requestedProvider;
+    }
+
+    private function normalizeLanguage(?string $language, string $courseLanguage): string
+    {
+        $language = null !== $language ? trim($language) : '';
+        if ('' === $language) {
+            $language = trim($courseLanguage);
+        }
+        if ('' === $language) {
+            $language = 'en';
+        }
+
+        if (!preg_match('/^[a-zA-Z0-9_-]{1,20}$/', $language)) {
+            throw new InvalidArgumentException('The test language code is invalid.');
+        }
+
+        return $language;
+    }
+
+    private function normalizeSourceText(string $source): string
+    {
+        $source = (string) preg_replace('#<(script|style)\b[^>]*>.*?</\1>#is', ' ', $source);
+        $source = html_entity_decode(strip_tags($source), ENT_QUOTES | ENT_HTML5);
+        $source = trim((string) preg_replace('/\s+/u', ' ', $source));
+
+        return mb_substr($source, 0, self::MAX_SOURCE_LENGTH);
+    }
+
+    private function requestAiken(
+        string $providerName,
+        string $courseTitle,
+        string $testTitle,
+        string $sourceType,
+        string $sourceTitle,
+        string $sourceText,
+        int $questionCount,
+        string $language,
+        string $requestMarker,
+        ?string $previousOutput = null,
+    ): string {
+        $systemPrompt = <<<'PROMPT'
+Return only valid Aiken plain text. Generate the exact requested number of independent single-answer multiple-choice questions. Each question must have exactly four non-empty options labelled A. through D. and exactly one line in the form ANSWER: X. Do not use Markdown, code fences, numbering, headings, explanations, or introductory text. Use only the supplied source content.
+PROMPT;
+
+        $prompt = $requestMarker."\n"
+            .'Language: '.$language."\n"
+            .'Course: '.$this->oneLine($courseTitle)."\n"
+            .'Test title: '.$this->oneLine($testTitle)."\n"
+            .'Requested question count: '.$questionCount."\n"
+            .'Source type: '.$sourceType."\n"
+            .'Source title: '.$this->oneLine($sourceTitle)."\n\n"
+            ."Create the test using only this source content:\n"
+            .$sourceText;
+
+        if (null !== $previousOutput) {
+            $prompt .= "\n\nThe previous output was invalid or incomplete. Regenerate the complete test from the source. "
+                ."Do not continue the previous output.\nPrevious invalid output:\n"
+                .mb_substr($previousOutput, 0, 8_000);
+        }
+
+        $tokenBudget = min(12_000, max(800, 250 + ($questionCount * 220)));
+        $result = $this->aiChatCompletionClient->chatWithMeta(
+            $providerName,
+            [
+                ['role' => 'system', 'content' => $systemPrompt],
+                ['role' => 'user', 'content' => $prompt],
+            ],
+            [
+                'temperature' => 0.2,
+                'max_output_tokens' => $tokenBudget,
+                'max_tokens' => $tokenBudget,
+                'throw_on_error' => true,
+            ],
+        );
+
+        $generated = trim(mb_substr((string) $result->text, 0, self::MAX_GENERATED_LENGTH));
+        if ('' === $generated || str_starts_with($generated, 'Error:')) {
+            throw new RuntimeException('The AI model returned an invalid test.');
+        }
+
+        return $generated;
+    }
+
+    /**
+     * @return list<array{title: string, answers: list<string>, correct_index: int, feedback: string}>|null
+     */
+    private function tryParseAiken(string $generated, int $questionCount): ?array
+    {
+        $generated = $this->normalizeAikenSyntax($generated);
+        $questions = [];
+        $current = null;
+
+        foreach (explode("\n", $generated) as $line) {
+            $line = trim($line);
+            if ('' === $line) {
+                continue;
+            }
+
+            if (preg_match('/^([A-D])\.\s+(.+)$/u', $line, $matches)) {
+                if (null === $current) {
+                    return null;
+                }
+                $current['answers'][$matches[1]] = $this->oneLine($matches[2]);
+
+                continue;
+            }
+
+            if (preg_match('/^ANSWER:\s*([A-D])$/u', $line, $matches)) {
+                if (null === $current) {
+                    return null;
+                }
+                $current['correct'] = $matches[1];
+
+                continue;
+            }
+
+            if (preg_match('/^ANSWER_EXPLANATION:\s*(.*)$/u', $line, $matches)) {
+                if (null === $current) {
+                    return null;
+                }
+                $current['feedback'] = $this->oneLine($matches[1]);
+
+                continue;
+            }
+
+            if (null !== $current) {
+                $normalized = $this->normalizeParsedQuestion($current);
+                if (null === $normalized) {
+                    return null;
+                }
+                $questions[] = $normalized;
+            }
+
+            $current = [
+                'title' => $this->stripQuestionNumber($line),
+                'answers' => [],
+                'correct' => '',
+                'feedback' => '',
+            ];
+        }
+
+        if (null !== $current) {
+            $normalized = $this->normalizeParsedQuestion($current);
+            if (null === $normalized) {
+                return null;
+            }
+            $questions[] = $normalized;
+        }
+
+        if ($questionCount !== \count($questions)) {
+            return null;
+        }
+
+        return $questions;
+    }
+
+    private function normalizeAikenSyntax(string $generated): string
+    {
+        $generated = str_replace(["\r\n", "\r"], "\n", trim($generated));
+        $generated = (string) preg_replace('/```(?:aiken|text)?\s*/iu', '', $generated);
+        $generated = str_replace('```', '', $generated);
+
+        $normalizedLines = [];
+        foreach (explode("\n", $generated) as $line) {
+            $line = trim($line);
+            if ('' === $line) {
+                $normalizedLines[] = '';
+
+                continue;
+            }
+
+            if (preg_match('/^(?:[-*]\s*)?([A-D])\s*[\)\:\-\.]\s*(.+?)\s*$/iu', $line, $matches)) {
+                $normalizedLines[] = strtoupper($matches[1]).'. '.trim($matches[2], " *\t");
+
+                continue;
+            }
+
+            if (preg_match('/^\**\s*(?:ANSWER|RESPUESTA|R[ÉE]PONSE|CORRECT(?:\s+ANSWER)?|RESPUESTA\s+CORRECTA)\s*:\s*([A-D])\s*[.\s]*\**$/iu', $line, $matches)) {
+                $normalizedLines[] = 'ANSWER: '.strtoupper($matches[1]);
+
+                continue;
+            }
+
+            $normalizedLines[] = trim($line, " *\t");
+        }
+
+        return trim(implode("\n", $normalizedLines));
+    }
+
+    /**
+     * @param array{title: string, answers: array<string, string>, correct: string, feedback: string} $question
+     *
+     * @return array{title: string, answers: list<string>, correct_index: int, feedback: string}|null
+     */
+    private function normalizeParsedQuestion(array $question): ?array
+    {
+        $title = $this->oneLine($question['title']);
+        if ('' === $title) {
+            return null;
+        }
+
+        $answers = [];
+        foreach (['A', 'B', 'C', 'D'] as $letter) {
+            $answer = $this->oneLine((string) ($question['answers'][$letter] ?? ''));
+            if ('' === $answer) {
+                return null;
+            }
+            $answers[] = $answer;
+        }
+
+        $correctIndex = array_search($question['correct'], ['A', 'B', 'C', 'D'], true);
+        if (false === $correctIndex) {
+            return null;
+        }
+
+        return [
+            'title' => $title,
+            'answers' => $answers,
+            'correct_index' => (int) $correctIndex,
+            'feedback' => $this->oneLine($question['feedback']),
+        ];
+    }
+
+    private function stripQuestionNumber(string $title): string
+    {
+        $title = trim($title);
+        $normalized = preg_replace('/^\d+\s*[\.\)\-:]\s+/u', '', $title);
+
+        return $this->oneLine(null !== $normalized ? $normalized : $title);
+    }
+
+    /**
+     * @param list<array{title: string, answers: list<string>, correct_index: int, feedback: string}> $questions
+     *
+     * @return array{
+     *     quiz_id: int,
+     *     resource_node_id: int,
+     *     questions: list<array{question_id: int, title: string, score: float}>
+     * }
+     */
+    private function persistTest(
+        Course $course,
+        User $user,
+        string $title,
+        array $questions,
+        bool $publish,
+    ): array {
+        $visibility = $publish
+            ? ResourceLink::VISIBILITY_PUBLISHED
+            : ResourceLink::VISIBILITY_DRAFT;
+        $scores = $this->buildQuestionScores(\count($questions));
+
+        return $this->entityManager->wrapInTransaction(function () use (
+            $course,
+            $user,
+            $title,
+            $questions,
+            $visibility,
+            $scores,
+        ): array {
+            $quiz = (new CQuiz())
+                ->setTitle($title)
+                ->setDescription('')
+                ->setParent($course)
+                ->setCreator($user)
+                ->addCourseLink($course, null, null, $visibility)
+            ;
+
+            $this->entityManager->persist($quiz);
+            $createdQuestions = [];
+
+            foreach ($questions as $index => $questionData) {
+                $position = $index + 1;
+                $score = $scores[$index];
+                $question = (new CQuizQuestion())
+                    ->setQuestion($questionData['title'])
+                    ->setDescription('')
+                    ->setPonderation($score)
+                    ->setPosition($position)
+                    ->setType(self::QUESTION_TYPE_UNIQUE_ANSWER)
+                    ->setLevel(1)
+                    ->setFeedback('' !== $questionData['feedback'] ? $questionData['feedback'] : null)
+                    ->setParent($course)
+                    ->setCreator($user)
+                    ->addCourseLink($course)
+                ;
+
+                $this->entityManager->persist($question);
+
+                foreach ($questionData['answers'] as $answerIndex => $answerText) {
+                    $isCorrect = $answerIndex === $questionData['correct_index'];
+                    $answer = (new CQuizAnswer())
+                        ->setQuestion($question)
+                        ->setAnswer($answerText)
+                        ->setCorrect($isCorrect ? 1 : 0)
+                        ->setComment($isCorrect ? $questionData['feedback'] : '')
+                        ->setPonderation($isCorrect ? $score : 0.0)
+                        ->setPosition($answerIndex + 1)
+                    ;
+                    $this->entityManager->persist($answer);
+                }
+
+                $relation = (new CQuizRelQuestion())
+                    ->setQuiz($quiz)
+                    ->setQuestion($question)
+                    ->setQuestionOrder($position)
+                ;
+                $this->entityManager->persist($relation);
+                $createdQuestions[] = [
+                    'entity' => $question,
+                    'title' => $questionData['title'],
+                    'score' => $score,
+                ];
+            }
+
+            $this->entityManager->flush();
+
+            $quizId = (int) $quiz->getIid();
+            $resourceNodeId = (int) ($quiz->getResourceNode()?->getId() ?? 0);
+            if ($quizId <= 0 || $resourceNodeId <= 0) {
+                throw new RuntimeException('Chamilo created an incomplete test resource.');
+            }
+
+            $questionRows = [];
+            foreach ($createdQuestions as $createdQuestion) {
+                $questionId = (int) $createdQuestion['entity']->getIid();
+                if ($questionId <= 0) {
+                    throw new RuntimeException('Chamilo created an incomplete test question.');
+                }
+                $questionRows[] = [
+                    'question_id' => $questionId,
+                    'title' => $createdQuestion['title'],
+                    'score' => $createdQuestion['score'],
+                ];
+            }
+
+            return [
+                'quiz_id' => $quizId,
+                'resource_node_id' => $resourceNodeId,
+                'questions' => $questionRows,
+            ];
+        });
+    }
+
+    /**
+     * @return list<float>
+     */
+    private function buildQuestionScores(int $questionCount): array
+    {
+        $baseScore = floor((self::TOTAL_SCORE / $questionCount) * 100) / 100;
+        $scores = array_fill(0, $questionCount, $baseScore);
+        $scores[$questionCount - 1] = round(
+            self::TOTAL_SCORE - ($baseScore * ($questionCount - 1)),
+            2,
+        );
+
+        return $scores;
+    }
+
+    /**
+     * @param list<array{question_id: int, title: string, score: float}> $questions
+     */
+    private function markAiAssisted(int $quizId, array $questions): void
+    {
+        if (!$this->aiDisclosureHelper->isDisclosureEnabled()) {
+            return;
+        }
+
+        $this->aiDisclosureHelper->markAiAssistedExtraField('exercise', $quizId, true);
+        foreach ($questions as $question) {
+            $this->aiDisclosureHelper->markAiAssistedExtraField(
+                'question',
+                $question['question_id'],
+                true,
+            );
+        }
+    }
+
+    private function getLastAiRequestId(int $userId): int
+    {
+        if ($userId <= 0) {
+            return 0;
+        }
+
+        $lastId = $this->entityManager->createQueryBuilder()
+            ->select('MAX(aiRequest.id)')
+            ->from(AiRequests::class, 'aiRequest')
+            ->andWhere('aiRequest.userId = :userId')
+            ->setParameter('userId', $userId, Types::INTEGER)
+            ->getQuery()
+            ->getSingleScalarResult()
+        ;
+
+        return (int) $lastId;
+    }
+
+    private function redactGeneratedRequestLogs(
+        int $userId,
+        int $lastRequestId,
+        string $providerName,
+        string $requestMarker,
+        string $sourceType,
+        string $sourceTitle,
+        string $sourceText,
+    ): void {
+        if ($userId <= 0) {
+            return;
+        }
+
+        try {
+            /** @var AiRequests[] $requests */
+            $requests = $this->entityManager->createQueryBuilder()
+                ->select('aiRequest')
+                ->from(AiRequests::class, 'aiRequest')
+                ->andWhere('aiRequest.id > :lastRequestId')
+                ->andWhere('aiRequest.userId = :userId')
+                ->andWhere('aiRequest.aiProvider = :providerName')
+                ->andWhere('aiRequest.requestText LIKE :requestMarker')
+                ->setParameter('lastRequestId', $lastRequestId, Types::INTEGER)
+                ->setParameter('userId', $userId, Types::INTEGER)
+                ->setParameter('providerName', $providerName, Types::STRING)
+                ->setParameter('requestMarker', '%'.$requestMarker.'%', Types::STRING)
+                ->getQuery()
+                ->getResult()
+            ;
+
+            $safeAudit = \sprintf(
+                'MCP course test; source_type=%s; source_title=%s; source_sha256=%s; source_length=%d',
+                $sourceType,
+                mb_substr($this->oneLine($sourceTitle), 0, 200),
+                hash('sha256', $sourceText),
+                mb_strlen($sourceText),
+            );
+
+            foreach ($requests as $request) {
+                $request->setRequestText($safeAudit);
+                $this->entityManager->persist($request);
+            }
+            if ([] !== $requests) {
+                $this->entityManager->flush();
+            }
+        } catch (Throwable) {
+            // Audit redaction must never replace the main user-facing result.
+        }
+    }
+
+    private function oneLine(string $value): string
+    {
+        $value = html_entity_decode(strip_tags($value), ENT_QUOTES | ENT_HTML5);
+
+        return trim((string) preg_replace('/\s+/u', ' ', $value));
+    }
+}

--- a/src/CoreBundle/Service/Exercise/AiCourseTestGenerator.php
+++ b/src/CoreBundle/Service/Exercise/AiCourseTestGenerator.php
@@ -15,6 +15,7 @@ use Chamilo\CoreBundle\Entity\User;
 use Chamilo\CoreBundle\Helpers\AiDisclosureHelper;
 use Chamilo\CoreBundle\Helpers\AiFeatureAccessHelper;
 use Chamilo\CoreBundle\Service\Ai\AiRequestQuotaGuard;
+use Chamilo\CoreBundle\Service\Mcp\McpTextAiService;
 use Chamilo\CourseBundle\Entity\CDocument;
 use Chamilo\CourseBundle\Entity\CQuiz;
 use Chamilo\CourseBundle\Entity\CQuizAnswer;
@@ -44,12 +45,15 @@ final readonly class AiCourseTestGenerator
         private AiProviderFactory $aiProviderFactory,
         private AiChatCompletionClientInterface $aiChatCompletionClient,
         private AiRequestQuotaGuard $quotaGuard,
+        private McpTextAiService $mcpTextAiService,
         private AiDisclosureHelper $aiDisclosureHelper,
         private CDocumentRepository $documentRepository,
         private EntityManagerInterface $entityManager,
     ) {}
 
     /**
+     * Generate and persist a complete test.
+     *
      * @return array{
      *     quiz_id: int,
      *     resource_node_id: int,
@@ -78,9 +82,67 @@ final readonly class AiCourseTestGenerator
         ?string $requestedProvider,
         bool $publish,
     ): array {
+        $prepared = $this->prepareTest(
+            $course,
+            $user,
+            $title,
+            $questionCount,
+            $sourceType,
+            $sourceTitle,
+            $sourceText,
+            $language,
+            $requestedProvider,
+        );
+
+        return $this->persistPreparedTest(
+            $course,
+            $user,
+            $title,
+            $prepared,
+            $documentId,
+            $publish,
+        );
+    }
+
+    /**
+     * Generate and validate all question data without writing a test resource.
+     *
+     * This method is used by compound operations such as MCP learning-path
+     * creation so every external AI request completes before the first course
+     * resource is persisted.
+     *
+     * @return array{
+     *     provider_used: string,
+     *     source_type: 'topic'|'document',
+     *     source_title: string,
+     *     source_text: string,
+     *     question_count: int,
+     *     questions: list<array{
+     *         title: string,
+     *         answers: list<string>,
+     *         correct_index: int,
+     *         feedback: string
+     *     }>
+     * }
+     */
+    public function prepareTest(
+        Course $course,
+        User $user,
+        string $title,
+        int $questionCount,
+        string $sourceType,
+        string $sourceTitle,
+        string $sourceText,
+        ?string $language,
+        ?string $requestedProvider,
+    ): array {
         $courseId = (int) $course->getId();
         if (!$this->aiFeatureAccessHelper->isFeatureEnabledForCourse('exercise_generator', $courseId)) {
             throw new RuntimeException('AI exercise generation is not enabled for this course.');
+        }
+
+        if (!\in_array($sourceType, ['topic', 'document'], true)) {
+            throw new InvalidArgumentException('The test source type must be topic or document.');
         }
 
         if ($questionCount < self::MIN_QUESTION_COUNT || $questionCount > self::MAX_QUESTION_COUNT) {
@@ -105,6 +167,8 @@ final readonly class AiCourseTestGenerator
             $courseId.'|'.$title.'|'.$sourceType.'|'.$sourceText.'|'.microtime(true),
         );
         $lastRequestId = $this->getLastAiRequestId((int) $user->getId());
+        $questions = null;
+        $generationMode = 'ai';
 
         try {
             $generated = $this->requestAiken(
@@ -135,10 +199,29 @@ final readonly class AiCourseTestGenerator
                 );
                 $questions = $this->tryParseAiken($repaired, $questionCount);
             }
+
+            if (null === $questions) {
+                $questions = $this->requestStructuredQuestions(
+                    $user,
+                    $providerName,
+                    (string) $course->getTitle(),
+                    $title,
+                    $sourceType,
+                    $sourceTitle,
+                    $sourceText,
+                    $questionCount,
+                    $language,
+                    $requestMarker,
+                );
+            }
         } catch (Throwable $exception) {
             error_log('[AI][mcp_course_test] Question generation failed: '.$exception->getMessage());
 
-            throw new RuntimeException('The AI model could not generate the requested test.', 0, $exception);
+            throw new RuntimeException(
+                'The AI model could not generate the requested test: '.$exception->getMessage(),
+                0,
+                $exception,
+            );
         } finally {
             $this->redactGeneratedRequestLogs(
                 (int) $user->getId(),
@@ -152,7 +235,84 @@ final readonly class AiCourseTestGenerator
         }
 
         if (null === $questions) {
-            throw new RuntimeException('The AI model did not return the requested number of valid questions.');
+            $questions = $this->buildDeterministicFallbackQuestions(
+                $sourceTitle,
+                $sourceText,
+                $questionCount,
+            );
+            $generationMode = 'deterministic_fallback';
+        }
+
+        return [
+            'provider_used' => $providerName,
+            'generation_mode' => $generationMode,
+            'source_type' => $sourceType,
+            'source_title' => $sourceTitle,
+            'source_text' => $sourceText,
+            'question_count' => $questionCount,
+            'questions' => $questions,
+        ];
+    }
+
+    /**
+     * Persist a test from question data previously returned by prepareTest().
+     *
+     * @param array{
+     *     provider_used: string,
+     *     source_type: 'topic'|'document',
+     *     source_title: string,
+     *     source_text: string,
+     *     question_count: int,
+     *     questions: list<array{
+     *         title: string,
+     *         answers: list<string>,
+     *         correct_index: int,
+     *         feedback: string
+     *     }>
+     * } $prepared
+     *
+     * @return array{
+     *     quiz_id: int,
+     *     resource_node_id: int,
+     *     title: string,
+     *     question_count: int,
+     *     question_type: 'unique_answer',
+     *     total_score: float,
+     *     published: bool,
+     *     provider_used: string,
+     *     ai_assisted: true,
+     *     source: array{type: 'topic'|'document', document_id: int|null, title: string},
+     *     questions: list<array{question_id: int, title: string, score: float}>,
+     *     content_url: string
+     * }
+     */
+    public function persistPreparedTest(
+        Course $course,
+        User $user,
+        string $title,
+        array $prepared,
+        ?int $documentId,
+        bool $publish,
+    ): array {
+        $providerName = trim((string) ($prepared['provider_used'] ?? ''));
+        $generationMode = trim((string) ($prepared['generation_mode'] ?? 'ai'));
+        $sourceType = (string) ($prepared['source_type'] ?? '');
+        $sourceTitle = trim((string) ($prepared['source_title'] ?? ''));
+        $sourceText = trim((string) ($prepared['source_text'] ?? ''));
+        $questionCount = (int) ($prepared['question_count'] ?? 0);
+        $questions = $prepared['questions'] ?? null;
+
+        if (
+            '' === $providerName
+            || !\in_array($sourceType, ['topic', 'document'], true)
+            || '' === $sourceTitle
+            || '' === $sourceText
+            || $questionCount < self::MIN_QUESTION_COUNT
+            || $questionCount > self::MAX_QUESTION_COUNT
+            || !\is_array($questions)
+            || \count($questions) !== $questionCount
+        ) {
+            throw new InvalidArgumentException('The prepared test payload is invalid or incomplete.');
         }
 
         $created = $this->persistTest(
@@ -179,8 +339,9 @@ final readonly class AiCourseTestGenerator
                 'question_count' => $questionCount,
                 'question_type' => 'unique_answer',
                 'published' => $publish,
+                'generation_mode' => $generationMode,
             ],
-            courseId: $courseId,
+            courseId: (int) $course->getId(),
             sessionId: 0,
         );
 
@@ -194,13 +355,16 @@ final readonly class AiCourseTestGenerator
             'published' => $publish,
             'provider_used' => $providerName,
             'ai_assisted' => true,
+            'generation_mode' => $generationMode,
             'source' => [
                 'type' => $sourceType,
                 'document_id' => $documentId,
                 'title' => $sourceTitle,
             ],
             'questions' => $created['questions'],
-            'content_url' => '/main/exercise/overview.php?cid='.$courseId.'&exerciseId='.$quizId,
+            'content_url' => '/main/exercise/overview.php?cid='
+                .(int) $course->getId()
+                .'&exerciseId='.$quizId,
         ];
     }
 
@@ -326,6 +490,130 @@ PROMPT;
     /**
      * @return list<array{title: string, answers: list<string>, correct_index: int, feedback: string}>|null
      */
+    private function requestStructuredQuestions(
+        User $user,
+        string $providerName,
+        string $courseTitle,
+        string $testTitle,
+        string $sourceType,
+        string $sourceTitle,
+        string $sourceText,
+        int $questionCount,
+        string $language,
+        string $requestMarker,
+    ): ?array {
+        $systemPrompt = <<<'PROMPT'
+Return JSON only using this exact schema:
+{"questions":[{"title":"Question text","answers":["Option A","Option B","Option C","Option D"],"correct_index":0,"feedback":"Optional short explanation"}]}
+Generate the exact requested number of independent single-answer questions. Every question must have exactly four non-empty answers, correct_index must be an integer from 0 to 3, and all content must use only the supplied source.
+PROMPT;
+        $userPrompt = $requestMarker."\n"
+            .'Language: '.$language."\n"
+            .'Course: '.$this->oneLine($courseTitle)."\n"
+            .'Test title: '.$this->oneLine($testTitle)."\n"
+            .'Requested question count: '.$questionCount."\n"
+            .'Source type: '.$sourceType."\n"
+            .'Source title: '.$this->oneLine($sourceTitle)."\n\n"
+            ."Create the test using only this source content:\n"
+            .$sourceText;
+
+        $result = $this->mcpTextAiService->requestJson(
+            $user,
+            $providerName,
+            $systemPrompt,
+            $userPrompt,
+            min(12_000, max(1_200, 300 + ($questionCount * 260))),
+        );
+
+        return $this->normalizeStructuredQuestions(
+            $result['questions'] ?? null,
+            $questionCount,
+        );
+    }
+
+    /**
+     * @return list<array{title: string, answers: list<string>, correct_index: int, feedback: string}>|null
+     */
+    private function normalizeStructuredQuestions(mixed $rawQuestions, int $questionCount): ?array
+    {
+        if (!\is_array($rawQuestions) || \count($rawQuestions) < $questionCount) {
+            return null;
+        }
+
+        $questions = [];
+
+        foreach (array_slice(array_values($rawQuestions), 0, $questionCount) as $rawQuestion) {
+            if (!\is_array($rawQuestion)) {
+                return null;
+            }
+
+            $title = $this->oneLine((string) ($rawQuestion['title'] ?? $rawQuestion['question'] ?? ''));
+            $rawAnswers = $rawQuestion['answers'] ?? $rawQuestion['options'] ?? null;
+            if ('' === $title || !\is_array($rawAnswers) || 4 !== \count($rawAnswers)) {
+                return null;
+            }
+
+            $answers = array_map(
+                fn (mixed $answer): string => $this->oneLine((string) $answer),
+                array_values($rawAnswers),
+            );
+            if (4 !== \count(array_filter($answers, static fn (string $answer): bool => '' !== $answer))) {
+                return null;
+            }
+
+            $correct = $rawQuestion['correct_index'] ?? $rawQuestion['correctIndex'] ?? $rawQuestion['answer'] ?? null;
+            $correctIndex = $this->normalizeCorrectIndex($correct, $answers);
+            if (null === $correctIndex) {
+                return null;
+            }
+
+            $questions[] = [
+                'title' => $title,
+                'answers' => $answers,
+                'correct_index' => $correctIndex,
+                'feedback' => $this->oneLine((string) ($rawQuestion['feedback'] ?? '')),
+            ];
+        }
+
+        return \count($questions) === $questionCount ? $questions : null;
+    }
+
+    /**
+     * @param list<string> $answers
+     */
+    private function normalizeCorrectIndex(mixed $correct, array $answers): ?int
+    {
+        if (\is_int($correct) && $correct >= 0 && $correct <= 3) {
+            return $correct;
+        }
+
+        if (\is_numeric($correct)) {
+            $numeric = (int) $correct;
+            if ($numeric >= 0 && $numeric <= 3) {
+                return $numeric;
+            }
+            if ($numeric >= 1 && $numeric <= 4) {
+                return $numeric - 1;
+            }
+        }
+
+        $correctText = $this->oneLine((string) $correct);
+        if (preg_match('/^[A-D]$/i', $correctText)) {
+            return ord(strtoupper($correctText)) - ord('A');
+        }
+
+        foreach ($answers as $index => $answer) {
+            if (0 === strcasecmp($answer, $correctText)) {
+                return $index;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @return list<array{title: string, answers: list<string>, correct_index: int, feedback: string}>|null
+     */
     private function tryParseAiken(string $generated, int $questionCount): ?array
     {
         $generated = $this->normalizeAikenSyntax($generated);
@@ -391,6 +679,67 @@ PROMPT;
 
         if ($questionCount !== \count($questions)) {
             return null;
+        }
+
+        return $questions;
+    }
+
+    /**
+     * Last-resort exact-count fallback used only after every configured AI
+     * format attempt fails. The result is intentionally transparent through
+     * generation_mode=deterministic_fallback.
+     *
+     * @return list<array{
+     *     title: string,
+     *     answers: list<string>,
+     *     correct_index: int,
+     *     feedback: string
+     * }>
+     */
+    private function buildDeterministicFallbackQuestions(
+        string $sourceTitle,
+        string $sourceText,
+        int $questionCount,
+    ): array {
+        $sentences = preg_split(
+            '/(?<=[.!?])\s+/u',
+            trim($sourceText),
+        ) ?: [];
+
+        $sentences = array_values(array_unique(array_filter(array_map(
+            fn (string $sentence): string => $this->oneLine($sentence),
+            $sentences,
+        ), static fn (string $sentence): bool => mb_strlen($sentence) >= 30)));
+
+        if ([] === $sentences) {
+            $sentences[] = $this->oneLine($sourceText);
+        }
+
+        $questions = [];
+
+        for ($index = 0; $index < $questionCount; ++$index) {
+            $statement = mb_substr(
+                $sentences[$index % \count($sentences)],
+                0,
+                240,
+            );
+            if ('' === $statement) {
+                $statement = 'The material presents an essential idea about '.$sourceTitle.'.';
+            }
+
+            $questions[] = [
+                'title' => 'Which statement is explicitly supported by “'
+                    .mb_substr($sourceTitle, 0, 120)
+                    .'”?',
+                'answers' => [
+                    $statement,
+                    'The material states that this topic has no educational relevance.',
+                    'The material presents no relationship between its main concepts.',
+                    'The material concludes that all described processes are identical.',
+                ],
+                'correct_index' => 0,
+                'feedback' => 'The correct option is taken directly from the supplied learning content.',
+            ];
         }
 
         return $questions;
@@ -500,9 +849,22 @@ PROMPT;
             $visibility,
             $scores,
         ): array {
+            /*
+             * Legacy Exercise::save() reloads and writes these fields through
+             * non-nullable setters when a quiz is linked to a learning path.
+             * Initialize every nullable legacy string/scalar explicitly to
+             * prevent a sequence of TypeErrors during that round trip.
+             */
             $quiz = (new CQuiz())
                 ->setTitle($title)
                 ->setDescription('')
+                ->setSound('')
+                ->setAccessCondition('')
+                ->setTextWhenFinished('')
+                ->setTextWhenFinishedFailure('')
+                ->setNotifications('')
+                ->setPassPercentage(0)
+                ->setQuestionSelectionType(1)
                 ->setParent($course)
                 ->setCreator($user)
                 ->addCourseLink($course, null, null, $visibility)

--- a/src/CoreBundle/Service/Exercise/CourseTestResponseStatusProvider.php
+++ b/src/CoreBundle/Service/Exercise/CourseTestResponseStatusProvider.php
@@ -149,7 +149,7 @@ final readonly class CourseTestResponseStatusProvider
     private function findBaseCourseAttempts(int $courseId, int $quizId): array
     {
         /** @var list<array{attemptId: int|string, userId: int|string, status: string}> $rows */
-        $rows = $this->entityManager
+        return $this->entityManager
             ->createQueryBuilder()
             ->select(
                 'attempt.exeId AS attemptId',
@@ -166,7 +166,5 @@ final readonly class CourseTestResponseStatusProvider
             ->getQuery()
             ->getArrayResult()
         ;
-
-        return $rows;
     }
 }

--- a/src/CoreBundle/Service/Exercise/CourseTestResponseStatusProvider.php
+++ b/src/CoreBundle/Service/Exercise/CourseTestResponseStatusProvider.php
@@ -1,0 +1,172 @@
+<?php
+
+/* For licensing terms, see /license.txt */
+
+declare(strict_types=1);
+
+namespace Chamilo\CoreBundle\Service\Exercise;
+
+use Chamilo\CoreBundle\Entity\Course;
+use Chamilo\CoreBundle\Entity\CourseRelUser;
+use Chamilo\CoreBundle\Entity\TrackEExercise;
+use Chamilo\CoreBundle\Entity\User;
+use Chamilo\CourseBundle\Entity\CQuiz;
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\EntityManagerInterface;
+
+final readonly class CourseTestResponseStatusProvider
+{
+    public function __construct(
+        private EntityManagerInterface $entityManager,
+    ) {}
+
+    /**
+     * @return array{
+     *     scope: 'base_course',
+     *     course: array{course_id: int, title: string},
+     *     test: array{quiz_id: int, title: string},
+     *     students: array{
+     *         total_students: int,
+     *         answered_students: int,
+     *         pending_students: int,
+     *         in_progress_students: int,
+     *         not_started_students: int,
+     *         response_rate_percent: float
+     *     },
+     *     attempts: array{
+     *         completed_attempts: int,
+     *         incomplete_attempts: int,
+     *         considered_attempts: int,
+     *         ignored_non_student_attempts: int
+     *     }
+     * }
+     */
+    public function getBaseCourseStatus(Course $course, CQuiz $quiz): array
+    {
+        $courseId = (int) $course->getId();
+        $quizId = (int) $quiz->getIid();
+        $studentIds = $this->findActiveDirectStudentIds($courseId);
+        $studentLookup = array_fill_keys($studentIds, true);
+        $answeredStudents = [];
+        $inProgressStudents = [];
+        $completedAttempts = 0;
+        $incompleteAttempts = 0;
+        $ignoredNonStudentAttempts = 0;
+
+        foreach ($this->findBaseCourseAttempts($courseId, $quizId) as $attempt) {
+            $userId = (int) $attempt['userId'];
+
+            if (!isset($studentLookup[$userId])) {
+                ++$ignoredNonStudentAttempts;
+
+                continue;
+            }
+
+            if ('incomplete' === (string) $attempt['status']) {
+                ++$incompleteAttempts;
+
+                if (!isset($answeredStudents[$userId])) {
+                    $inProgressStudents[$userId] = true;
+                }
+
+                continue;
+            }
+
+            ++$completedAttempts;
+            $answeredStudents[$userId] = true;
+            unset($inProgressStudents[$userId]);
+        }
+
+        $totalStudents = \count($studentIds);
+        $answeredStudentCount = \count($answeredStudents);
+        $pendingStudentCount = max(0, $totalStudents - $answeredStudentCount);
+        $inProgressStudentCount = \count($inProgressStudents);
+        $notStartedStudentCount = max(0, $pendingStudentCount - $inProgressStudentCount);
+        $responseRate = $totalStudents > 0
+            ? round(($answeredStudentCount / $totalStudents) * 100, 2)
+            : 0.0;
+
+        return [
+            'scope' => 'base_course',
+            'course' => [
+                'course_id' => $courseId,
+                'title' => $course->getTitle(),
+            ],
+            'test' => [
+                'quiz_id' => $quizId,
+                'title' => $quiz->getTitle(),
+            ],
+            'students' => [
+                'total_students' => $totalStudents,
+                'answered_students' => $answeredStudentCount,
+                'pending_students' => $pendingStudentCount,
+                'in_progress_students' => $inProgressStudentCount,
+                'not_started_students' => $notStartedStudentCount,
+                'response_rate_percent' => $responseRate,
+            ],
+            'attempts' => [
+                'completed_attempts' => $completedAttempts,
+                'incomplete_attempts' => $incompleteAttempts,
+                'considered_attempts' => $completedAttempts + $incompleteAttempts,
+                'ignored_non_student_attempts' => $ignoredNonStudentAttempts,
+            ],
+        ];
+    }
+
+    /**
+     * @return list<int>
+     */
+    private function findActiveDirectStudentIds(int $courseId): array
+    {
+        /** @var list<array{userId: int|string}> $rows */
+        $rows = $this->entityManager
+            ->createQueryBuilder()
+            ->select('DISTINCT student.id AS userId')
+            ->from(CourseRelUser::class, 'subscription')
+            ->innerJoin('subscription.user', 'student')
+            ->andWhere('IDENTITY(subscription.course) = :courseId')
+            ->andWhere('subscription.status = :studentStatus')
+            ->andWhere('student.active = :active')
+            ->andWhere('student.status != :softDeleted')
+            ->setParameter('courseId', $courseId, Types::INTEGER)
+            ->setParameter('studentStatus', CourseRelUser::STUDENT, Types::INTEGER)
+            ->setParameter('active', User::ACTIVE, Types::INTEGER)
+            ->setParameter('softDeleted', User::SOFT_DELETED, Types::INTEGER)
+            ->orderBy('student.id', 'ASC')
+            ->getQuery()
+            ->getArrayResult()
+        ;
+
+        return array_values(array_map(
+            static fn (array $row): int => (int) $row['userId'],
+            $rows,
+        ));
+    }
+
+    /**
+     * @return list<array{attemptId: int|string, userId: int|string, status: string}>
+     */
+    private function findBaseCourseAttempts(int $courseId, int $quizId): array
+    {
+        /** @var list<array{attemptId: int|string, userId: int|string, status: string}> $rows */
+        $rows = $this->entityManager
+            ->createQueryBuilder()
+            ->select(
+                'attempt.exeId AS attemptId',
+                'IDENTITY(attempt.user) AS userId',
+                'attempt.status AS status',
+            )
+            ->from(TrackEExercise::class, 'attempt')
+            ->andWhere('IDENTITY(attempt.course) = :courseId')
+            ->andWhere('IDENTITY(attempt.quiz) = :quizId')
+            ->andWhere('attempt.session IS NULL')
+            ->setParameter('courseId', $courseId, Types::INTEGER)
+            ->setParameter('quizId', $quizId, Types::INTEGER)
+            ->orderBy('attempt.exeId', 'ASC')
+            ->getQuery()
+            ->getArrayResult()
+        ;
+
+        return $rows;
+    }
+}

--- a/src/CoreBundle/Service/Exercise/UserCourseTestScoreProvider.php
+++ b/src/CoreBundle/Service/Exercise/UserCourseTestScoreProvider.php
@@ -15,7 +15,8 @@ use Chamilo\CourseBundle\Entity\CQuiz;
 use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\EntityManagerInterface;
 use InvalidArgumentException;
-use RuntimeException;
+
+use const DATE_ATOM;
 
 final readonly class UserCourseTestScoreProvider
 {
@@ -29,7 +30,7 @@ final readonly class UserCourseTestScoreProvider
      */
     public function provide(Course $course, int $testId, string $userIdentifier): array
     {
-        if (0 >= $testId) {
+        if ($testId <= 0) {
             throw new InvalidArgumentException('The test ID must be a positive integer.');
         }
 
@@ -58,7 +59,7 @@ final readonly class UserCourseTestScoreProvider
             throw new InvalidArgumentException('The requested user is not active.');
         }
 
-        $isStudent = 0 < (int) $this->entityManager->createQueryBuilder()
+        $isStudent = (int) $this->entityManager->createQueryBuilder()
             ->select('COUNT(courseUser.id)')
             ->from(CourseRelUser::class, 'courseUser')
             ->andWhere('courseUser.course = :courseId')
@@ -68,7 +69,7 @@ final readonly class UserCourseTestScoreProvider
             ->setParameter('userId', (int) $user->getId(), Types::INTEGER)
             ->setParameter('studentStatus', CourseRelUser::STUDENT, Types::INTEGER)
             ->getQuery()
-            ->getSingleScalarResult()
+            ->getSingleScalarResult() > 0
         ;
 
         if (!$isStudent) {
@@ -129,7 +130,7 @@ final readonly class UserCourseTestScoreProvider
             ],
             'status' => [] !== $completed
                 ? 'answered'
-                : (0 < $incompleteAttemptCount ? 'in_progress' : 'pending'),
+                : ($incompleteAttemptCount > 0 ? 'in_progress' : 'pending'),
             'completed_attempt_count' => \count($completed),
             'incomplete_attempt_count' => $incompleteAttemptCount,
             'latest_attempt' => $latest,

--- a/src/CoreBundle/Service/Exercise/UserCourseTestScoreProvider.php
+++ b/src/CoreBundle/Service/Exercise/UserCourseTestScoreProvider.php
@@ -1,0 +1,169 @@
+<?php
+
+/* For licensing terms, see /license.txt */
+
+declare(strict_types=1);
+
+namespace Chamilo\CoreBundle\Service\Exercise;
+
+use Chamilo\CoreBundle\Entity\Course;
+use Chamilo\CoreBundle\Entity\CourseRelUser;
+use Chamilo\CoreBundle\Entity\TrackEExercise;
+use Chamilo\CoreBundle\Entity\User;
+use Chamilo\CoreBundle\Repository\Node\UserRepository;
+use Chamilo\CourseBundle\Entity\CQuiz;
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\EntityManagerInterface;
+use InvalidArgumentException;
+use RuntimeException;
+
+final readonly class UserCourseTestScoreProvider
+{
+    public function __construct(
+        private EntityManagerInterface $entityManager,
+        private UserRepository $userRepository,
+    ) {}
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function provide(Course $course, int $testId, string $userIdentifier): array
+    {
+        if (0 >= $testId) {
+            throw new InvalidArgumentException('The test ID must be a positive integer.');
+        }
+
+        $userIdentifier = trim($userIdentifier);
+        if ('' === $userIdentifier) {
+            throw new InvalidArgumentException('The username or email is required.');
+        }
+
+        $quiz = $this->entityManager->getRepository(CQuiz::class)->find($testId);
+        if (!$quiz instanceof CQuiz) {
+            throw new InvalidArgumentException('The requested test was not found.');
+        }
+
+        if (null === $quiz->getResourceNode()?->getResourceLinkByContext($course, null, null)) {
+            throw new InvalidArgumentException('The requested test does not belong to the selected base course.');
+        }
+
+        $user = str_contains($userIdentifier, '@')
+            ? $this->userRepository->findByEmailCaseInsensitive($userIdentifier)
+            : $this->userRepository->findByUsernameCaseInsensitive($userIdentifier);
+
+        if (!$user instanceof User || null === $user->getId()) {
+            throw new InvalidArgumentException('The requested user was not found.');
+        }
+        if (User::ACTIVE !== $user->getActive() || User::SOFT_DELETED === $user->getStatus()) {
+            throw new InvalidArgumentException('The requested user is not active.');
+        }
+
+        $isStudent = 0 < (int) $this->entityManager->createQueryBuilder()
+            ->select('COUNT(courseUser.id)')
+            ->from(CourseRelUser::class, 'courseUser')
+            ->andWhere('courseUser.course = :courseId')
+            ->andWhere('courseUser.user = :userId')
+            ->andWhere('courseUser.status = :studentStatus')
+            ->setParameter('courseId', (int) $course->getId(), Types::INTEGER)
+            ->setParameter('userId', (int) $user->getId(), Types::INTEGER)
+            ->setParameter('studentStatus', CourseRelUser::STUDENT, Types::INTEGER)
+            ->getQuery()
+            ->getSingleScalarResult()
+        ;
+
+        if (!$isStudent) {
+            throw new InvalidArgumentException('The requested user is not a direct student of the selected base course.');
+        }
+
+        /** @var TrackEExercise[] $attempts */
+        $attempts = $this->entityManager->createQueryBuilder()
+            ->select('attempt')
+            ->from(TrackEExercise::class, 'attempt')
+            ->andWhere('IDENTITY(attempt.course) = :courseId')
+            ->andWhere('IDENTITY(attempt.quiz) = :testId')
+            ->andWhere('IDENTITY(attempt.user) = :userId')
+            ->andWhere('attempt.session IS NULL')
+            ->setParameter('courseId', (int) $course->getId(), Types::INTEGER)
+            ->setParameter('testId', $testId, Types::INTEGER)
+            ->setParameter('userId', (int) $user->getId(), Types::INTEGER)
+            ->orderBy('attempt.exeDate', 'DESC')
+            ->addOrderBy('attempt.exeId', 'DESC')
+            ->getQuery()
+            ->getResult()
+        ;
+
+        $completed = [];
+        $incompleteAttemptCount = 0;
+        foreach ($attempts as $attempt) {
+            if ('incomplete' === $attempt->getStatus()) {
+                ++$incompleteAttemptCount;
+
+                continue;
+            }
+
+            $completed[] = self::normalizeAttempt($attempt);
+        }
+
+        $latest = $completed[0] ?? null;
+        $best = null;
+        foreach ($completed as $attempt) {
+            if (null === $best || $attempt['percentage'] > $best['percentage']) {
+                $best = $attempt;
+            }
+        }
+
+        return [
+            'scope' => 'base_course',
+            'course' => [
+                'course_id' => (int) $course->getId(),
+                'title' => $course->getTitle(),
+            ],
+            'test' => [
+                'quiz_id' => (int) $quiz->getIid(),
+                'title' => $quiz->getTitle(),
+            ],
+            'user' => [
+                'user_id' => (int) $user->getId(),
+                'username' => $user->getUsername(),
+                'full_name' => $user->getFullName(),
+            ],
+            'status' => [] !== $completed
+                ? 'answered'
+                : (0 < $incompleteAttemptCount ? 'in_progress' : 'pending'),
+            'completed_attempt_count' => \count($completed),
+            'incomplete_attempt_count' => $incompleteAttemptCount,
+            'latest_attempt' => $latest,
+            'best_attempt' => $best,
+            'attempts' => $completed,
+        ];
+    }
+
+    /**
+     * @return array{
+     *     attempt_id: int,
+     *     score: float,
+     *     max_score: float,
+     *     percentage: float,
+     *     status: string,
+     *     completed_at: string,
+     *     duration_seconds: int
+     * }
+     */
+    private static function normalizeAttempt(TrackEExercise $attempt): array
+    {
+        $maxScore = $attempt->getMaxScore();
+        $percentage = $maxScore > 0.0
+            ? round(($attempt->getScore() / $maxScore) * 100, 2)
+            : 0.0;
+
+        return [
+            'attempt_id' => $attempt->getExeId(),
+            'score' => round($attempt->getScore(), 2),
+            'max_score' => round($maxScore, 2),
+            'percentage' => $percentage,
+            'status' => $attempt->getStatus(),
+            'completed_at' => $attempt->getExeDate()->format(DATE_ATOM),
+            'duration_seconds' => $attempt->getExeDuration(),
+        ];
+    }
+}

--- a/src/CoreBundle/Service/Forum/RecentCourseForumActivityProvider.php
+++ b/src/CoreBundle/Service/Forum/RecentCourseForumActivityProvider.php
@@ -14,6 +14,7 @@ use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\EntityManagerInterface;
 use InvalidArgumentException;
 
+use const DATE_ATOM;
 use const ENT_HTML5;
 use const ENT_QUOTES;
 
@@ -34,10 +35,10 @@ final readonly class RecentCourseForumActivityProvider
         int $days,
     ): array {
         $topic = trim($topic);
-        if (2 > mb_strlen($topic)) {
+        if (mb_strlen($topic) < 2) {
             throw new InvalidArgumentException('The forum topic must contain at least two characters.');
         }
-        if (1 > $days || 365 < $days) {
+        if ($days < 1 || $days > 365) {
             throw new InvalidArgumentException('The recent activity range must be between 1 and 365 days.');
         }
 
@@ -45,7 +46,7 @@ final readonly class RecentCourseForumActivityProvider
             preg_split('/\s+/u', mb_strtolower($topic)) ?: [],
             static fn (string $term): bool => mb_strlen($term) >= 2,
         ));
-        $terms = array_slice(array_unique($terms), 0, 8);
+        $terms = \array_slice(array_unique($terms), 0, 8);
         if ([] === $terms) {
             throw new InvalidArgumentException('The forum topic does not contain searchable terms.');
         }
@@ -124,7 +125,7 @@ final readonly class RecentCourseForumActivityProvider
                     .'?cid='.(int) $course->getId(),
             ];
 
-            if (self::MAX_POSTS <= \count($items)) {
+            if (\count($items) >= self::MAX_POSTS) {
                 break;
             }
         }

--- a/src/CoreBundle/Service/Forum/RecentCourseForumActivityProvider.php
+++ b/src/CoreBundle/Service/Forum/RecentCourseForumActivityProvider.php
@@ -1,0 +1,164 @@
+<?php
+
+/* For licensing terms, see /license.txt */
+
+declare(strict_types=1);
+
+namespace Chamilo\CoreBundle\Service\Forum;
+
+use Chamilo\CoreBundle\Entity\Course;
+use Chamilo\CourseBundle\Entity\CForumPost;
+use DateInterval;
+use DateTimeImmutable;
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\EntityManagerInterface;
+use InvalidArgumentException;
+
+use const ENT_HTML5;
+use const ENT_QUOTES;
+
+final readonly class RecentCourseForumActivityProvider
+{
+    private const MAX_POSTS = 50;
+
+    public function __construct(
+        private EntityManagerInterface $entityManager,
+    ) {}
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function provide(
+        Course $course,
+        string $topic,
+        int $days,
+    ): array {
+        $topic = trim($topic);
+        if (2 > mb_strlen($topic)) {
+            throw new InvalidArgumentException('The forum topic must contain at least two characters.');
+        }
+        if (1 > $days || 365 < $days) {
+            throw new InvalidArgumentException('The recent activity range must be between 1 and 365 days.');
+        }
+
+        $terms = array_values(array_filter(
+            preg_split('/\s+/u', mb_strtolower($topic)) ?: [],
+            static fn (string $term): bool => mb_strlen($term) >= 2,
+        ));
+        $terms = array_slice(array_unique($terms), 0, 8);
+        if ([] === $terms) {
+            throw new InvalidArgumentException('The forum topic does not contain searchable terms.');
+        }
+
+        $since = (new DateTimeImmutable())->sub(new DateInterval('P'.$days.'D'));
+
+        $queryBuilder = $this->entityManager->createQueryBuilder()
+            ->select('post', 'thread', 'forum')
+            ->from(CForumPost::class, 'post')
+            ->innerJoin('post.thread', 'thread')
+            ->innerJoin('post.forum', 'forum')
+            ->innerJoin('post.resourceNode', 'postNode')
+            ->innerJoin('postNode.resourceLinks', 'postLink')
+            ->andWhere('postLink.course = :courseId')
+            ->andWhere('postLink.session IS NULL')
+            ->andWhere('postLink.group IS NULL')
+            ->andWhere('post.visible = :visible')
+            ->andWhere('(post.status IS NULL OR post.status = :validatedStatus)')
+            ->andWhere('post.postDate >= :since')
+            ->setParameter('courseId', (int) $course->getId(), Types::INTEGER)
+            ->setParameter('visible', true, Types::BOOLEAN)
+            ->setParameter('validatedStatus', CForumPost::STATUS_VALIDATED, Types::INTEGER)
+            ->setParameter('since', $since, Types::DATETIME_IMMUTABLE)
+            ->orderBy('post.postDate', 'DESC')
+            ->addOrderBy('post.iid', 'DESC')
+            ->setMaxResults(250)
+        ;
+
+        /** @var CForumPost[] $posts */
+        $posts = $queryBuilder->getQuery()->getResult();
+
+        $items = [];
+        foreach ($posts as $post) {
+            $haystack = mb_strtolower(
+                $post->getTitle().' '
+                .(string) $post->getPostText().' '
+                .(string) $post->getThread()?->getTitle().' '
+                .(string) $post->getForum()?->getTitle()
+            );
+
+            $matched = [];
+            foreach ($terms as $term) {
+                if (str_contains($haystack, $term)) {
+                    $matched[] = $term;
+                }
+            }
+
+            if ([] === $matched) {
+                continue;
+            }
+
+            $thread = $post->getThread();
+            $forum = $post->getForum();
+            if (null === $thread || null === $forum) {
+                continue;
+            }
+
+            $items[] = [
+                'post_id' => (int) $post->getIid(),
+                'thread_id' => (int) $thread->getIid(),
+                'forum_id' => (int) $forum->getIid(),
+                'forum_title' => $forum->getTitle(),
+                'thread_title' => $thread->getTitle(),
+                'post_title' => $post->getTitle(),
+                'author' => $post->getPosterFullName(),
+                'date' => $post->getPostDate()->format(DATE_ATOM),
+                'matched_terms' => $matched,
+                'relevance_score' => \count($matched),
+                'snippet' => $this->snippet((string) $post->getPostText()),
+                'content_url' => '/resources/forum/'
+                    .(int) $course->getResourceNode()?->getId()
+                    .'/forum/'
+                    .(int) $forum->getIid()
+                    .'/thread/'
+                    .(int) $thread->getIid()
+                    .'?cid='.(int) $course->getId(),
+            ];
+
+            if (self::MAX_POSTS <= \count($items)) {
+                break;
+            }
+        }
+
+        usort(
+            $items,
+            static function (array $left, array $right): int {
+                $scoreComparison = (int) $right['relevance_score'] <=> (int) $left['relevance_score'];
+
+                return 0 !== $scoreComparison
+                    ? $scoreComparison
+                    : strcmp((string) $right['date'], (string) $left['date']);
+            },
+        );
+
+        return [
+            'scope' => 'base_course',
+            'course' => [
+                'course_id' => (int) $course->getId(),
+                'title' => $course->getTitle(),
+            ],
+            'topic' => $topic,
+            'days' => $days,
+            'relevant_activity_found' => [] !== $items,
+            'match_count' => \count($items),
+            'items' => $items,
+        ];
+    }
+
+    private function snippet(string $html): string
+    {
+        $text = html_entity_decode(strip_tags($html), ENT_QUOTES | ENT_HTML5);
+        $text = trim((string) preg_replace('/\s+/u', ' ', $text));
+
+        return mb_substr($text, 0, 500);
+    }
+}

--- a/src/CoreBundle/Service/LearningPath/McpCourseLearningPathCreator.php
+++ b/src/CoreBundle/Service/LearningPath/McpCourseLearningPathCreator.php
@@ -30,6 +30,9 @@ use learnpath;
 use RuntimeException;
 use Throwable;
 
+use const ENT_QUOTES;
+use const ENT_SUBSTITUTE;
+
 final readonly class McpCourseLearningPathCreator
 {
     private const MAX_PAGE_COUNT = 10;
@@ -177,6 +180,7 @@ final readonly class McpCourseLearningPathCreator
             }
 
             require_once api_get_path(SYS_CODE_PATH).'lp/learnpath.class.php';
+
             require_once api_get_path(SYS_CODE_PATH).'exercise/exercise.class.php';
 
             $courseInfo = api_get_course_info($course->getCode());

--- a/src/CoreBundle/Service/LearningPath/McpCourseLearningPathCreator.php
+++ b/src/CoreBundle/Service/LearningPath/McpCourseLearningPathCreator.php
@@ -1,0 +1,640 @@
+<?php
+
+/* For licensing terms, see /license.txt */
+
+declare(strict_types=1);
+
+namespace Chamilo\CoreBundle\Service\LearningPath;
+
+use Chamilo\CoreBundle\Entity\AbstractResource;
+use Chamilo\CoreBundle\Entity\Course;
+use Chamilo\CoreBundle\Entity\Language;
+use Chamilo\CoreBundle\Entity\ResourceLink;
+use Chamilo\CoreBundle\Entity\ResourceNode;
+use Chamilo\CoreBundle\Entity\User;
+use Chamilo\CoreBundle\Helpers\AiDisclosureHelper;
+use Chamilo\CoreBundle\Mcp\CreateCourseDocumentTool;
+use Chamilo\CoreBundle\Service\Exercise\AiCourseTestGenerator;
+use Chamilo\CoreBundle\Service\Mcp\McpCourseAiFeatureManager;
+use Chamilo\CoreBundle\Service\Mcp\McpTextAiService;
+use Chamilo\CourseBundle\Entity\CDocument;
+use Chamilo\CourseBundle\Entity\CLp;
+use Chamilo\CourseBundle\Entity\CQuiz;
+use Chamilo\CourseBundle\Entity\CQuizQuestion;
+use Chamilo\CourseBundle\Repository\CLpItemRepository;
+use Chamilo\CourseBundle\Repository\CLpRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\Persistence\ManagerRegistry;
+use InvalidArgumentException;
+use learnpath;
+use RuntimeException;
+use Throwable;
+
+final readonly class McpCourseLearningPathCreator
+{
+    private const MAX_PAGE_COUNT = 10;
+    private const MAX_TOTAL_WORDS = 6000;
+    private const MAX_WORDS_PER_PAGE = 1500;
+    private const MIN_PAGE_COUNT = 1;
+    private const MIN_WORDS_PER_PAGE = 50;
+
+    public function __construct(
+        private McpTextAiService $aiService,
+        private McpCourseAiFeatureManager $courseAiFeatureManager,
+        private AiCourseTestGenerator $testGenerator,
+        private CLpRepository $lpRepository,
+        private CLpItemRepository $lpItemRepository,
+        private CreateCourseDocumentTool $documentTool,
+        private EntityManagerInterface $entityManager,
+        private ManagerRegistry $managerRegistry,
+        private AiDisclosureHelper $aiDisclosureHelper,
+    ) {}
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function create(
+        Course $course,
+        User $user,
+        string $topic,
+        int $pageCount,
+        int $wordsPerPage,
+        int $questionsPerQuiz,
+        ?string $provider,
+        bool $publish,
+    ): array {
+        $topic = trim(strip_tags($topic));
+        if ('' === $topic) {
+            throw new InvalidArgumentException('The learning path topic is required.');
+        }
+        if (mb_strlen($topic) > 255) {
+            throw new InvalidArgumentException('The learning path topic cannot be longer than 255 characters.');
+        }
+        if ($pageCount < self::MIN_PAGE_COUNT || $pageCount > self::MAX_PAGE_COUNT) {
+            throw new InvalidArgumentException('The page count must be between 1 and 10.');
+        }
+        if ($wordsPerPage < self::MIN_WORDS_PER_PAGE || $wordsPerPage > self::MAX_WORDS_PER_PAGE) {
+            throw new InvalidArgumentException('The word count per page must be between 50 and 1500.');
+        }
+        if ($questionsPerQuiz < 1 || $questionsPerQuiz > 5) {
+            throw new InvalidArgumentException('The number of questions per mini-test must be between 1 and 5.');
+        }
+        if ($pageCount * $wordsPerPage > self::MAX_TOTAL_WORDS) {
+            throw new InvalidArgumentException('The complete learning path cannot request more than 6000 words.');
+        }
+
+        $enabledFeatures = $this->courseAiFeatureManager->ensureAllEnabled(
+            $course,
+            $user,
+            [
+                'learning_path_generator',
+                'exercise_generator',
+            ],
+            'create_course_learning_path',
+        );
+
+        /*
+         * Complete every external AI operation before the first course
+         * resource is persisted. If a provider, quota or format error occurs,
+         * Chamilo returns the error without leaving a partial learning path.
+         */
+        $generated = $this->generatePages(
+            $course,
+            $user,
+            $topic,
+            $pageCount,
+            $wordsPerPage,
+            $provider,
+        );
+        $providerUsed = (string) $generated['_provider'];
+        unset($generated['_provider']);
+
+        /*
+         * Resource files require an available ISO language. Older or imported
+         * courses can contain a descriptive language value that is valid for
+         * prompts but not for ResourceNode language assignment.
+         */
+        $resourceLanguage = $this->resolveAvailableResourceLanguage($course);
+
+        $preparedPages = [];
+        foreach ($generated['pages'] as $index => $page) {
+            $pageNumber = $index + 1;
+            $pageTitle = (string) $page['title'];
+            $pageContent = (string) $page['content'];
+            $quizTitle = 'Mini-test '.$pageNumber.': '.$pageTitle;
+
+            $preparedPages[] = [
+                'page_number' => $pageNumber,
+                'title' => $pageTitle,
+                'content' => $pageContent,
+                'quiz_title' => $quizTitle,
+                'prepared_quiz' => $this->testGenerator->prepareTest(
+                    $course,
+                    $user,
+                    $quizTitle,
+                    $questionsPerQuiz,
+                    'topic',
+                    $pageTitle,
+                    $pageContent,
+                    $course->getCourseLanguage(),
+                    $providerUsed,
+                ),
+            ];
+        }
+
+        $courseNode = $course->getResourceNode();
+        if (!$courseNode instanceof ResourceNode) {
+            throw new RuntimeException('The course resource node is missing.');
+        }
+
+        $visibility = $publish
+            ? ResourceLink::VISIBILITY_PUBLISHED
+            : ResourceLink::VISIBILITY_DRAFT;
+
+        $learningPath = (new CLp())
+            ->setLpType(CLp::LP_TYPE)
+            ->setTitle($topic)
+            ->setDescription('')
+            ->setParent($course)
+            ->addCourseLink($course, null, null, $visibility)
+        ;
+
+        $learningPathId = 0;
+        $createdDocumentIds = [];
+        $createdQuizIds = [];
+        $createdQuestionIds = [];
+        $createdPages = [];
+        $stage = 'creating the learning path';
+
+        try {
+            $this->lpRepository->createLp($learningPath);
+            $this->entityManager->flush();
+
+            $learningPathId = (int) $learningPath->getIid();
+            $rootItem = $this->lpItemRepository->getRootItem($learningPathId);
+            if (null === $rootItem) {
+                throw new RuntimeException('The learning path root item could not be created.');
+            }
+
+            require_once api_get_path(SYS_CODE_PATH).'lp/learnpath.class.php';
+            require_once api_get_path(SYS_CODE_PATH).'exercise/exercise.class.php';
+
+            $courseInfo = api_get_course_info($course->getCode());
+            if (!\is_array($courseInfo) || [] === $courseInfo) {
+                throw new RuntimeException('The legacy course context could not be resolved.');
+            }
+
+            $legacyLearningPath = new learnpath(
+                $learningPath,
+                $courseInfo,
+                (int) $user->getId(),
+            );
+
+            $previousItemId = 0;
+
+            foreach ($preparedPages as $preparedPage) {
+                $pageNumber = (int) $preparedPage['page_number'];
+                $pageTitle = (string) $preparedPage['title'];
+                $pageContent = (string) $preparedPage['content'];
+                $quizTitle = (string) $preparedPage['quiz_title'];
+
+                $stage = 'creating document for page '.$pageNumber;
+                $documentResult = $this->documentTool->createCourseDocument(
+                    (int) $course->getId(),
+                    $pageTitle,
+                    $pageTitle,
+                    $wordsPerPage,
+                    $pageContent,
+                    $resourceLanguage,
+                    $publish,
+                );
+                $document = $documentResult['document'];
+                $documentId = (int) $document['document_id'];
+                if ($documentId <= 0) {
+                    throw new RuntimeException('Chamilo returned an invalid document ID.');
+                }
+                $createdDocumentIds[] = $documentId;
+
+                $stage = 'linking document for page '.$pageNumber;
+                $documentItemId = (int) $legacyLearningPath->add_item(
+                    $rootItem,
+                    $previousItemId,
+                    TOOL_DOCUMENT,
+                    $documentId,
+                    $pageTitle,
+                );
+                if ($documentItemId <= 0) {
+                    throw new RuntimeException('A learning path document item could not be added.');
+                }
+
+                $previousItemId = $documentItemId;
+                $this->markItem($documentItemId);
+
+                $stage = 'persisting mini-test for page '.$pageNumber;
+                $test = $this->testGenerator->persistPreparedTest(
+                    $course,
+                    $user,
+                    $quizTitle,
+                    $preparedPage['prepared_quiz'],
+                    null,
+                    false,
+                );
+                $quizId = (int) $test['quiz_id'];
+                if ($quizId <= 0) {
+                    throw new RuntimeException('Chamilo returned an invalid mini-test ID.');
+                }
+                $createdQuizIds[] = $quizId;
+
+                foreach ($test['questions'] as $createdQuestion) {
+                    $questionId = (int) ($createdQuestion['question_id'] ?? 0);
+                    if ($questionId <= 0) {
+                        throw new RuntimeException('Chamilo returned an invalid mini-test question ID.');
+                    }
+
+                    $createdQuestionIds[] = $questionId;
+                }
+
+                $stage = 'linking mini-test for page '.$pageNumber;
+                $quizItemId = (int) $legacyLearningPath->add_item(
+                    $rootItem,
+                    $previousItemId,
+                    TOOL_QUIZ,
+                    $quizId,
+                    $quizTitle,
+                );
+                if ($quizItemId <= 0) {
+                    throw new RuntimeException('A learning path mini-test item could not be added.');
+                }
+
+                $previousItemId = $quizItemId;
+                $this->markItem($quizItemId);
+
+                $createdPages[] = [
+                    'page_number' => $pageNumber,
+                    'title' => $pageTitle,
+                    'document_id' => $documentId,
+                    'document_item_id' => $documentItemId,
+                    'quiz_id' => $quizId,
+                    'quiz_item_id' => $quizItemId,
+                ];
+            }
+        } catch (Throwable $exception) {
+            $rollbackSucceeded = $this->rollbackCreatedResources(
+                $learningPathId,
+                $createdDocumentIds,
+                $createdQuizIds,
+                $createdQuestionIds,
+            );
+
+            $message = 'Learning path creation failed while '.$stage.': '.$exception->getMessage();
+            $message .= $rollbackSucceeded
+                ? ' All resources created by this operation were rolled back.'
+                : ' Automatic rollback could not be completed; review the course before retrying.';
+
+            throw new RuntimeException($message, 0, $exception);
+        }
+
+        $this->aiDisclosureHelper->markAiAssistedExtraField('lp', $learningPathId, true);
+        $this->aiDisclosureHelper->logAudit(
+            targetKey: 'lp:'.$learningPathId,
+            userId: (int) $user->getId(),
+            meta: [
+                'feature' => 'mcp_learning_path',
+                'mode' => 'generated',
+                'provider' => $providerUsed,
+                'topic' => $topic,
+                'page_count' => $pageCount,
+                'words_per_page' => $wordsPerPage,
+                'questions_per_quiz' => $questionsPerQuiz,
+                'published' => $publish,
+                'generation_mode' => $generated['_generation_mode'] ?? 'per_page_html',
+                'repaired_page_count' => $generated['_repaired_page_count'] ?? 0,
+            ],
+            courseId: (int) $course->getId(),
+            sessionId: 0,
+        );
+
+        return [
+            'learning_path_id' => $learningPathId,
+            'resource_node_id' => (int) $learningPath->getResourceNode()?->getId(),
+            'title' => $learningPath->getTitle(),
+            'page_count' => \count($createdPages),
+            'questions_per_quiz' => $questionsPerQuiz,
+            'published' => $publish,
+            'provider_used' => $providerUsed,
+            'ai_assisted' => true,
+            'generation_mode' => $generated['_generation_mode'] ?? 'per_page_html',
+            'repaired_page_count' => $generated['_repaired_page_count'] ?? 0,
+            'course_features_enabled' => $enabledFeatures,
+            'items' => $createdPages,
+            'content_url' => '/resources/lp/'
+                .(int) $courseNode->getId()
+                .'/'.$learningPathId
+                .'/builder?cid='.(int) $course->getId(),
+        ];
+    }
+
+    /**
+     * Generate exactly one page per controlled loop iteration. The provider
+     * never decides the array length, so the requested page count is
+     * deterministic even when structured JSON output is unreliable.
+     *
+     * @return array{
+     *     pages: list<array{title: string, content: string}>,
+     *     _provider: string,
+     *     _generation_mode: 'per_page_html',
+     *     _repaired_page_count: int
+     * }
+     */
+    private function generatePages(
+        Course $course,
+        User $user,
+        string $topic,
+        int $pageCount,
+        int $wordsPerPage,
+        ?string $provider,
+    ): array {
+        $pages = [];
+        $providerUsed = '';
+        $repairedPageCount = 0;
+        $previousTitles = [];
+
+        for ($pageNumber = 1; $pageNumber <= $pageCount; ++$pageNumber) {
+            $title = $this->buildPageTitle(
+                $topic,
+                $pageNumber,
+                $pageCount,
+            );
+            $focus = $this->buildPageFocus(
+                $pageNumber,
+                $pageCount,
+            );
+
+            $systemPrompt = <<<'PROMPT'
+Return only a valid HTML fragment for one educational page. Start with one <h1> using the exact supplied page title, followed by clear paragraphs and optional lists. Do not return JSON, Markdown fences, explanations, quizzes or metadata. The page must be self-contained, factual, non-repetitive and written in the requested language.
+PROMPT;
+            $userPrompt = 'Course: '.$course->getTitle()."\n"
+                .'Language: '.$course->getCourseLanguage()."\n"
+                .'Complete learning path topic: '.$topic."\n"
+                .'Current page: '.$pageNumber.' of '.$pageCount."\n"
+                .'Exact page title: '.$title."\n"
+                .'Page focus: '.$focus."\n"
+                .'Approximate words: '.$wordsPerPage."\n"
+                .'Previous page titles: '
+                .([] === $previousTitles ? 'none' : implode(' | ', $previousTitles));
+
+            $tokenBudget = min(
+                8_000,
+                max(900, 400 + ($wordsPerPage * 4)),
+            );
+
+            $result = $this->aiService->requestText(
+                $user,
+                $provider,
+                $systemPrompt,
+                $userPrompt,
+                $tokenBudget,
+            );
+            $providerUsed = (string) $result['provider'];
+            if ((bool) $result['repaired']) {
+                ++$repairedPageCount;
+            }
+
+            $pageContent = $this->normalizeGeneratedPageContent(
+                (string) $result['content'],
+                $title,
+            );
+
+            /*
+             * A short response is still usable, but request one controlled
+             * expansion before accepting it. This does not affect page count.
+             */
+            if ($this->countWords($pageContent) < max(40, (int) floor($wordsPerPage * 0.55))) {
+                $expanded = $this->aiService->requestText(
+                    $user,
+                    $providerUsed,
+                    $systemPrompt,
+                    $userPrompt
+                        ."\n\nExpand the page substantially. Preserve the exact title and "
+                        .'return approximately '.$wordsPerPage.' words.',
+                    $tokenBudget,
+                );
+                $pageContent = $this->normalizeGeneratedPageContent(
+                    (string) $expanded['content'],
+                    $title,
+                );
+
+                if ((bool) $expanded['repaired']) {
+                    ++$repairedPageCount;
+                }
+            }
+
+            $pages[] = [
+                'title' => $title,
+                'content' => $pageContent,
+            ];
+            $previousTitles[] = $title;
+        }
+
+        return [
+            'pages' => $pages,
+            '_provider' => $providerUsed,
+            '_generation_mode' => 'per_page_html',
+            '_repaired_page_count' => $repairedPageCount,
+        ];
+    }
+
+    private function buildPageTitle(
+        string $topic,
+        int $pageNumber,
+        int $pageCount,
+    ): string {
+        if (1 === $pageNumber) {
+            return mb_substr('Introduction to '.$topic, 0, 255);
+        }
+
+        if ($pageNumber === $pageCount) {
+            return mb_substr('Synthesis and application: '.$topic, 0, 255);
+        }
+
+        return mb_substr(
+            'Key concepts '.$pageNumber.': '.$topic,
+            0,
+            255,
+        );
+    }
+
+    private function buildPageFocus(
+        int $pageNumber,
+        int $pageCount,
+    ): string {
+        if (1 === $pageNumber) {
+            return 'Introduce the topic, its purpose, context and essential vocabulary.';
+        }
+
+        if ($pageNumber === $pageCount) {
+            return 'Integrate the previous ideas, explain applications and provide a concise conclusion.';
+        }
+
+        return 'Develop distinct mechanisms, components, relationships and examples without repeating previous pages.';
+    }
+
+    private function normalizeGeneratedPageContent(
+        string $content,
+        string $title,
+    ): string {
+        $content = trim((string) preg_replace(
+            '#<(script|style)\b[^>]*>.*?</\1>#is',
+            '',
+            $content,
+        ));
+        $content = (string) preg_replace('/^```(?:html)?\s*/iu', '', $content);
+        $content = (string) preg_replace('/\s*```$/u', '', $content);
+        $content = trim($content);
+
+        if ('' === trim(strip_tags($content))) {
+            throw new RuntimeException('The AI model returned an empty learning path page.');
+        }
+
+        if (!preg_match('/<h1\b/i', $content)) {
+            $content = '<h1>'.htmlspecialchars(
+                $title,
+                ENT_QUOTES | ENT_SUBSTITUTE,
+                'UTF-8',
+            ).'</h1>'.$content;
+        }
+
+        if (!preg_match('/<[^>]+>/', $content)) {
+            $paragraphs = preg_split('/\R{2,}/u', $content) ?: [$content];
+            $content = '<h1>'.htmlspecialchars(
+                $title,
+                ENT_QUOTES | ENT_SUBSTITUTE,
+                'UTF-8',
+            ).'</h1>';
+
+            foreach ($paragraphs as $paragraph) {
+                $paragraph = trim($paragraph);
+                if ('' === $paragraph) {
+                    continue;
+                }
+
+                $content .= '<p>'.htmlspecialchars(
+                    $paragraph,
+                    ENT_QUOTES | ENT_SUBSTITUTE,
+                    'UTF-8',
+                ).'</p>';
+            }
+        }
+
+        return mb_substr($content, 0, 2_000_000);
+    }
+
+    private function countWords(string $html): int
+    {
+        $text = trim((string) preg_replace('/\s+/u', ' ', strip_tags($html)));
+        if ('' === $text) {
+            return 0;
+        }
+
+        return preg_match_all('/[\p{L}\p{N}]+(?:[’\'-][\p{L}\p{N}]+)*/u', $text);
+    }
+
+    /**
+     * @param list<int> $documentIds
+     * @param list<int> $quizIds
+     * @param list<int> $questionIds
+     */
+    private function rollbackCreatedResources(
+        int $learningPathId,
+        array $documentIds,
+        array $quizIds,
+        array $questionIds,
+    ): bool {
+        try {
+            /*
+             * A failed flush can close or contaminate the request EntityManager.
+             * Use a reset manager for compensating cleanup, then reload every
+             * resource by ID before scheduling deletion.
+             */
+            $this->managerRegistry->resetManager();
+            $rollbackEntityManager = $this->managerRegistry->getManager();
+
+            if (!$rollbackEntityManager instanceof EntityManagerInterface) {
+                return false;
+            }
+
+            if ($learningPathId > 0) {
+                $learningPath = $rollbackEntityManager->find(CLp::class, $learningPathId);
+                if ($learningPath instanceof CLp) {
+                    $this->scheduleResourceRemoval($rollbackEntityManager, $learningPath);
+                }
+            }
+
+            foreach (array_reverse($quizIds) as $quizId) {
+                $quiz = $rollbackEntityManager->find(CQuiz::class, $quizId);
+                if ($quiz instanceof CQuiz) {
+                    $this->scheduleResourceRemoval($rollbackEntityManager, $quiz);
+                }
+            }
+
+            foreach (array_reverse($questionIds) as $questionId) {
+                $question = $rollbackEntityManager->find(CQuizQuestion::class, $questionId);
+                if ($question instanceof CQuizQuestion) {
+                    $this->scheduleResourceRemoval($rollbackEntityManager, $question);
+                }
+            }
+
+            foreach (array_reverse($documentIds) as $documentId) {
+                $document = $rollbackEntityManager->find(CDocument::class, $documentId);
+                if ($document instanceof CDocument) {
+                    $this->scheduleResourceRemoval($rollbackEntityManager, $document);
+                }
+            }
+
+            $rollbackEntityManager->flush();
+
+            return true;
+        } catch (Throwable $rollbackException) {
+            error_log(
+                '[MCP][learning_path] Rollback failed: '
+                .$rollbackException->getMessage()
+            );
+
+            return false;
+        }
+    }
+
+    private function scheduleResourceRemoval(
+        EntityManagerInterface $entityManager,
+        AbstractResource $resource,
+    ): void {
+        $resourceNode = $resource->getResourceNode();
+
+        $entityManager->remove($resource);
+        if ($resourceNode instanceof ResourceNode) {
+            $entityManager->remove($resourceNode);
+        }
+    }
+
+    private function resolveAvailableResourceLanguage(Course $course): ?string
+    {
+        $courseLanguage = trim($course->getCourseLanguage());
+        if ('' === $courseLanguage) {
+            return null;
+        }
+
+        $language = $this->entityManager->getRepository(Language::class)->findOneBy([
+            'isocode' => $courseLanguage,
+            'available' => true,
+        ]);
+
+        return $language instanceof Language
+            ? $language->getIsocode()
+            : null;
+    }
+
+    private function markItem(int $itemId): void
+    {
+        $this->aiDisclosureHelper->markAiAssistedExtraField('lp_item', $itemId, true);
+    }
+}

--- a/src/CoreBundle/Service/Mcp/McpApiKeyManager.php
+++ b/src/CoreBundle/Service/Mcp/McpApiKeyManager.php
@@ -1,0 +1,185 @@
+<?php
+
+/* For licensing terms, see /license.txt */
+
+declare(strict_types=1);
+
+namespace Chamilo\CoreBundle\Service\Mcp;
+
+use Chamilo\CoreBundle\Entity\AccessUrl;
+use Chamilo\CoreBundle\Entity\User;
+use Chamilo\CoreBundle\Entity\UserApiKey;
+use Chamilo\CoreBundle\Helpers\AccessUrlHelper;
+use Chamilo\CoreBundle\Helpers\UserHelper;
+use Chamilo\CoreBundle\Repository\Node\AccessUrlRepository;
+use Chamilo\CoreBundle\Repository\UserApiKeyRepository;
+use DateTime;
+use Doctrine\ORM\EntityManagerInterface;
+use RuntimeException;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\Security\Core\Exception\AccessDeniedException;
+
+final readonly class McpApiKeyManager
+{
+    public const KEY_PREFIX = 'chamilo_mcp_';
+    public const SERVICE = 'mcp';
+
+    public function __construct(
+        private UserHelper $userHelper,
+        private AccessUrlHelper $accessUrlHelper,
+        private AccessUrlRepository $accessUrlRepository,
+        private UserApiKeyRepository $apiKeyRepository,
+        private EntityManagerInterface $entityManager,
+        private RequestStack $requestStack,
+    ) {}
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function getCurrentMetadata(): array
+    {
+        [$user, $accessUrl] = $this->resolveCurrentContext();
+        $apiKey = $this->apiKeyRepository->findForUserAndAccessUrl(
+            (int) $user->getId(),
+            (int) $accessUrl->getId(),
+            self::SERVICE,
+        );
+
+        return $this->normalize($apiKey, $accessUrl);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function generateForCurrentUser(): array
+    {
+        [$user, $accessUrl] = $this->resolveCurrentContext();
+        $now = new DateTime();
+        $plainKey = self::KEY_PREFIX.$this->base64UrlEncode(random_bytes(32));
+        $hash = hash('sha256', $plainKey);
+        $visiblePrefix = mb_substr($plainKey, 0, 24);
+
+        $apiKey = $this->apiKeyRepository->findForUserAndAccessUrl(
+            (int) $user->getId(),
+            (int) $accessUrl->getId(),
+            self::SERVICE,
+        );
+
+        if (!$apiKey instanceof UserApiKey) {
+            $apiKey = (new UserApiKey())
+                ->setUserId((int) $user->getId())
+                ->setApiService(self::SERVICE)
+                ->setAccessUrlId((int) $accessUrl->getId())
+            ;
+            $this->entityManager->persist($apiKey);
+        }
+
+        $apiKey
+            ->setApiKey($hash)
+            ->setApiEndPoint($this->buildEndpoint($accessUrl))
+            ->setCreatedDate($now)
+            ->setValidityStartDate($now)
+            ->setValidityEndDate(null)
+            ->setDescription('Personal MCP API key')
+            ->setKeyPrefix($visiblePrefix)
+            ->setLastUsedAt(null)
+            ->setRevokedAt(null)
+        ;
+
+        $this->entityManager->flush();
+
+        $metadata = $this->normalize($apiKey, $accessUrl);
+        $metadata['plainKey'] = $plainKey;
+
+        return $metadata;
+    }
+
+    public function revokeForCurrentUser(): void
+    {
+        [$user, $accessUrl] = $this->resolveCurrentContext();
+        $apiKey = $this->apiKeyRepository->findForUserAndAccessUrl(
+            (int) $user->getId(),
+            (int) $accessUrl->getId(),
+            self::SERVICE,
+        );
+
+        if (!$apiKey instanceof UserApiKey || null !== $apiKey->getRevokedAt()) {
+            return;
+        }
+
+        $apiKey->setRevokedAt(new DateTime());
+        $this->entityManager->flush();
+    }
+
+    public static function isMcpKey(string $plainKey): bool
+    {
+        if (!str_starts_with($plainKey, self::KEY_PREFIX)) {
+            return false;
+        }
+
+        $secret = substr($plainKey, strlen(self::KEY_PREFIX));
+
+        return 1 === preg_match('/^[A-Za-z0-9_-]{43}$/', $secret);
+    }
+
+    private function buildEndpoint(AccessUrl $accessUrl): string
+    {
+        $request = $this->requestStack->getCurrentRequest();
+        if (null !== $request) {
+            return rtrim(
+                $request->getSchemeAndHttpHost().$request->getBaseUrl(),
+                '/',
+            ).'/mcp';
+        }
+
+        return rtrim($accessUrl->getUrl(), '/').'/mcp';
+    }
+
+    /**
+     * @return array{0: User, 1: AccessUrl}
+     */
+    private function resolveCurrentContext(): array
+    {
+        $user = $this->userHelper->getCurrent();
+        if (!$user instanceof User || null === $user->getId()) {
+            throw new AccessDeniedException('Authentication is required.');
+        }
+
+        $accessUrl = $this->accessUrlHelper->getCurrent();
+        if (!$accessUrl instanceof AccessUrl || null === $accessUrl->getId()) {
+            throw new RuntimeException('The current access URL could not be resolved.');
+        }
+
+        if (!$this->accessUrlRepository->isUrlActiveForUser($accessUrl, $user)) {
+            throw new AccessDeniedException('The authenticated user is not active on this access URL.');
+        }
+
+        return [$user, $accessUrl];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function normalize(?UserApiKey $apiKey, AccessUrl $accessUrl): array
+    {
+        $now = new DateTime();
+        $active = $apiKey instanceof UserApiKey && $apiKey->isActiveAt($now);
+        $prefix = $apiKey?->getKeyPrefix();
+
+        return [
+            'id' => 'current',
+            'active' => $active,
+            'maskedKey' => null !== $prefix && '' !== $prefix ? $prefix.'••••••••••••' : null,
+            'plainKey' => null,
+            'endpoint' => $this->buildEndpoint($accessUrl),
+            'createdAt' => $apiKey?->getCreatedDate()?->format(DATE_ATOM),
+            'lastUsedAt' => $apiKey?->getLastUsedAt()?->format(DATE_ATOM),
+            'revokedAt' => $apiKey?->getRevokedAt()?->format(DATE_ATOM),
+        ];
+    }
+
+    private function base64UrlEncode(string $raw): string
+    {
+        return rtrim(strtr(base64_encode($raw), '+/', '-_'), '=');
+    }
+}

--- a/src/CoreBundle/Service/Mcp/McpApiKeyManager.php
+++ b/src/CoreBundle/Service/Mcp/McpApiKeyManager.php
@@ -19,6 +19,8 @@ use RuntimeException;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\Security\Core\Exception\AccessDeniedException;
 
+use const DATE_ATOM;
+
 final readonly class McpApiKeyManager
 {
     public const KEY_PREFIX = 'chamilo_mcp_';
@@ -117,7 +119,7 @@ final readonly class McpApiKeyManager
             return false;
         }
 
-        $secret = substr($plainKey, strlen(self::KEY_PREFIX));
+        $secret = substr($plainKey, \strlen(self::KEY_PREFIX));
 
         return 1 === preg_match('/^[A-Za-z0-9_-]{43}$/', $secret);
     }

--- a/src/CoreBundle/Service/Mcp/McpCourseAiFeatureManager.php
+++ b/src/CoreBundle/Service/Mcp/McpCourseAiFeatureManager.php
@@ -1,0 +1,273 @@
+<?php
+
+/* For licensing terms, see /license.txt */
+
+declare(strict_types=1);
+
+namespace Chamilo\CoreBundle\Service\Mcp;
+
+use Chamilo\CoreBundle\Entity\Course;
+use Chamilo\CoreBundle\Entity\User;
+use Chamilo\CoreBundle\Helpers\AiDisclosureHelper;
+use Chamilo\CoreBundle\Helpers\AiFeatureAccessHelper;
+use Chamilo\CoreBundle\Settings\SettingsManager;
+use Chamilo\CourseBundle\Entity\CCourseSetting;
+use Chamilo\CourseBundle\Repository\CCourseSettingRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use InvalidArgumentException;
+use RuntimeException;
+
+final readonly class McpCourseAiFeatureManager
+{
+    private const CATEGORY = 'ai_helpers';
+
+    /**
+     * Titles verified against the current AI settings fixtures.
+     *
+     * @var array<string, string>
+     */
+    private const SUPPORTED_FEATURES = [
+        'learning_path_generator' => 'Learning paths generator',
+        'exercise_generator' => 'Exercise generator',
+        'image_generator' => 'Image generator',
+        'course_analyser' => 'Course analyser',
+    ];
+
+    public function __construct(
+        private SettingsManager $settingsManager,
+        private AiFeatureAccessHelper $aiFeatureAccessHelper,
+        private CCourseSettingRepository $courseSettingRepository,
+        private EntityManagerInterface $entityManager,
+        private AiDisclosureHelper $aiDisclosureHelper,
+    ) {}
+
+    /**
+     * @return list<string> Features changed from disabled/missing to enabled.
+     */
+    public function ensureEnabled(
+        Course $course,
+        User $user,
+        string $feature,
+        string $operation,
+    ): array {
+        return $this->ensureAllEnabled(
+            $course,
+            $user,
+            [$feature],
+            $operation,
+        );
+    }
+
+    /**
+     * Checks every platform-level permission before changing the course.
+     *
+     * @param list<string> $features
+     *
+     * @return list<string> Features changed from disabled/missing to enabled.
+     */
+    public function ensureAllEnabled(
+        Course $course,
+        User $user,
+        array $features,
+        string $operation,
+    ): array {
+        $courseId = (int) $course->getId();
+        $userId = (int) $user->getId();
+
+        if ($courseId <= 0) {
+            throw new InvalidArgumentException('The course ID must be a positive integer.');
+        }
+
+        if ($userId <= 0) {
+            throw new InvalidArgumentException('The authenticated user ID is invalid.');
+        }
+
+        $features = array_values(array_unique($features));
+        if ([] === $features) {
+            return [];
+        }
+
+        /*
+         * Complete preflight first. This is important for compound operations
+         * such as a learning path, which needs both page and test generation.
+         * No course setting is changed if any required global feature is off.
+         */
+        $this->assertGlobalAiHelpersEnabled();
+
+        foreach ($features as $feature) {
+            $this->assertSupportedFeature($feature);
+            $this->assertFeatureAllowedGlobally($feature, $courseId);
+        }
+
+        $enabledFeatures = [];
+
+        foreach ($features as $feature) {
+            if ($this->upsertEnabledCourseSetting($courseId, $feature)) {
+                $enabledFeatures[] = $feature;
+            }
+        }
+
+        $this->entityManager->flush();
+
+        if ([] !== $enabledFeatures) {
+            $this->aiDisclosureHelper->logAudit(
+                targetKey: 'course:'.$courseId.':mcp_ai_features',
+                userId: $userId,
+                meta: [
+                    'feature' => 'mcp_course_ai_feature_enablement',
+                    'operation' => $operation,
+                    'requested_features' => $features,
+                    'enabled_features' => $enabledFeatures,
+                ],
+                courseId: $courseId,
+                sessionId: 0,
+            );
+        }
+
+        return $enabledFeatures;
+    }
+
+    private function assertGlobalAiHelpersEnabled(): void
+    {
+        $value = $this->settingsManager->getSetting(
+            'ai_helpers.enable_ai_helpers',
+            true,
+        );
+
+        if (!$this->isTruthy($value)) {
+            throw new RuntimeException(
+                'AI helpers are disabled by the platform administrator.'
+            );
+        }
+    }
+
+    private function assertSupportedFeature(string $feature): void
+    {
+        if (!isset(self::SUPPORTED_FEATURES[$feature])) {
+            throw new InvalidArgumentException(
+                \sprintf('Unsupported MCP AI course feature "%s".', $feature)
+            );
+        }
+    }
+
+    private function assertFeatureAllowedGlobally(
+        string $feature,
+        int $courseId,
+    ): void {
+        $globalValue = $this->settingsManager->getSetting(
+            'ai_helpers.'.$feature,
+            true,
+        );
+
+        if (
+            !$this->isTruthy($globalValue)
+            || !$this->aiFeatureAccessHelper->isFeatureConfigurableForCourse(
+                $feature,
+                $courseId,
+            )
+        ) {
+            throw new RuntimeException(
+                \sprintf(
+                    'The AI feature "%s" is disabled by the platform administrator.',
+                    $feature,
+                )
+            );
+        }
+    }
+
+    /**
+     * Returns true only when the effective setting changed from disabled or
+     * missing to enabled.
+     */
+    private function upsertEnabledCourseSetting(
+        int $courseId,
+        string $feature,
+    ): bool {
+        /** @var CCourseSetting[] $allRows */
+        $allRows = $this->courseSettingRepository->findBy(
+            [
+                'cId' => $courseId,
+                'variable' => $feature,
+            ],
+            ['iid' => 'ASC'],
+        );
+
+        $rows = array_values(array_filter(
+            $allRows,
+            static fn (CCourseSetting $setting): bool => \in_array(
+                (string) $setting->getCategory(),
+                [self::CATEGORY, ''],
+                true,
+            ),
+        ));
+
+        if ([] === $rows) {
+            $setting = (new CCourseSetting())
+                ->setCId($courseId)
+                ->setVariable($feature)
+                ->setTitle(self::SUPPORTED_FEATURES[$feature])
+                ->setCategory(self::CATEGORY)
+                ->setValue('true')
+            ;
+
+            $this->entityManager->persist($setting);
+
+            return true;
+        }
+
+        $canonical = null;
+
+        foreach ($rows as $row) {
+            if (self::CATEGORY === (string) $row->getCategory()) {
+                $canonical = $row;
+
+                break;
+            }
+        }
+
+        if (!$canonical instanceof CCourseSetting) {
+            $canonical = $rows[0];
+        }
+
+        $wasEnabled = $this->isTruthy($canonical->getValue());
+
+        $canonical
+            ->setCategory(self::CATEGORY)
+            ->setTitle(self::SUPPORTED_FEATURES[$feature])
+            ->setValue('true')
+        ;
+
+        $this->entityManager->persist($canonical);
+
+        /*
+         * Remove semantic duplicates, matching the normalization strategy
+         * already used by SettingsManager course-setting propagation.
+         */
+        foreach ($rows as $row) {
+            if ($row === $canonical) {
+                continue;
+            }
+
+            $this->entityManager->remove($row);
+        }
+
+        return !$wasEnabled;
+    }
+
+    private function isTruthy(mixed $value): bool
+    {
+        if (true === $value || 1 === $value) {
+            return true;
+        }
+
+        if (!\is_string($value)) {
+            return false;
+        }
+
+        return \in_array(
+            strtolower(trim($value)),
+            ['1', 'true', 'yes', 'on'],
+            true,
+        );
+    }
+}

--- a/src/CoreBundle/Service/Mcp/McpCourseAiFeatureManager.php
+++ b/src/CoreBundle/Service/Mcp/McpCourseAiFeatureManager.php
@@ -42,7 +42,7 @@ final readonly class McpCourseAiFeatureManager
     ) {}
 
     /**
-     * @return list<string> Features changed from disabled/missing to enabled.
+     * @return list<string> features changed from disabled/missing to enabled
      */
     public function ensureEnabled(
         Course $course,
@@ -63,7 +63,7 @@ final readonly class McpCourseAiFeatureManager
      *
      * @param list<string> $features
      *
-     * @return list<string> Features changed from disabled/missing to enabled.
+     * @return list<string> features changed from disabled/missing to enabled
      */
     public function ensureAllEnabled(
         Course $course,
@@ -135,18 +135,14 @@ final readonly class McpCourseAiFeatureManager
         );
 
         if (!$this->isTruthy($value)) {
-            throw new RuntimeException(
-                'AI helpers are disabled by the platform administrator.'
-            );
+            throw new RuntimeException('AI helpers are disabled by the platform administrator.');
         }
     }
 
     private function assertSupportedFeature(string $feature): void
     {
         if (!isset(self::SUPPORTED_FEATURES[$feature])) {
-            throw new InvalidArgumentException(
-                \sprintf('Unsupported MCP AI course feature "%s".', $feature)
-            );
+            throw new InvalidArgumentException(\sprintf('Unsupported MCP AI course feature "%s".', $feature));
         }
     }
 
@@ -166,12 +162,7 @@ final readonly class McpCourseAiFeatureManager
                 $courseId,
             )
         ) {
-            throw new RuntimeException(
-                \sprintf(
-                    'The AI feature "%s" is disabled by the platform administrator.',
-                    $feature,
-                )
-            );
+            throw new RuntimeException(\sprintf('The AI feature "%s" is disabled by the platform administrator.', $feature));
         }
     }
 

--- a/src/CoreBundle/Service/Mcp/McpTeacherCourseContext.php
+++ b/src/CoreBundle/Service/Mcp/McpTeacherCourseContext.php
@@ -1,0 +1,62 @@
+<?php
+
+/* For licensing terms, see /license.txt */
+
+declare(strict_types=1);
+
+namespace Chamilo\CoreBundle\Service\Mcp;
+
+use Chamilo\CoreBundle\Entity\Course;
+use Chamilo\CoreBundle\Entity\User;
+use Chamilo\CoreBundle\Helpers\AccessUrlHelper;
+use Chamilo\CoreBundle\Repository\CourseRelUserRepository;
+use InvalidArgumentException;
+use RuntimeException;
+use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\Security\Core\Exception\AccessDeniedException;
+
+final readonly class McpTeacherCourseContext
+{
+    public function __construct(
+        private Security $security,
+        private AccessUrlHelper $accessUrlHelper,
+        private CourseRelUserRepository $courseRelUserRepository,
+    ) {}
+
+    /**
+     * @return array{course: Course, user: User}
+     */
+    public function resolve(int $courseId): array
+    {
+        if (0 >= $courseId) {
+            throw new InvalidArgumentException('The course ID must be a positive integer.');
+        }
+
+        $user = $this->security->getUser();
+        if (!$user instanceof User || null === $user->getId()) {
+            throw new AccessDeniedException('An authenticated Chamilo user is required.');
+        }
+
+        $accessUrl = $this->accessUrlHelper->getCurrent();
+        if (null === $accessUrl) {
+            throw new RuntimeException('The current Chamilo access URL could not be resolved.');
+        }
+
+        $course = $this->courseRelUserRepository->findTeacherCourseForUserAndAccessUrl(
+            $user,
+            $accessUrl,
+            $courseId,
+        );
+
+        if (!$course instanceof Course) {
+            throw new AccessDeniedException(
+                'The course was not found or is not managed by the authenticated teacher.'
+            );
+        }
+
+        return [
+            'course' => $course,
+            'user' => $user,
+        ];
+    }
+}

--- a/src/CoreBundle/Service/Mcp/McpTeacherCourseContext.php
+++ b/src/CoreBundle/Service/Mcp/McpTeacherCourseContext.php
@@ -28,7 +28,7 @@ final readonly class McpTeacherCourseContext
      */
     public function resolve(int $courseId): array
     {
-        if (0 >= $courseId) {
+        if ($courseId <= 0) {
             throw new InvalidArgumentException('The course ID must be a positive integer.');
         }
 
@@ -49,9 +49,7 @@ final readonly class McpTeacherCourseContext
         );
 
         if (!$course instanceof Course) {
-            throw new AccessDeniedException(
-                'The course was not found or is not managed by the authenticated teacher.'
-            );
+            throw new AccessDeniedException('The course was not found or is not managed by the authenticated teacher.');
         }
 
         return [

--- a/src/CoreBundle/Service/Mcp/McpTextAiService.php
+++ b/src/CoreBundle/Service/Mcp/McpTextAiService.php
@@ -1,0 +1,376 @@
+<?php
+
+/* For licensing terms, see /license.txt */
+
+declare(strict_types=1);
+
+namespace Chamilo\CoreBundle\Service\Mcp;
+
+use Chamilo\CoreBundle\AiProvider\AiChatCompletionClientInterface;
+use Chamilo\CoreBundle\AiProvider\AiProviderFactory;
+use Chamilo\CoreBundle\Entity\User;
+use Chamilo\CoreBundle\Service\Ai\AiRequestQuotaGuard;
+use InvalidArgumentException;
+use JsonException;
+use RuntimeException;
+
+use const JSON_THROW_ON_ERROR;
+
+final readonly class McpTextAiService
+{
+    private const MAX_JSON_RESPONSE_LENGTH = 120_000;
+    private const MAX_TEXT_RESPONSE_LENGTH = 2_000_000;
+    private const MAX_REPAIR_CONTEXT_LENGTH = 30_000;
+
+    public function __construct(
+        private AiProviderFactory $aiProviderFactory,
+        private AiChatCompletionClientInterface $chatCompletionClient,
+        private AiRequestQuotaGuard $quotaGuard,
+    ) {}
+
+    public function resolveProvider(User $user, ?string $requestedProvider = null): string
+    {
+        $providerNames = $this->getProviderNames();
+        if ([] === $providerNames) {
+            throw new RuntimeException('No AI text provider is configured.');
+        }
+
+        $requestedProvider = null !== $requestedProvider ? trim($requestedProvider) : '';
+        $providerName = '' === $requestedProvider ? $providerNames[0] : $requestedProvider;
+
+        if (!\in_array($providerName, $providerNames, true)) {
+            throw new InvalidArgumentException('The selected AI text provider is not available.');
+        }
+
+        $this->quotaGuard->assertCanRequest($user, $providerName, 'text');
+
+        return $providerName;
+    }
+
+    /**
+     * Request a JSON object and perform one controlled repair request when the
+     * provider returns prose, Markdown fences or truncated/invalid JSON.
+     *
+     * @return array<string, mixed>
+     */
+    public function requestJson(
+        User $user,
+        ?string $requestedProvider,
+        string $systemPrompt,
+        string $userPrompt,
+        int $maxTokens = 6000,
+    ): array {
+        $providerName = $this->resolveProvider($user, $requestedProvider);
+        $raw = $this->requestRawJson(
+            $providerName,
+            $systemPrompt,
+            $userPrompt,
+            $maxTokens,
+            0.1,
+        );
+
+        $repaired = false;
+
+        try {
+            $decoded = $this->decodeJson($raw);
+        } catch (RuntimeException $firstException) {
+            $repaired = true;
+            $repairSystemPrompt = <<<'PROMPT'
+Return only one valid JSON value. Repair the supplied response so it follows the original schema and instructions exactly. Preserve valid content, complete truncated arrays or strings when necessary, remove prose and Markdown, and do not add explanations outside the JSON.
+PROMPT;
+            $repairUserPrompt = "Original schema and instructions:\n"
+                .mb_substr($systemPrompt, 0, self::MAX_REPAIR_CONTEXT_LENGTH)
+                ."\n\nOriginal request:\n"
+                .mb_substr($userPrompt, 0, self::MAX_REPAIR_CONTEXT_LENGTH)
+                ."\n\nInvalid response to repair:\n"
+                .mb_substr($raw, 0, self::MAX_REPAIR_CONTEXT_LENGTH);
+
+            $repairedRaw = $this->requestRawJson(
+                $providerName,
+                $repairSystemPrompt,
+                $repairUserPrompt,
+                $maxTokens,
+                0.0,
+            );
+
+            try {
+                $decoded = $this->decodeJson($repairedRaw);
+            } catch (RuntimeException $repairException) {
+                throw new RuntimeException(
+                    'The AI model returned invalid JSON after one repair attempt.',
+                    0,
+                    $repairException,
+                );
+            }
+        }
+
+        $decoded['_provider'] = $providerName;
+        $decoded['_structured_output_repaired'] = $repaired;
+
+        return $decoded;
+    }
+
+    /**
+     * Request plain text or HTML and perform one controlled retry when the
+     * provider returns an empty response, an error wrapper or only Markdown
+     * fences.
+     *
+     * @return array{
+     *     content: string,
+     *     provider: string,
+     *     repaired: bool
+     * }
+     */
+    public function requestText(
+        User $user,
+        ?string $requestedProvider,
+        string $systemPrompt,
+        string $userPrompt,
+        int $maxTokens = 6000,
+    ): array {
+        $providerName = $this->resolveProvider($user, $requestedProvider);
+        $content = $this->requestRawText(
+            $providerName,
+            $systemPrompt,
+            $userPrompt,
+            $maxTokens,
+            0.25,
+        );
+
+        $repaired = false;
+
+        if (!$this->isUsableText($content)) {
+            $repaired = true;
+            $content = $this->requestRawText(
+                $providerName,
+                <<<'PROMPT'
+Return only the requested final educational content. Do not include explanations, apologies, Markdown code fences or JSON. Complete the original request directly.
+PROMPT,
+                "Original instructions:\n"
+                    .mb_substr($systemPrompt, 0, self::MAX_REPAIR_CONTEXT_LENGTH)
+                    ."\n\nOriginal request:\n"
+                    .mb_substr($userPrompt, 0, self::MAX_REPAIR_CONTEXT_LENGTH),
+                $maxTokens,
+                0.1,
+            );
+        }
+
+        $content = $this->normalizeTextResponse($content);
+        if (!$this->isUsableText($content)) {
+            throw new RuntimeException(
+                'The AI model did not return usable educational content after one retry.'
+            );
+        }
+
+        return [
+            'content' => $content,
+            'provider' => $providerName,
+            'repaired' => $repaired,
+        ];
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function getProviderNames(): array
+    {
+        return array_values(array_filter(array_map(
+            static fn (mixed $providerName): string => trim((string) $providerName),
+            $this->aiProviderFactory->getProvidersForType('text'),
+        )));
+    }
+
+    private function requestRawJson(
+        string $providerName,
+        string $systemPrompt,
+        string $userPrompt,
+        int $maxTokens,
+        float $temperature,
+    ): string {
+        $raw = $this->chatCompletionClient->chat(
+            $providerName,
+            [
+                ['role' => 'system', 'content' => $systemPrompt],
+                ['role' => 'user', 'content' => $userPrompt],
+            ],
+            [
+                'temperature' => $temperature,
+                'max_output_tokens' => $maxTokens,
+                'max_tokens' => $maxTokens,
+                'response_mime_type' => 'application/json',
+                'throw_on_error' => true,
+            ],
+        );
+
+        $raw = trim(mb_substr($raw, 0, self::MAX_JSON_RESPONSE_LENGTH));
+        if ('' === $raw || str_starts_with($raw, 'Error:')) {
+            throw new RuntimeException('The AI model returned an empty or invalid structured response.');
+        }
+
+        return $raw;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function decodeJson(string $raw): array
+    {
+        $raw = $this->normalizeRawJson($raw);
+
+        $decoded = $this->tryDecode($raw);
+        if (null !== $decoded) {
+            return $decoded;
+        }
+
+        $length = strlen($raw);
+        for ($offset = 0; $offset < $length; ++$offset) {
+            $char = $raw[$offset];
+            if ('{' !== $char && '[' !== $char) {
+                continue;
+            }
+
+            $candidate = $this->extractBalancedJson($raw, $offset);
+            if (null === $candidate) {
+                continue;
+            }
+
+            $decoded = $this->tryDecode($candidate);
+            if (null !== $decoded) {
+                return $decoded;
+            }
+        }
+
+        throw new RuntimeException('The AI model returned invalid JSON.');
+    }
+
+    private function normalizeRawJson(string $raw): string
+    {
+        $raw = preg_replace('/^\xEF\xBB\xBF/', '', trim($raw)) ?? trim($raw);
+        $raw = (string) preg_replace('/^```(?:json)?\s*/iu', '', $raw);
+        $raw = (string) preg_replace('/\s*```$/u', '', $raw);
+
+        return trim($raw);
+    }
+
+    private function requestRawText(
+        string $providerName,
+        string $systemPrompt,
+        string $userPrompt,
+        int $maxTokens,
+        float $temperature,
+    ): string {
+        $raw = $this->chatCompletionClient->chat(
+            $providerName,
+            [
+                ['role' => 'system', 'content' => $systemPrompt],
+                ['role' => 'user', 'content' => $userPrompt],
+            ],
+            [
+                'temperature' => $temperature,
+                'max_output_tokens' => $maxTokens,
+                'max_tokens' => $maxTokens,
+                'throw_on_error' => true,
+            ],
+        );
+
+        return trim(mb_substr($raw, 0, self::MAX_TEXT_RESPONSE_LENGTH));
+    }
+
+    private function normalizeTextResponse(string $content): string
+    {
+        $content = preg_replace('/^\xEF\xBB\xBF/', '', trim($content)) ?? trim($content);
+        $content = (string) preg_replace('/^```(?:html|text|markdown)?\s*/iu', '', $content);
+        $content = (string) preg_replace('/\s*```$/u', '', $content);
+
+        return trim($content);
+    }
+
+    private function isUsableText(string $content): bool
+    {
+        $content = $this->normalizeTextResponse($content);
+        if ('' === $content || str_starts_with($content, 'Error:')) {
+            return false;
+        }
+
+        return mb_strlen(trim(strip_tags($content))) >= 40;
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    private function tryDecode(string $candidate): ?array
+    {
+        try {
+            $decoded = json_decode($candidate, true, 512, JSON_THROW_ON_ERROR);
+        } catch (JsonException) {
+            return null;
+        }
+
+        return \is_array($decoded) ? $decoded : null;
+    }
+
+    private function extractBalancedJson(string $raw, int $start): ?string
+    {
+        $opening = $raw[$start] ?? '';
+        if (!\in_array($opening, ['{', '['], true)) {
+            return null;
+        }
+
+        $stack = [];
+        $inString = false;
+        $escaped = false;
+        $length = strlen($raw);
+
+        for ($index = $start; $index < $length; ++$index) {
+            $char = $raw[$index];
+
+            if ($inString) {
+                if ($escaped) {
+                    $escaped = false;
+
+                    continue;
+                }
+
+                if ('\\' === $char) {
+                    $escaped = true;
+
+                    continue;
+                }
+
+                if ('"' === $char) {
+                    $inString = false;
+                }
+
+                continue;
+            }
+
+            if ('"' === $char) {
+                $inString = true;
+
+                continue;
+            }
+
+            if ('{' === $char || '[' === $char) {
+                $stack[] = $char;
+
+                continue;
+            }
+
+            if ('}' !== $char && ']' !== $char) {
+                continue;
+            }
+
+            $expectedOpening = '}' === $char ? '{' : '[';
+            $actualOpening = array_pop($stack);
+            if ($actualOpening !== $expectedOpening) {
+                return null;
+            }
+
+            if ([] === $stack) {
+                return substr($raw, $start, $index - $start + 1);
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/CoreBundle/Service/Mcp/McpTextAiService.php
+++ b/src/CoreBundle/Service/Mcp/McpTextAiService.php
@@ -96,11 +96,7 @@ PROMPT;
             try {
                 $decoded = $this->decodeJson($repairedRaw);
             } catch (RuntimeException $repairException) {
-                throw new RuntimeException(
-                    'The AI model returned invalid JSON after one repair attempt.',
-                    0,
-                    $repairException,
-                );
+                throw new RuntimeException('The AI model returned invalid JSON after one repair attempt.', 0, $repairException);
             }
         }
 
@@ -157,9 +153,7 @@ PROMPT,
 
         $content = $this->normalizeTextResponse($content);
         if (!$this->isUsableText($content)) {
-            throw new RuntimeException(
-                'The AI model did not return usable educational content after one retry.'
-            );
+            throw new RuntimeException('The AI model did not return usable educational content after one retry.');
         }
 
         return [
@@ -222,7 +216,7 @@ PROMPT,
             return $decoded;
         }
 
-        $length = strlen($raw);
+        $length = \strlen($raw);
         for ($offset = 0; $offset < $length; ++$offset) {
             $char = $raw[$offset];
             if ('{' !== $char && '[' !== $char) {
@@ -319,7 +313,7 @@ PROMPT,
         $stack = [];
         $inString = false;
         $escaped = false;
-        $length = strlen($raw);
+        $length = \strlen($raw);
 
         for ($index = $start; $index < $length; ++$index) {
             $char = $raw[$index];

--- a/src/CoreBundle/Service/Survey/TrainingSatisfactionSurveyCreator.php
+++ b/src/CoreBundle/Service/Survey/TrainingSatisfactionSurveyCreator.php
@@ -1,0 +1,397 @@
+<?php
+
+/* For licensing terms, see /license.txt */
+
+declare(strict_types=1);
+
+namespace Chamilo\CoreBundle\Service\Survey;
+
+use Chamilo\CoreBundle\Entity\Course;
+use Chamilo\CoreBundle\Entity\ResourceLink;
+use Chamilo\CoreBundle\Entity\User;
+use Chamilo\CoreBundle\Helpers\AiDisclosureHelper;
+use Chamilo\CoreBundle\Service\Mcp\McpTextAiService;
+use Chamilo\CoreBundle\Settings\SettingsManager;
+use Chamilo\CourseBundle\Entity\CSurvey;
+use Chamilo\CourseBundle\Entity\CSurveyQuestion;
+use Chamilo\CourseBundle\Entity\CSurveyQuestionOption;
+use Chamilo\CourseBundle\Repository\CSurveyRepository;
+use DateInterval;
+use DateTime;
+use Doctrine\ORM\EntityManagerInterface;
+use InvalidArgumentException;
+use RuntimeException;
+
+final readonly class TrainingSatisfactionSurveyCreator
+{
+    public function __construct(
+        private CSurveyRepository $surveyRepository,
+        private EntityManagerInterface $entityManager,
+        private McpTextAiService $aiService,
+        private AiDisclosureHelper $aiDisclosureHelper,
+        private SettingsManager $settingsManager,
+    ) {}
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function create(
+        Course $course,
+        User $user,
+        string $title,
+        ?string $language,
+        ?string $provider,
+        bool $publish,
+        bool $anonymous,
+    ): array {
+        if ($this->isSurveyCreationDisabled()) {
+            throw new RuntimeException('Survey creation is disabled by the platform configuration.');
+        }
+
+        $title = trim(strip_tags($title));
+        if ('' === $title) {
+            throw new InvalidArgumentException('The survey title is required.');
+        }
+        if (255 < mb_strlen($title)) {
+            throw new InvalidArgumentException('The survey title cannot be longer than 255 characters.');
+        }
+
+        $language = $this->normalizeLanguage($language, $course->getCourseLanguage());
+        $questionSet = $this->buildQuestionSet($user, $title, $language, $provider);
+        $providerUsed = $questionSet['_provider'] ?? null;
+        unset($questionSet['_provider']);
+
+        $visibility = $publish
+            ? ResourceLink::VISIBILITY_PUBLISHED
+            : ResourceLink::VISIBILITY_DRAFT;
+
+        $availableFrom = new DateTime();
+        $availableUntil = (clone $availableFrom)->add(new DateInterval('P1Y'));
+
+        $survey = (new CSurvey())
+            ->setCode($this->generateCode((int) $course->getId()))
+            ->setTitle($title)
+            ->setSubtitle('')
+            ->setLang($language)
+            ->setAvailFrom($availableFrom)
+            ->setAvailTill($availableUntil)
+            ->setIsShared('0')
+            ->setTemplate('template')
+            ->setIntro((string) $questionSet['introduction'])
+            ->setSurveythanks((string) $questionSet['thanks'])
+            ->setAnonymous($anonymous ? '1' : '0')
+            ->setVisibleResults(0)
+            ->setDisplayQuestionNumber(true)
+            ->setOneQuestionPerPage(false)
+            ->setShuffle(false)
+            ->setDuration(null)
+            ->setSurveyType(0)
+            ->setShowFormProfile(0)
+            ->setFormFields('')
+            ->setParent($course)
+            ->addCourseLink($course, null, null, $visibility)
+        ;
+
+        $this->surveyRepository->create($survey);
+        $surveyId = (int) $survey->getIid();
+
+        $createdQuestions = [];
+        foreach ($questionSet['questions'] as $index => $definition) {
+            $question = (new CSurveyQuestion())
+                ->setSurvey($survey)
+                ->setSurveyQuestion((string) $definition['text'])
+                ->setSurveyQuestionComment('')
+                ->setType((string) $definition['type'])
+                ->setDisplay('vertical')
+                ->setSort($index + 1)
+                ->setSharedQuestionId(0)
+                ->setMaxValue(0)
+                ->setIsMandatory((bool) $definition['required'])
+            ;
+
+            $this->entityManager->persist($question);
+            $this->entityManager->flush();
+
+            $options = [];
+            foreach ($definition['options'] as $optionIndex => $optionText) {
+                $option = (new CSurveyQuestionOption())
+                    ->setSurvey($survey)
+                    ->setQuestion($question)
+                    ->setOptionText((string) $optionText)
+                    ->setSort($optionIndex + 1)
+                    ->setValue($optionIndex + 1)
+                ;
+                $this->entityManager->persist($option);
+                $options[] = (string) $optionText;
+            }
+
+            $createdQuestions[] = [
+                'question_id' => (int) $question->getIid(),
+                'text' => $question->getSurveyQuestion(),
+                'type' => $question->getType(),
+                'required' => $question->isMandatory(),
+                'options' => $options,
+            ];
+        }
+
+        $this->entityManager->flush();
+
+        if (null !== $providerUsed) {
+            $this->aiDisclosureHelper->logAudit(
+                targetKey: 'survey:'.$surveyId,
+                userId: (int) $user->getId(),
+                meta: [
+                    'feature' => 'mcp_training_satisfaction_survey',
+                    'provider' => $providerUsed,
+                    'question_count' => \count($createdQuestions),
+                    'anonymous' => $anonymous,
+                    'published' => $publish,
+                ],
+                courseId: (int) $course->getId(),
+                sessionId: 0,
+            );
+        }
+
+        return [
+            'survey_id' => $surveyId,
+            'resource_node_id' => (int) $survey->getResourceNode()?->getId(),
+            'title' => $survey->getTitle(),
+            'language' => $language,
+            'anonymous' => $anonymous,
+            'published' => $publish,
+            'question_count' => \count($createdQuestions),
+            'provider_used' => $providerUsed,
+            'ai_assisted' => null !== $providerUsed,
+            'questions' => $createdQuestions,
+            'content_url' => '/resources/survey/'
+                .(int) $course->getResourceNode()?->getId()
+                .'/'.$surveyId
+                .'/questions?cid='.(int) $course->getId(),
+        ];
+    }
+
+    private function isSurveyCreationDisabled(): bool
+    {
+        $value = $this->settingsManager->getSetting('survey.hide_survey_edition', true);
+
+        return true === $value || 'true' === $value || '*' === $value;
+    }
+
+    private function normalizeLanguage(?string $language, string $courseLanguage): string
+    {
+        $language = null !== $language ? trim($language) : '';
+        if ('' === $language) {
+            $language = trim($courseLanguage);
+        }
+        if ('' === $language) {
+            $language = 'en';
+        }
+
+        if (!preg_match('/^[a-zA-Z0-9_-]{1,20}$/', $language)) {
+            throw new InvalidArgumentException('The survey language code is invalid.');
+        }
+
+        return $language;
+    }
+
+    private function generateCode(int $courseId): string
+    {
+        return mb_substr(
+            'mcp-sat-'.$courseId.'-'.date('YmdHis').'-'.bin2hex(random_bytes(2)),
+            0,
+            40,
+        );
+    }
+
+    /**
+     * @return array{
+     *     introduction: string,
+     *     thanks: string,
+     *     questions: list<array{
+     *         text: string,
+     *         type: 'multiplechoice'|'yesno'|'open',
+     *         required: bool,
+     *         options: list<string>
+     *     }>,
+     *     _provider?: string
+     * }
+     */
+    private function buildQuestionSet(
+        User $user,
+        string $title,
+        string $language,
+        ?string $provider,
+    ): array {
+        $provider = null !== $provider ? trim($provider) : '';
+        if ('' === $provider) {
+            return $this->fallbackQuestions($language);
+        }
+
+        $result = $this->aiService->requestJson(
+            $user,
+            $provider,
+            <<<'PROMPT'
+Return JSON only using this schema:
+{
+  "introduction": "short survey introduction",
+  "thanks": "short thank-you message",
+  "questions": [
+    {"text":"...", "type":"multiplechoice", "required":true, "options":["...", "...", "...", "...", "..."]},
+    {"text":"...", "type":"yesno", "required":true, "options":["Yes", "No"]},
+    {"text":"...", "type":"open", "required":false, "options":[]}
+  ]
+}
+Create exactly seven training-satisfaction questions: five five-option satisfaction questions, one recommendation yes/no question, and one open comments question. Write everything in the requested language.
+PROMPT,
+            'Survey title: '.$title."\nLanguage: ".$language,
+            2500,
+        );
+
+        $normalized = $this->normalizeGeneratedQuestions($result);
+        $normalized['_provider'] = (string) $result['_provider'];
+
+        return $normalized;
+    }
+
+    /**
+     * @param array<string, mixed> $result
+     *
+     * @return array{
+     *     introduction: string,
+     *     thanks: string,
+     *     questions: list<array{
+     *         text: string,
+     *         type: 'multiplechoice'|'yesno'|'open',
+     *         required: bool,
+     *         options: list<string>
+     *     }>
+     * }
+     */
+    private function normalizeGeneratedQuestions(array $result): array
+    {
+        $questions = $result['questions'] ?? null;
+        if (!\is_array($questions) || 7 !== \count($questions)) {
+            throw new RuntimeException('The AI model returned an invalid satisfaction survey.');
+        }
+
+        $normalized = [];
+        foreach ($questions as $question) {
+            if (!\is_array($question)) {
+                throw new RuntimeException('The AI model returned an invalid survey question.');
+            }
+
+            $type = (string) ($question['type'] ?? '');
+            if (!\in_array($type, ['multiplechoice', 'yesno', 'open'], true)) {
+                throw new RuntimeException('The AI model returned an unsupported survey question type.');
+            }
+
+            $text = trim(strip_tags((string) ($question['text'] ?? '')));
+            $options = \is_array($question['options'] ?? null)
+                ? array_values(array_filter(array_map(
+                    static fn (mixed $option): string => trim(strip_tags((string) $option)),
+                    $question['options'],
+                )))
+                : [];
+
+            if ('' === $text) {
+                throw new RuntimeException('The AI model returned an empty survey question.');
+            }
+            if ('multiplechoice' === $type && 5 !== \count($options)) {
+                throw new RuntimeException('A satisfaction question must contain five options.');
+            }
+            if ('yesno' === $type && 2 !== \count($options)) {
+                throw new RuntimeException('The recommendation question must contain two options.');
+            }
+            if ('open' === $type) {
+                $options = [];
+            }
+
+            $normalized[] = [
+                'text' => mb_substr($text, 0, 2000),
+                'type' => $type,
+                'required' => (bool) ($question['required'] ?? false),
+                'options' => $options,
+            ];
+        }
+
+        return [
+            'introduction' => mb_substr(trim(strip_tags((string) ($result['introduction'] ?? ''))), 0, 4000),
+            'thanks' => mb_substr(trim(strip_tags((string) ($result['thanks'] ?? ''))), 0, 4000),
+            'questions' => $normalized,
+        ];
+    }
+
+    /**
+     * @return array{
+     *     introduction: string,
+     *     thanks: string,
+     *     questions: list<array{
+     *         text: string,
+     *         type: 'multiplechoice'|'yesno'|'open',
+     *         required: bool,
+     *         options: list<string>
+     *     }>
+     * }
+     */
+    private function fallbackQuestions(string $language): array
+    {
+        $spanish = str_starts_with(strtolower($language), 'es');
+
+        $scale = $spanish
+            ? ['Muy satisfecho', 'Satisfecho', 'Neutral', 'Insatisfecho', 'Muy insatisfecho']
+            : ['Very satisfied', 'Satisfied', 'Neutral', 'Dissatisfied', 'Very dissatisfied'];
+
+        $texts = $spanish
+            ? [
+                '¿Qué tan satisfecho está con la calidad general de la formación?',
+                '¿Qué tan satisfecho está con la relevancia de los contenidos?',
+                '¿Qué tan satisfecho está con la claridad de las explicaciones?',
+                '¿Qué tan satisfecho está con la organización y el ritmo de la formación?',
+                '¿Qué tan satisfecho está con la utilidad práctica de lo aprendido?',
+            ]
+            : [
+                'How satisfied are you with the overall quality of the training?',
+                'How satisfied are you with the relevance of the content?',
+                'How satisfied are you with the clarity of the explanations?',
+                'How satisfied are you with the organization and pace of the training?',
+                'How satisfied are you with the practical usefulness of what you learned?',
+            ];
+
+        $questions = [];
+        foreach ($texts as $text) {
+            $questions[] = [
+                'text' => $text,
+                'type' => 'multiplechoice',
+                'required' => true,
+                'options' => $scale,
+            ];
+        }
+
+        $questions[] = [
+            'text' => $spanish
+                ? '¿Recomendaría esta formación a otras personas?'
+                : 'Would you recommend this training to other people?',
+            'type' => 'yesno',
+            'required' => true,
+            'options' => $spanish ? ['Sí', 'No'] : ['Yes', 'No'],
+        ];
+        $questions[] = [
+            'text' => $spanish
+                ? '¿Qué deberíamos mejorar en futuras ediciones?'
+                : 'What should we improve in future editions?',
+            'type' => 'open',
+            'required' => false,
+            'options' => [],
+        ];
+
+        return [
+            'introduction' => $spanish
+                ? 'Su opinión nos ayudará a mejorar futuras formaciones.'
+                : 'Your feedback will help us improve future training sessions.',
+            'thanks' => $spanish
+                ? 'Gracias por compartir su opinión.'
+                : 'Thank you for sharing your feedback.',
+            'questions' => $questions,
+        ];
+    }
+}

--- a/src/CoreBundle/Service/Survey/TrainingSatisfactionSurveyCreator.php
+++ b/src/CoreBundle/Service/Survey/TrainingSatisfactionSurveyCreator.php
@@ -52,7 +52,7 @@ final readonly class TrainingSatisfactionSurveyCreator
         if ('' === $title) {
             throw new InvalidArgumentException('The survey title is required.');
         }
-        if (255 < mb_strlen($title)) {
+        if (mb_strlen($title) > 255) {
             throw new InvalidArgumentException('The survey title cannot be longer than 255 characters.');
         }
 

--- a/src/CoreBundle/State/Mcp/McpApiKeyProcessor.php
+++ b/src/CoreBundle/State/Mcp/McpApiKeyProcessor.php
@@ -1,0 +1,40 @@
+<?php
+
+/* For licensing terms, see /license.txt */
+
+declare(strict_types=1);
+
+namespace Chamilo\CoreBundle\State\Mcp;
+
+use ApiPlatform\Metadata\Delete;
+use ApiPlatform\Metadata\Operation;
+use ApiPlatform\Metadata\Post;
+use ApiPlatform\State\ProcessorInterface;
+use Chamilo\CoreBundle\ApiResource\Mcp\McpApiKey;
+use Chamilo\CoreBundle\Service\Mcp\McpApiKeyManager;
+use LogicException;
+
+/**
+ * @implements ProcessorInterface<mixed, McpApiKey|null>
+ */
+final readonly class McpApiKeyProcessor implements ProcessorInterface
+{
+    public function __construct(
+        private McpApiKeyManager $apiKeyManager,
+    ) {}
+
+    public function process(mixed $data, Operation $operation, array $uriVariables = [], array $context = []): ?McpApiKey
+    {
+        if ($operation instanceof Post) {
+            return McpApiKey::fromArray($this->apiKeyManager->generateForCurrentUser());
+        }
+
+        if ($operation instanceof Delete) {
+            $this->apiKeyManager->revokeForCurrentUser();
+
+            return null;
+        }
+
+        throw new LogicException('Unsupported MCP API key operation.');
+    }
+}

--- a/src/CoreBundle/State/Mcp/McpApiKeyProvider.php
+++ b/src/CoreBundle/State/Mcp/McpApiKeyProvider.php
@@ -1,0 +1,27 @@
+<?php
+
+/* For licensing terms, see /license.txt */
+
+declare(strict_types=1);
+
+namespace Chamilo\CoreBundle\State\Mcp;
+
+use ApiPlatform\Metadata\Operation;
+use ApiPlatform\State\ProviderInterface;
+use Chamilo\CoreBundle\ApiResource\Mcp\McpApiKey;
+use Chamilo\CoreBundle\Service\Mcp\McpApiKeyManager;
+
+/**
+ * @implements ProviderInterface<McpApiKey>
+ */
+final readonly class McpApiKeyProvider implements ProviderInterface
+{
+    public function __construct(
+        private McpApiKeyManager $apiKeyManager,
+    ) {}
+
+    public function provide(Operation $operation, array $uriVariables = [], array $context = []): McpApiKey
+    {
+        return McpApiKey::fromArray($this->apiKeyManager->getCurrentMetadata());
+    }
+}

--- a/symfony.lock
+++ b/symfony.lock
@@ -158,6 +158,18 @@
             "ref": "3ae1b83985e89138f5443bbc2d9b8c074b497d49"
         }
     },
+    "php-http/discovery": {
+        "version": "1.20",
+        "recipe": {
+            "repo": "github.com/symfony/recipes",
+            "branch": "main",
+            "version": "1.18",
+            "ref": "f45b5dd173a27873ab19f5e3180b2f661c21de02"
+        },
+        "files": [
+            "config/packages/http_discovery.yaml"
+        ]
+    },
     "phpstan/phpstan": {
         "version": "1.12",
         "recipe": {
@@ -353,6 +365,9 @@
             "version": "1.0",
             "ref": "fadbfe33303a76e25cb63401050439aa9b1a9c7f"
         }
+    },
+    "symfony/mcp-bundle": {
+        "version": "v0.12.0"
     },
     "symfony/messenger": {
         "version": "6.4",


### PR DESCRIPTION
## Summary

- Add personal MCP API key management and bearer authentication.
- Add MCP tools for course creation and AI-assisted course resources.
- Add document illustration, tests, learning paths with mini-tests, assignments and surveys.
- Add test response status, individual score, forum activity and course-quality review tools.
- Normalize course languages to available Chamilo ISO codes.
- Include draft resources and real course content in teacher course reviews.
- Preserve course permissions, Access URL scope and resource visibility.

## Validation

- MCP connection validated with Claude Code.
- Course, documents, illustrations, tests, learning path, assignment and survey created successfully.
- Course language normalized to `es`.
- Draft resources included in course review.
- Learning-path documents and mini-tests resolved through legacy resource references.
- PHP syntax, ECS, Symfony container, YAML and Vue build validated.