### PR TITLE
Gradebook: Security: Harden access control on the certificate page

### DIFF
--- a/certificates/index.php
+++ b/certificates/index.php
@@ -7,9 +7,9 @@
  */
 require_once '../main/inc/global.inc.php';
 
-$action = isset($_GET['action']) ? $_GET['action'] : null;
-$userId = isset($_GET['user_id']) ? $_GET['user_id'] : 0;
-$certificateId = isset($_GET['id']) ? $_GET['id'] : 0;
+$action = $_GET['action'] ?? null;
+$userId = isset($_GET['user_id']) ? (int) $_GET['user_id'] : 0;
+$certificateId = isset($_GET['id']) ? (int) $_GET['id'] : 0;
 
 $category = Category::findByCertificate($certificateId);
 
@@ -28,18 +28,31 @@ if (!empty($category) && !empty($category->get_course_code())) {
     $language_interface_initial_value = $language_interface;
 }
 
-$certificate = new Certificate($certificateId, $userId);
-$certificateData = $certificate->get($certificateId);
+// Access control has to be fully settled *before* instantiating Certificate: its constructor
+// regenerates the certificate as a side effect (writes the HTML file, updates the gradebook
+// row and assigns skills to the owner). Instantiating first would let an unauthenticated
+// visitor trigger those writes for any certificate by iterating ?id=N, even though the
+// checks below would then deny the response.
+$certificateData = Certificate::getCertificateData($certificateId);
 if (empty($certificateData)) {
     api_not_allowed(false, Display::return_message(get_lang('NoCertificateAvailable'), 'warning'));
 }
 
-// Access control: only the owner, a platform admin, or a teacher of the certificate's course
-// may view or export a certificate. Compare against $certificate->user_id (set from DB in the
-// constructor) — not the $userId GET parameter, which an attacker can spoof to their own ID
-// while supplying someone else's certificate $id.
+// Only the owner, a platform admin, or a teacher of the certificate's course may view or
+// export a certificate. Compare against the owner recorded in the database — not the $userId
+// GET parameter, which an attacker can spoof to their own ID while supplying someone else's
+// certificate $id.
+// Anonymous visitors are only ever allowed to reach a certificate that was explicitly
+// published for public verification, and that must hold for every action: the 'export' branch
+// never calls isVisible(), so leaving the check to the 'default' branch alone let an
+// unauthenticated visitor enumerate ?action=export&id=N and download the full PDF (name,
+// course, score) of every certificate on the platform.
 $currentUserId = api_get_user_id();
-if (!api_is_anonymous() && (int) $currentUserId !== (int) $certificate->user_id) {
+if (api_is_anonymous()) {
+    if (!Certificate::isPubliclyVisible($certificateData['cat_id'])) {
+        api_not_allowed(false, Display::return_message(get_lang('CertificateExistsButNotPublic'), 'warning'));
+    }
+} elseif ((int) $currentUserId !== (int) $certificateData['user_id']) {
     $isCourseTeacher = false;
     if (!empty($category) && !empty($category->get_course_code())) {
         $isCourseTeacher = CourseManager::is_course_teacher($currentUserId, $category->get_course_code());
@@ -48,6 +61,8 @@ if (!api_is_anonymous() && (int) $currentUserId !== (int) $certificate->user_id)
         api_not_allowed(true);
     }
 }
+
+$certificate = new Certificate($certificateId, $userId);
 
 CustomCertificatePlugin::redirectCheck($certificate, $certificateId, $userId);
 

--- a/main/inc/lib/certificate.lib.php
+++ b/main/inc/lib/certificate.lib.php
@@ -612,17 +612,40 @@ class Certificate extends Model
             return true;
         }
 
+        if (!isset($this->certificate_data, $this->certificate_data['cat_id'])) {
+            return false;
+        }
+
+        return self::isPubliclyVisible($this->certificate_data['cat_id']);
+    }
+
+    /**
+     * Check whether certificates of the given gradebook category may be shown to
+     * anonymous visitors, based on the global and the course "allow_public_certificates"
+     * settings.
+     *
+     * Static so that the check can be run before a Certificate object is instantiated:
+     * the constructor regenerates the certificate as a side effect, which must not happen
+     * before the caller has been authorized.
+     *
+     * @param int $catId Gradebook category ID
+     *
+     * @return bool
+     */
+    public static function isPubliclyVisible($catId)
+    {
+        $catId = (int) $catId;
+        if (empty($catId)) {
+            return false;
+        }
+
         if (api_get_setting('allow_public_certificates') != 'true') {
             // The "non-public" setting is set, so do not print
             return false;
         }
 
-        if (!isset($this->certificate_data, $this->certificate_data['cat_id'])) {
-            return false;
-        }
-
         $gradeBook = new Gradebook();
-        $gradeBookInfo = $gradeBook->get($this->certificate_data['cat_id']);
+        $gradeBookInfo = $gradeBook->get($catId);
 
         if (empty($gradeBookInfo['course_code'])) {
             return false;
@@ -891,6 +914,36 @@ class Certificate extends Model
      *
      * @return array
      */
+    /**
+     * Get a single certificate row by its ID.
+     *
+     * Static so the certificate data (owner, category) can be read for authorization
+     * purposes without instantiating this class, whose constructor regenerates the
+     * certificate as a side effect.
+     *
+     * @param int $id
+     *
+     * @return array Empty array if no such certificate
+     */
+    public static function getCertificateData($id)
+    {
+        $id = (int) $id;
+        if (empty($id)) {
+            return [];
+        }
+
+        $table = Database::get_main_table(TABLE_MAIN_GRADEBOOK_CERTIFICATE);
+        $sql = "SELECT * FROM $table
+                WHERE id = $id";
+        $rs = Database::query($sql);
+
+        if (Database::num_rows($rs) === 0) {
+            return [];
+        }
+
+        return Database::fetch_assoc($rs);
+    }
+
     public static function getCertificateByUser($userId)
     {
         $userId = (int) $userId;


### PR DESCRIPTION
Consolidate the authorization check in certificates/index.php so it is
evaluated once, before the action dispatch, and therefore applies to every
action instead of only the default one.

Anonymous visitors must now pass the public-visibility check
(allow_public_certificates, globally and per course) for any action.
Authenticated users other than the certificate owner still require platform
admin or course teacher rights, compared against the owner recorded in the
database rather than the user_id request parameter.

The check also runs before the Certificate object is instantiated, since its
constructor regenerates the certificate as a side effect: it writes the HTML
file, updates the gradebook row and assigns skills to the owner.

To keep the visibility rules in a single place, extract the public-visibility
check from Certificate::isVisible() into the static
Certificate::isPubliclyVisible(), and add Certificate::getCertificateData() to
read a certificate row without constructing the object. isVisible() keeps its
signature and semantics and now delegates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)