### PR TITLE
Admin: Security: Normalize add_type and access_url_id on URL management pages

### DIFF
--- a/main/admin/access_url_edit_course_category_to_url.php
+++ b/main/admin/access_url_edit_course_category_to_url.php
@@ -31,7 +31,7 @@ $interbreadcrumb[] = ['url' => 'access_urls.php', 'name' => get_lang('MultipleAc
 
 $add_type = 'multiple';
 if (isset($_REQUEST['add_type']) && $_REQUEST['add_type'] != '') {
-    $add_type = Security::remove_XSS($_REQUEST['add_type']);
+    $add_type = $_REQUEST['add_type'] === 'unique' ? 'unique' : 'multiple';
 }
 
 $access_url_id = 1;

--- a/main/admin/access_url_edit_courses_to_url.php
+++ b/main/admin/access_url_edit_courses_to_url.php
@@ -31,12 +31,12 @@ $interbreadcrumb[] = ['url' => 'access_urls.php', 'name' => get_lang('MultipleAc
 
 $add_type = 'multiple';
 if (isset($_REQUEST['add_type']) && $_REQUEST['add_type'] != '') {
-    $add_type = Security::remove_XSS($_REQUEST['add_type']);
+    $add_type = $_REQUEST['add_type'] === 'unique' ? 'unique' : 'multiple';
 }
 
 $access_url_id = 1;
 if (isset($_REQUEST['access_url_id']) && $_REQUEST['access_url_id'] != '') {
-    $access_url_id = Security::remove_XSS($_REQUEST['access_url_id']);
+    $access_url_id = (int) $_REQUEST['access_url_id'];
 }
 
 $xajax->processRequests();

--- a/main/admin/access_url_edit_usergroup_to_url.php
+++ b/main/admin/access_url_edit_usergroup_to_url.php
@@ -30,12 +30,12 @@ $interbreadcrumb[] = ['url' => 'access_urls.php', 'name' => get_lang('MultipleAc
 
 $add_type = 'multiple';
 if (isset($_REQUEST['add_type']) && $_REQUEST['add_type'] != '') {
-    $add_type = Security::remove_XSS($_REQUEST['add_type']);
+    $add_type = $_REQUEST['add_type'] === 'unique' ? 'unique' : 'multiple';
 }
 
 $access_url_id = 1;
 if (isset($_REQUEST['access_url_id']) && $_REQUEST['access_url_id'] != '') {
-    $access_url_id = Security::remove_XSS($_REQUEST['access_url_id']);
+    $access_url_id = (int) $_REQUEST['access_url_id'];
 }
 
 $xajax->processRequests();

--- a/main/admin/access_url_edit_users_to_url.php
+++ b/main/admin/access_url_edit_users_to_url.php
@@ -28,14 +28,19 @@ $tool_name = get_lang('EditUsersToURL');
 $interbreadcrumb[] = ['url' => 'index.php', 'name' => get_lang('PlatformAdmin')];
 $interbreadcrumb[] = ['url' => 'access_urls.php', 'name' => get_lang('MultipleAccessURLs')];
 
+// Both values are echoed into HTML attributes and into a JS string literal below.
+// Security::remove_XSS() sanitizes for HTML *content*, not for those contexts (it leaves
+// a bare double-quote untouched, so it does not prevent an attribute breakout). Normalize
+// each value to its legitimate domain instead: add_type is a fixed allowlist and
+// access_url_id is an integer URL id, which makes a breakout impossible in every context.
 $add_type = 'multiple';
 if (isset($_REQUEST['add_type']) && $_REQUEST['add_type'] != '') {
-    $add_type = Security::remove_XSS($_REQUEST['add_type']);
+    $add_type = $_REQUEST['add_type'] === 'unique' ? 'unique' : 'multiple';
 }
 
 $access_url_id = 1;
 if (isset($_REQUEST['access_url_id']) && $_REQUEST['access_url_id'] != '') {
-    $access_url_id = Security::remove_XSS($_REQUEST['access_url_id']);
+    $access_url_id = (int) $_REQUEST['access_url_id'];
 }
 
 $xajax->processRequests();


### PR DESCRIPTION
### What

On the multi-URL admin pages, `add_type` and `access_url_id` came from the request and were echoed into HTML attributes (and, for `add_type`, into a JS string literal) after only `Security::remove_XSS()`, which sanitizes for HTML content rather than for attribute / JS-string contexts.

This normalizes both values to their legitimate domains at input:

- `add_type` is restricted to the `"unique"` / `"multiple"` allowlist.
- `access_url_id` is cast to its integer URL id.

With this, every output context stays safe regardless of where the values are printed, without relying on context-specific escaping at each sink.

### Files

- `main/admin/access_url_edit_users_to_url.php`
- `main/admin/access_url_edit_courses_to_url.php`
- `main/admin/access_url_edit_usergroup_to_url.php`
- `main/admin/access_url_edit_course_category_to_url.php`

### Notes

- Legitimate values (`unique` / `multiple` and integer URL ids) pass through unchanged, so view switching and URL selection are unaffected.
- Pages are gated by `api_protect_global_admin_script()` and the multi-URL feature.