### PR TITLE
Security: Reflected XSS via access_url_id/add_type attribute breakout in access_url edit admin pages

### DIFF
--- a/public/main/admin/access_url_edit_course_category_to_url.php
+++ b/public/main/admin/access_url_edit_course_category_to_url.php
@@ -33,7 +33,7 @@ $interbreadcrumb[] = ['url' => 'access_urls.php', 'name' => get_lang('Multiple a
 
 $add_type = 'multiple';
 if (isset($_REQUEST['add_type']) && '' != $_REQUEST['add_type']) {
-    $add_type = Security::remove_XSS($_REQUEST['add_type']);
+    $add_type = 'unique' === $_REQUEST['add_type'] ? 'unique' : 'multiple';
 }
 
 $access_url_id = 1;

--- a/public/main/admin/access_url_edit_courses_to_url.php
+++ b/public/main/admin/access_url_edit_courses_to_url.php
@@ -67,12 +67,12 @@ $interbreadcrumb[] = ['url' => 'access_urls.php', 'name' => get_lang('Multiple a
 
 $add_type = 'multiple';
 if (isset($_REQUEST['add_type']) && '' != $_REQUEST['add_type']) {
-    $add_type = Security::remove_XSS($_REQUEST['add_type']);
+    $add_type = 'unique' === $_REQUEST['add_type'] ? 'unique' : 'multiple';
 }
 
 $access_url_id = 1;
 if (isset($_REQUEST['access_url_id']) && '' != $_REQUEST['access_url_id']) {
-    $access_url_id = Security::remove_XSS($_REQUEST['access_url_id']);
+    $access_url_id = (int) $_REQUEST['access_url_id'];
 }
 
 $xajax->processRequests();

--- a/public/main/admin/access_url_edit_usergroup_to_url.php
+++ b/public/main/admin/access_url_edit_usergroup_to_url.php
@@ -25,8 +25,8 @@ $tool_name = get_lang('Edit groups for one URL');
 $interbreadcrumb[] = ['url' => 'index.php', 'name' => get_lang('Administration')];
 $interbreadcrumb[] = ['url' => 'access_urls.php', 'name' => get_lang('Multiple access URL / Branding')];
 
-$add_type = $_REQUEST['add_type'] ?? 'multiple';
-$access_url_id = $_REQUEST['access_url_id'] ?? 1;
+$add_type = 'unique' === ($_REQUEST['add_type'] ?? '') ? 'unique' : 'multiple';
+$access_url_id = (int) ($_REQUEST['access_url_id'] ?? 1);
 
 $userGroup = new UserGroupModel();
 

--- a/public/main/admin/access_url_edit_users_to_url.php
+++ b/public/main/admin/access_url_edit_users_to_url.php
@@ -36,7 +36,7 @@ $interbreadcrumb[] = ['url' => 'access_urls.php', 'name' => get_lang('Multiple a
 
 $add_type = 'multiple';
 if (isset($_REQUEST['add_type']) && '' != $_REQUEST['add_type']) {
-    $add_type = htmlspecialchars(Security::remove_XSS($_REQUEST['add_type']), ENT_QUOTES, 'UTF-8');
+    $add_type = 'unique' === $_REQUEST['add_type'] ? 'unique' : 'multiple';
 }
 
 $access_url_id = 1;

--- a/public/main/admin/access_url_edit_users_to_url.php
+++ b/public/main/admin/access_url_edit_users_to_url.php
@@ -36,12 +36,12 @@ $interbreadcrumb[] = ['url' => 'access_urls.php', 'name' => get_lang('Multiple a
 
 $add_type = 'multiple';
 if (isset($_REQUEST['add_type']) && '' != $_REQUEST['add_type']) {
-    $add_type = Security::remove_XSS($_REQUEST['add_type']);
+    $add_type = htmlspecialchars(Security::remove_XSS($_REQUEST['add_type']), ENT_QUOTES, 'UTF-8');
 }
 
 $access_url_id = 1;
 if (isset($_REQUEST['access_url_id']) && '' != $_REQUEST['access_url_id']) {
-    $access_url_id = Security::remove_XSS($_REQUEST['access_url_id']);
+    $access_url_id = (int) $_REQUEST['access_url_id'];
 }
 
 $xajax->processRequests();


### PR DESCRIPTION
Hardens the `add_type` and `access_url_id` request parameters in the multi-URL admin pages, where they were sanitized only with `Security::remove_XSS()` (which does not escape for HTML-attribute context) — or, in one page, not sanitized at all — and then reflected into `href` / hidden-input `value` attributes and an inline JS string.

- `add_type` is now restricted to its two valid values through an allowlist (`'unique'` or `'multiple'`), so no attacker-controlled text can reach the output.
- `access_url_id` is cast to `(int)`.

Applied to the reported page and its sibling admin pages that share the same pattern:
- `public/main/admin/access_url_edit_users_to_url.php`
- `public/main/admin/access_url_edit_courses_to_url.php`
- `public/main/admin/access_url_edit_usergroup_to_url.php`
- `public/main/admin/access_url_edit_course_category_to_url.php` (`access_url_id` was already `(int)`)

All of these pages are gated behind `api_protect_global_admin_script()`.

Refs GHSA-3rmg-cx7r-rcqh