### PR TITLE
Security: Missing authorization on ContactCategory CRUD routes

### DIFF
--- a/src/CoreBundle/Controller/ContactCategoryController.php
+++ b/src/CoreBundle/Controller/ContactCategoryController.php
@@ -13,15 +13,15 @@ use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
 
+#[IsGranted('ROLE_ADMIN')]
 #[Route('/contact/category')]
 class ContactCategoryController extends AbstractController
 {
     #[Route('/', name: 'chamilo_contact_category_index', methods: ['GET'])]
     public function index(EntityManagerInterface $entityManager): Response
     {
-        $this->denyAccessUnlessGranted('ROLE_ADMIN');
-
         $contactCategories = $entityManager
             ->getRepository(ContactCategory::class)
             ->findAll()


### PR DESCRIPTION
The `new`, `show`, `edit` and `delete` routes of `ContactCategoryController` had no authorization check, so any authenticated user could manage contact categories. Access is now restricted to administrators for the whole controller via a class-level `#[IsGranted('ROLE_ADMIN')]`, which makes the previous per-method check on `index()` redundant.

Refs GHSA-33q8-6j2p-rxc3