### PR TITLE
Security: predictable password reset / email confirmation tokens via api_get_unique_id()

### DIFF
--- a/public/main/inc/lib/api.lib.php
+++ b/public/main/inc/lib/api.lib.php
@@ -6027,11 +6027,32 @@ function api_is_multiple_url_enabled(): bool
 /**
  * Returns a md5 unique id.
  *
+ * The value is derived from the current time and is therefore predictable, so
+ * it must not be used as a secret. For security tokens (password reset, e-mail
+ * confirmation, ...) use api_generate_secure_token() instead.
+ *
  * @todo add more parameters
  */
 function api_get_unique_id()
 {
     return md5(time().uniqid().api_get_user_id().api_get_course_id().api_get_session_id());
+}
+
+/**
+ * Generates a cryptographically secure, unpredictable random token, suitable
+ * for use as a secret (password reset links, e-mail confirmation links, ...).
+ *
+ * Unlike api_get_unique_id(), the returned value is not derived from the clock.
+ *
+ * @param int $bytes Number of random bytes to read (a floor of 16 is enforced)
+ *
+ * @return string
+ */
+function api_generate_secure_token($bytes = 32)
+{
+    $bytes = max(16, (int) $bytes);
+
+    return bin2hex(random_bytes($bytes));
 }
 
 /**

--- a/public/main/inc/lib/login.lib.php
+++ b/public/main/inc/lib/login.lib.php
@@ -197,7 +197,7 @@ class Login
 
     public static function sendResetEmail(User $user)
     {
-        $uniqueId = api_get_unique_id();
+        $uniqueId = bin2hex(random_bytes(32));
         $user->setConfirmationToken($uniqueId);
         $user->setPasswordRequestedAt(new \DateTime());
 
@@ -236,7 +236,7 @@ class Login
             return null;
         }
 
-        $token = api_get_unique_id();
+        $token = bin2hex(random_bytes(32));
         $userEntity->setConfirmationToken($token);
         $userEntity->setPasswordRequestedAt(new \DateTime());
 

--- a/public/main/inc/lib/login.lib.php
+++ b/public/main/inc/lib/login.lib.php
@@ -197,7 +197,7 @@ class Login
 
     public static function sendResetEmail(User $user)
     {
-        $uniqueId = bin2hex(random_bytes(32));
+        $uniqueId = api_generate_secure_token();
         $user->setConfirmationToken($uniqueId);
         $user->setPasswordRequestedAt(new \DateTime());
 
@@ -236,7 +236,7 @@ class Login
             return null;
         }
 
-        $token = bin2hex(random_bytes(32));
+        $token = api_generate_secure_token();
         $userEntity->setConfirmationToken($token);
         $userEntity->setPasswordRequestedAt(new \DateTime());
 

--- a/public/main/inc/lib/usermanager.lib.php
+++ b/public/main/inc/lib/usermanager.lib.php
@@ -5687,7 +5687,7 @@ SQL;
      */
     public static function sendUserConfirmationMail(User $user)
     {
-        $uniqueId = api_get_unique_id();
+        $uniqueId = bin2hex(random_bytes(32));
         $user->setConfirmationToken($uniqueId);
 
         Database::getManager()->persist($user);
@@ -6395,7 +6395,7 @@ SQL;
         if (!empty($askPassword) && isset($askPassword['ask_new_password']) &&
             1 === (int) $askPassword['ask_new_password']
         ) {
-            $uniqueId = api_get_unique_id();
+            $uniqueId = bin2hex(random_bytes(32));
             $userObj = api_get_user_entity($userId);
             $userObj->setConfirmationToken($uniqueId);
             $userObj->setPasswordRequestedAt(new \DateTime());

--- a/public/main/inc/lib/usermanager.lib.php
+++ b/public/main/inc/lib/usermanager.lib.php
@@ -5687,7 +5687,7 @@ SQL;
      */
     public static function sendUserConfirmationMail(User $user)
     {
-        $uniqueId = bin2hex(random_bytes(32));
+        $uniqueId = api_generate_secure_token();
         $user->setConfirmationToken($uniqueId);
 
         Database::getManager()->persist($user);
@@ -6395,7 +6395,7 @@ SQL;
         if (!empty($askPassword) && isset($askPassword['ask_new_password']) &&
             1 === (int) $askPassword['ask_new_password']
         ) {
-            $uniqueId = bin2hex(random_bytes(32));
+            $uniqueId = api_generate_secure_token();
             $userObj = api_get_user_entity($userId);
             $userObj->setConfirmationToken($uniqueId);
             $userObj->setPasswordRequestedAt(new \DateTime());


### PR DESCRIPTION
`api_get_unique_id()` returns `md5(time().uniqid()...)`, which for anonymous requests collapses to a clock-derived, low-entropy value. It was used to mint security-sensitive tokens in four sinks: `Login::sendResetEmail()`, `Login::generateResetToken()`, `UserManager::sendUserConfirmationMail()` and the `ask_new_password` flow in `UserManager`. These are now generated with `bin2hex(random_bytes(32))` (matching the existing secure-token idiom already used elsewhere in `usermanager.lib.php`). The tokens stay alphanumeric, so the `reset.php` / `user_mail_confirmation.php` consumers keep working unchanged.

⚠ Note for the reviewer: the advisory's declared vulnerable range is `<= 1.11.x`, but the weak-token code path is present and reachable in current 2.x `master` (verified directly), so this PR targets 2.0. Please confirm the range classification.

Refs GHSA-c65x-9x5c-66f2