### PR TITLE
Security: generate password reset and email confirmation tokens with random_bytes()

### DIFF
--- a/main/auth/reset.php
+++ b/main/auth/reset.php
@@ -6,11 +6,13 @@ require_once __DIR__.'/../inc/global.inc.php';
 
 $token = $_GET['token'] ?? '';
 
-if (!ctype_alnum($token)) {
+if (!is_string($token) || !ctype_alnum($token)) {
     $token = '';
 }
 
-$user = UserManager::getManager()->findUserByConfirmationToken($token);
+// Never look up an empty token: it would match any row left with an empty
+// confirmation_token instead of failing.
+$user = $token !== '' ? UserManager::getManager()->findUserByConfirmationToken($token) : null;
 
 if (!$user) {
     Display::addFlash(
@@ -60,8 +62,12 @@ if ($form->validate()) {
     $password = $values['pass1'];
     $token = $values['token'];
 
+    if (!is_string($token) || !ctype_alnum($token)) {
+        $token = '';
+    }
+
     /** @var \Chamilo\UserBundle\Entity\User $user */
-    $user = UserManager::getManager()->findUserByConfirmationToken($token);
+    $user = $token !== '' ? UserManager::getManager()->findUserByConfirmationToken($token) : null;
 
     if ($user) {
         if (!$user->isPasswordRequestNonExpired($ttl)) {

--- a/main/auth/user_mail_confirmation.php
+++ b/main/auth/user_mail_confirmation.php
@@ -5,12 +5,12 @@ require_once __DIR__.'/../inc/global.inc.php';
 
 $token = isset($_GET['token']) ? $_GET['token'] : '';
 
-if (!ctype_alnum($token)) {
+if (!is_string($token) || !ctype_alnum($token)) {
     $token = '';
 }
 
 /** @var \Chamilo\UserBundle\Entity\User $user */
-$user = UserManager::getManager()->findUserByConfirmationToken($token);
+$user = $token !== '' ? UserManager::getManager()->findUserByConfirmationToken($token) : null;
 
 if ($user) {
     $user->setActive(1); // Set to 1 to activate the user

--- a/main/inc/lib/api.lib.php
+++ b/main/inc/lib/api.lib.php
@@ -8016,6 +8016,11 @@ function api_is_multiple_url_enabled()
 /**
  * Returns a md5 unique id.
  *
+ * WARNING: this value is derived from the clock (time() + uniqid()) and is
+ * therefore predictable. It must never be used for security-sensitive,
+ * unguessable values such as password reset or e-mail confirmation tokens.
+ * Use api_generate_secure_token() instead.
+ *
  * @todo add more parameters
  */
 function api_get_unique_id()
@@ -8023,6 +8028,30 @@ function api_get_unique_id()
     $id = md5(time().uniqid().api_get_user_id().api_get_course_id().api_get_session_id());
 
     return $id;
+}
+
+/**
+ * Generates a cryptographically secure random token, suitable for password
+ * reset links, e-mail confirmation links and any other unguessable secret
+ * sent to a user.
+ *
+ * The returned value only contains hexadecimal characters, so it is safe to
+ * put in a URL and it passes the ctype_alnum() checks done by the consumers.
+ *
+ * @param int $bytes Number of random bytes to read (the returned string is twice as long)
+ *
+ * @throws Exception if no appropriate source of randomness is available
+ *
+ * @return string
+ */
+function api_generate_secure_token($bytes = 32)
+{
+    $bytes = (int) $bytes;
+    if ($bytes < 16) {
+        $bytes = 16;
+    }
+
+    return bin2hex(random_bytes($bytes));
 }
 
 /**

--- a/main/inc/lib/login.lib.php
+++ b/main/inc/lib/login.lib.php
@@ -219,7 +219,7 @@ class Login
 
     public static function sendResetEmail(User $user)
     {
-        $uniqueId = api_get_unique_id();
+        $uniqueId = api_generate_secure_token();
         $user->setConfirmationToken($uniqueId);
         $user->setPasswordRequestedAt(new \DateTime());
 
@@ -258,7 +258,7 @@ class Login
      */
     public static function generate_reset_token($userId)
     {
-        $token = bin2hex(random_bytes(32));
+        $token = api_generate_secure_token();
         $em = Database::getManager();
         /** @var User $user */
         $user = $em->find('ChamiloUserBundle:User', (int) $userId);

--- a/main/inc/lib/usermanager.lib.php
+++ b/main/inc/lib/usermanager.lib.php
@@ -7119,7 +7119,7 @@ SQL;
      */
     public static function sendUserConfirmationMail(User $user)
     {
-        $uniqueId = api_get_unique_id();
+        $uniqueId = api_generate_secure_token();
         $user->setConfirmationToken($uniqueId);
 
         Database::getManager()->persist($user);
@@ -7748,7 +7748,7 @@ SQL;
             if (!empty($askPassword) && isset($askPassword['ask_new_password']) &&
                 1 === (int) $askPassword['ask_new_password']
             ) {
-                $uniqueId = api_get_unique_id();
+                $uniqueId = api_generate_secure_token();
                 $userObj = api_get_user_entity($userId);
 
                 $userObj->setConfirmationToken($uniqueId);
@@ -7798,7 +7798,7 @@ SQL;
                 }
             }
             if ($forceRotate) {
-                $uniqueId = api_get_unique_id();
+                $uniqueId = api_generate_secure_token();
                 $userObj = api_get_user_entity($userId);
 
                 $userObj->setConfirmationToken($uniqueId);


### PR DESCRIPTION
Password reset and e-mail confirmation tokens are now generated with `random_bytes()` through a new `api_generate_secure_token()` helper, instead of `api_get_unique_id()`.

Tokens stay alphanumeric and the column already allows the length, so existing links and consumers keep working with no schema change.