### PR TITLE
Security: MessageAttachment API item GET missing message-ownership check (IDOR)

### DIFF
--- a/src/CoreBundle/Entity/MessageAttachment.php
+++ b/src/CoreBundle/Entity/MessageAttachment.php
@@ -16,7 +16,7 @@ use Symfony\Component\Serializer\Attribute\Groups;
 #[ApiResource(
     types: ['http://schema.org/MediaObject'],
     operations: [
-        new Get(security: "is_granted('ROLE_USER')"),
+        new Get(security: "object.getMessage() != null and is_granted('VIEW', object.getMessage())"),
     ],
     normalizationContext: [
         'groups' => ['message:read'],


### PR DESCRIPTION
The `MessageAttachment` item GET was gated on `is_granted('ROLE_USER')` only, so any authenticated user could enumerate the auto-increment attachment ids and read other users' private-message attachment metadata (comment, contentUrl, downloadUrl). The operation is now scoped to the parent message's ownership via `is_granted('VIEW', object.getMessage())`, reusing the existing `MessageVoter` (sender/receiver check) exactly as the parent `Message` resource already does.

Refs GHSA-jf75-vp35-w4mg