### PR TITLE
API Platform: read course context from CidReqHelper and declare cid/sid/gid in the operations (LearningPath, Portfolio, Forum, CourseInvitation, Ai, CalendarEvent)

### DIFF
--- a/src/CoreBundle/ApiResource/Ai/WysiwygTranslation.php
+++ b/src/CoreBundle/ApiResource/Ai/WysiwygTranslation.php
@@ -9,6 +9,7 @@ namespace Chamilo\CoreBundle\ApiResource\Ai;
 use ApiPlatform\Metadata\ApiResource;
 use ApiPlatform\Metadata\Get;
 use ApiPlatform\Metadata\Post;
+use ApiPlatform\Metadata\QueryParameter;
 use Chamilo\CoreBundle\State\Ai\WysiwygTranslationProcessor;
 use Chamilo\CoreBundle\State\Ai\WysiwygTranslationProvider;
 use Symfony\Component\Serializer\Attribute\Groups;
@@ -19,6 +20,16 @@ use Symfony\Component\Serializer\Attribute\Groups;
             uriTemplate: '/wysiwyg_translation',
             security: "is_granted('ROLE_USER')",
             name: 'get_wysiwyg_translation_configuration',
+            parameters: [
+                'cid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Course identifier',
+                ),
+                'sid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Session identifier',
+                ),
+            ],
             provider: WysiwygTranslationProvider::class,
         ),
         new Post(
@@ -26,6 +37,16 @@ use Symfony\Component\Serializer\Attribute\Groups;
             security: "is_granted('ROLE_USER')",
             read: false,
             name: 'create_wysiwyg_translation',
+            parameters: [
+                'cid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Course identifier',
+                ),
+                'sid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Session identifier',
+                ),
+            ],
             processor: WysiwygTranslationProcessor::class,
         ),
     ],

--- a/src/CoreBundle/ApiResource/CourseInvitation/CourseInvitationItem.php
+++ b/src/CoreBundle/ApiResource/CourseInvitation/CourseInvitationItem.php
@@ -12,6 +12,7 @@ use ApiPlatform\Metadata\Delete;
 use ApiPlatform\Metadata\Get;
 use ApiPlatform\Metadata\GetCollection;
 use ApiPlatform\Metadata\Post;
+use ApiPlatform\Metadata\QueryParameter;
 use Chamilo\CoreBundle\Entity\CourseInvitation;
 use Chamilo\CoreBundle\State\CourseInvitation\CourseInvitationProvider;
 use Chamilo\CoreBundle\State\CourseInvitation\CourseInvitationRevokeProcessor;
@@ -33,12 +34,34 @@ use const DATE_ATOM;
             uriTemplate: '/course-invitation/form',
             security: "is_granted('ROLE_USER')",
             name: 'get_course_invitation_form',
+            parameters: [
+                'cid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Course identifier',
+                    required: true,
+                ),
+                'sid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Session identifier',
+                ),
+            ],
             provider: CourseInvitationProvider::class,
         ),
         new GetCollection(
             uriTemplate: '/course-invitations',
             security: "is_granted('ROLE_USER')",
             name: 'get_course_invitations',
+            parameters: [
+                'cid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Course identifier',
+                    required: true,
+                ),
+                'sid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Session identifier',
+                ),
+            ],
             provider: CourseInvitationProvider::class,
         ),
         new Post(
@@ -47,6 +70,17 @@ use const DATE_ATOM;
             input: CourseInvitationWriteInput::class,
             read: false,
             name: 'post_course_invitation',
+            parameters: [
+                'cid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Course identifier',
+                    required: true,
+                ),
+                'sid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Session identifier',
+                ),
+            ],
             processor: CourseInvitationSendProcessor::class,
         ),
         new Delete(
@@ -54,6 +88,17 @@ use const DATE_ATOM;
             requirements: ['id' => '\d+'],
             security: "is_granted('ROLE_USER')",
             name: 'delete_course_invitation',
+            parameters: [
+                'cid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Course identifier',
+                    required: true,
+                ),
+                'sid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Session identifier',
+                ),
+            ],
             provider: CourseInvitationProvider::class,
             processor: CourseInvitationRevokeProcessor::class,
         ),

--- a/src/CoreBundle/ApiResource/Forum/ForumGradingOptions.php
+++ b/src/CoreBundle/ApiResource/Forum/ForumGradingOptions.php
@@ -9,8 +9,7 @@ namespace Chamilo\CoreBundle\ApiResource\Forum;
 use ApiPlatform\Metadata\ApiProperty;
 use ApiPlatform\Metadata\ApiResource;
 use ApiPlatform\Metadata\Get;
-use ApiPlatform\OpenApi\Model\Operation;
-use ApiPlatform\OpenApi\Model\Parameter;
+use ApiPlatform\Metadata\QueryParameter;
 use Chamilo\CoreBundle\State\Forum\ForumGradingOptionsProvider;
 use Symfony\Component\Serializer\Attribute\Groups;
 
@@ -18,25 +17,18 @@ use Symfony\Component\Serializer\Attribute\Groups;
     operations: [
         new Get(
             uriTemplate: '/forum/grading-options',
-            openapi: new Operation(
-                parameters: [
-                    new Parameter(
-                        name: 'cid',
-                        in: 'query',
-                        description: 'Course id',
-                        required: true,
-                        schema: ['type' => 'integer'],
-                    ),
-                    new Parameter(
-                        name: 'sid',
-                        in: 'query',
-                        description: 'Session id',
-                        required: false,
-                        schema: ['type' => 'integer'],
-                    ),
-                ],
-            ),
             security: "is_granted('ROLE_CURRENT_COURSE_TEACHER') or is_granted('ROLE_CURRENT_COURSE_SESSION_TEACHER') or is_granted('ROLE_ADMIN')",
+            parameters: [
+                'cid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Course identifier',
+                    required: true,
+                ),
+                'sid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Session identifier',
+                ),
+            ],
             provider: ForumGradingOptionsProvider::class,
         ),
     ],

--- a/src/CoreBundle/ApiResource/Forum/ForumThreadGrading.php
+++ b/src/CoreBundle/ApiResource/Forum/ForumThreadGrading.php
@@ -10,6 +10,7 @@ use ApiPlatform\Metadata\ApiProperty;
 use ApiPlatform\Metadata\ApiResource;
 use ApiPlatform\Metadata\Get;
 use ApiPlatform\Metadata\Patch;
+use ApiPlatform\Metadata\QueryParameter;
 use ApiPlatform\OpenApi\Model\Operation;
 use ApiPlatform\OpenApi\Model\Parameter;
 use ApiPlatform\OpenApi\Model\RequestBody;
@@ -79,6 +80,17 @@ use Symfony\Component\Serializer\Attribute\Groups;
             input: ForumThreadGradingInput::class,
             read: false,
             name: 'update_forum_thread_grading',
+            parameters: [
+                'cid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Course identifier',
+                    required: true,
+                ),
+                'sid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Session identifier',
+                ),
+            ],
             processor: ForumThreadGradingProcessor::class,
         ),
         new Patch(
@@ -105,6 +117,17 @@ use Symfony\Component\Serializer\Attribute\Groups;
             input: ForumThreadScoreInput::class,
             read: false,
             name: 'save_forum_thread_score',
+            parameters: [
+                'cid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Course identifier',
+                    required: true,
+                ),
+                'sid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Session identifier',
+                ),
+            ],
             processor: ForumThreadGradingProcessor::class,
         ),
     ],

--- a/src/CoreBundle/ApiResource/LearningPath/LearningPathAiGenerator.php
+++ b/src/CoreBundle/ApiResource/LearningPath/LearningPathAiGenerator.php
@@ -9,6 +9,7 @@ namespace Chamilo\CoreBundle\ApiResource\LearningPath;
 use ApiPlatform\Metadata\ApiResource;
 use ApiPlatform\Metadata\Get;
 use ApiPlatform\Metadata\Post;
+use ApiPlatform\Metadata\QueryParameter;
 use Chamilo\CoreBundle\State\LearningPath\LearningPathAiGeneratorProcessor;
 use Chamilo\CoreBundle\State\LearningPath\LearningPathAiGeneratorProvider;
 use Symfony\Component\Serializer\Attribute\Groups;
@@ -19,6 +20,21 @@ use Symfony\Component\Serializer\Attribute\Groups;
             uriTemplate: '/learning_paths/ai-generator',
             security: "is_granted('ROLE_ADMIN') or is_granted('ROLE_CURRENT_COURSE_TEACHER') or is_granted('ROLE_CURRENT_COURSE_SESSION_TEACHER')",
             name: 'get_learning_path_ai_generator',
+            parameters: [
+                'cid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Course identifier',
+                    required: true,
+                ),
+                'sid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Session identifier',
+                ),
+                'gid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Group identifier',
+                ),
+            ],
             provider: LearningPathAiGeneratorProvider::class,
         ),
         new Post(
@@ -26,6 +42,21 @@ use Symfony\Component\Serializer\Attribute\Groups;
             security: "is_granted('ROLE_ADMIN') or is_granted('ROLE_CURRENT_COURSE_TEACHER') or is_granted('ROLE_CURRENT_COURSE_SESSION_TEACHER')",
             read: false,
             name: 'create_learning_path_from_ai',
+            parameters: [
+                'cid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Course identifier',
+                    required: true,
+                ),
+                'sid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Session identifier',
+                ),
+                'gid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Group identifier',
+                ),
+            ],
             processor: LearningPathAiGeneratorProcessor::class,
         ),
     ],

--- a/src/CoreBundle/ApiResource/LearningPath/LearningPathBuilder.php
+++ b/src/CoreBundle/ApiResource/LearningPath/LearningPathBuilder.php
@@ -9,6 +9,7 @@ namespace Chamilo\CoreBundle\ApiResource\LearningPath;
 use ApiPlatform\Metadata\ApiProperty;
 use ApiPlatform\Metadata\ApiResource;
 use ApiPlatform\Metadata\Get;
+use ApiPlatform\Metadata\QueryParameter;
 use Chamilo\CoreBundle\State\LearningPath\LearningPathBuilderProvider;
 use Symfony\Component\Serializer\Attribute\Groups;
 
@@ -19,6 +20,21 @@ use Symfony\Component\Serializer\Attribute\Groups;
             requirements: ['lpId' => '\d+'],
             security: "is_granted('ROLE_ADMIN') or is_granted('ROLE_CURRENT_COURSE_TEACHER') or is_granted('ROLE_CURRENT_COURSE_SESSION_TEACHER')",
             name: 'get_learning_path_builder',
+            parameters: [
+                'cid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Course identifier',
+                    required: true,
+                ),
+                'sid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Session identifier',
+                ),
+                'gid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Group identifier',
+                ),
+            ],
             provider: LearningPathBuilderProvider::class,
         ),
     ],

--- a/src/CoreBundle/ApiResource/LearningPath/LearningPathBuilderBulkAuthorPriceInput.php
+++ b/src/CoreBundle/ApiResource/LearningPath/LearningPathBuilderBulkAuthorPriceInput.php
@@ -9,6 +9,7 @@ namespace Chamilo\CoreBundle\ApiResource\LearningPath;
 use ApiPlatform\Metadata\ApiProperty;
 use ApiPlatform\Metadata\ApiResource;
 use ApiPlatform\Metadata\Post;
+use ApiPlatform\Metadata\QueryParameter;
 use Chamilo\CoreBundle\State\LearningPath\LearningPathBuilderMutationProcessor;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Serializer\Attribute\Groups;
@@ -23,6 +24,21 @@ use Symfony\Component\Serializer\Attribute\Groups;
             output: false,
             read: false,
             name: 'update_learning_path_builder_author_price',
+            parameters: [
+                'cid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Course identifier',
+                    required: true,
+                ),
+                'sid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Session identifier',
+                ),
+                'gid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Group identifier',
+                ),
+            ],
             processor: LearningPathBuilderMutationProcessor::class,
         ),
     ],

--- a/src/CoreBundle/ApiResource/LearningPath/LearningPathBuilderDeleteInput.php
+++ b/src/CoreBundle/ApiResource/LearningPath/LearningPathBuilderDeleteInput.php
@@ -9,6 +9,7 @@ namespace Chamilo\CoreBundle\ApiResource\LearningPath;
 use ApiPlatform\Metadata\ApiProperty;
 use ApiPlatform\Metadata\ApiResource;
 use ApiPlatform\Metadata\Post;
+use ApiPlatform\Metadata\QueryParameter;
 use Chamilo\CoreBundle\State\LearningPath\LearningPathBuilderMutationProcessor;
 use Symfony\Component\Serializer\Attribute\Groups;
 
@@ -20,6 +21,21 @@ use Symfony\Component\Serializer\Attribute\Groups;
             security: "is_granted('ROLE_ADMIN') or is_granted('ROLE_CURRENT_COURSE_TEACHER') or is_granted('ROLE_CURRENT_COURSE_SESSION_TEACHER')",
             read: false,
             name: 'delete_learning_path_builder_item',
+            parameters: [
+                'cid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Course identifier',
+                    required: true,
+                ),
+                'sid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Session identifier',
+                ),
+                'gid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Group identifier',
+                ),
+            ],
             processor: LearningPathBuilderMutationProcessor::class,
         ),
     ],

--- a/src/CoreBundle/ApiResource/LearningPath/LearningPathBuilderFinalItemInput.php
+++ b/src/CoreBundle/ApiResource/LearningPath/LearningPathBuilderFinalItemInput.php
@@ -9,6 +9,7 @@ namespace Chamilo\CoreBundle\ApiResource\LearningPath;
 use ApiPlatform\Metadata\ApiProperty;
 use ApiPlatform\Metadata\ApiResource;
 use ApiPlatform\Metadata\Post;
+use ApiPlatform\Metadata\QueryParameter;
 use Chamilo\CoreBundle\State\LearningPath\LearningPathBuilderMutationProcessor;
 use Symfony\Component\Serializer\Attribute\Groups;
 
@@ -20,6 +21,21 @@ use Symfony\Component\Serializer\Attribute\Groups;
             security: "is_granted('ROLE_ADMIN') or is_granted('ROLE_CURRENT_COURSE_TEACHER') or is_granted('ROLE_CURRENT_COURSE_SESSION_TEACHER')",
             read: false,
             name: 'save_learning_path_builder_final_item',
+            parameters: [
+                'cid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Course identifier',
+                    required: true,
+                ),
+                'sid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Session identifier',
+                ),
+                'gid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Group identifier',
+                ),
+            ],
             processor: LearningPathBuilderMutationProcessor::class,
         ),
     ],

--- a/src/CoreBundle/ApiResource/LearningPath/LearningPathBuilderItemAudioInput.php
+++ b/src/CoreBundle/ApiResource/LearningPath/LearningPathBuilderItemAudioInput.php
@@ -9,6 +9,7 @@ namespace Chamilo\CoreBundle\ApiResource\LearningPath;
 use ApiPlatform\Metadata\ApiProperty;
 use ApiPlatform\Metadata\ApiResource;
 use ApiPlatform\Metadata\Patch;
+use ApiPlatform\Metadata\QueryParameter;
 use Chamilo\CoreBundle\State\LearningPath\LearningPathBuilderMutationProcessor;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Serializer\Attribute\Groups;
@@ -23,6 +24,21 @@ use Symfony\Component\Serializer\Attribute\Groups;
             output: false,
             read: false,
             name: 'update_learning_path_builder_item_audio',
+            parameters: [
+                'cid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Course identifier',
+                    required: true,
+                ),
+                'sid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Session identifier',
+                ),
+                'gid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Group identifier',
+                ),
+            ],
             processor: LearningPathBuilderMutationProcessor::class,
         ),
     ],

--- a/src/CoreBundle/ApiResource/LearningPath/LearningPathBuilderItemInput.php
+++ b/src/CoreBundle/ApiResource/LearningPath/LearningPathBuilderItemInput.php
@@ -9,6 +9,7 @@ namespace Chamilo\CoreBundle\ApiResource\LearningPath;
 use ApiPlatform\Metadata\ApiProperty;
 use ApiPlatform\Metadata\ApiResource;
 use ApiPlatform\Metadata\Post;
+use ApiPlatform\Metadata\QueryParameter;
 use Chamilo\CoreBundle\State\LearningPath\LearningPathBuilderMutationProcessor;
 use Symfony\Component\Serializer\Attribute\Groups;
 
@@ -20,6 +21,21 @@ use Symfony\Component\Serializer\Attribute\Groups;
             security: "is_granted('ROLE_ADMIN') or is_granted('ROLE_CURRENT_COURSE_TEACHER') or is_granted('ROLE_CURRENT_COURSE_SESSION_TEACHER')",
             read: false,
             name: 'create_learning_path_builder_section',
+            parameters: [
+                'cid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Course identifier',
+                    required: true,
+                ),
+                'sid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Session identifier',
+                ),
+                'gid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Group identifier',
+                ),
+            ],
             processor: LearningPathBuilderMutationProcessor::class,
         ),
     ],

--- a/src/CoreBundle/ApiResource/LearningPath/LearningPathBuilderItemPrerequisiteInput.php
+++ b/src/CoreBundle/ApiResource/LearningPath/LearningPathBuilderItemPrerequisiteInput.php
@@ -9,6 +9,7 @@ namespace Chamilo\CoreBundle\ApiResource\LearningPath;
 use ApiPlatform\Metadata\ApiProperty;
 use ApiPlatform\Metadata\ApiResource;
 use ApiPlatform\Metadata\Patch;
+use ApiPlatform\Metadata\QueryParameter;
 use Chamilo\CoreBundle\State\LearningPath\LearningPathBuilderMutationProcessor;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Serializer\Attribute\Groups;
@@ -23,6 +24,21 @@ use Symfony\Component\Serializer\Attribute\Groups;
             output: false,
             read: false,
             name: 'update_learning_path_builder_item_prerequisite',
+            parameters: [
+                'cid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Course identifier',
+                    required: true,
+                ),
+                'sid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Session identifier',
+                ),
+                'gid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Group identifier',
+                ),
+            ],
             processor: LearningPathBuilderMutationProcessor::class,
         ),
     ],

--- a/src/CoreBundle/ApiResource/LearningPath/LearningPathBuilderItemUpdateInput.php
+++ b/src/CoreBundle/ApiResource/LearningPath/LearningPathBuilderItemUpdateInput.php
@@ -10,6 +10,7 @@ use ApiPlatform\Metadata\ApiProperty;
 use ApiPlatform\Metadata\ApiResource;
 use ApiPlatform\Metadata\Patch;
 use ApiPlatform\Metadata\Post;
+use ApiPlatform\Metadata\QueryParameter;
 use Chamilo\CoreBundle\Controller\Api\LearningPathBuilderItemAction;
 use Chamilo\CoreBundle\State\LearningPath\LearningPathBuilderMutationProcessor;
 use Symfony\Component\HttpFoundation\Response;
@@ -24,6 +25,21 @@ use Symfony\Component\Serializer\Attribute\Groups;
             output: false,
             status: Response::HTTP_NO_CONTENT,
             name: 'update_learning_path_builder_item',
+            parameters: [
+                'cid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Course identifier',
+                    required: true,
+                ),
+                'sid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Session identifier',
+                ),
+                'gid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Group identifier',
+                ),
+            ],
             processor: LearningPathBuilderMutationProcessor::class,
             security: "is_granted('ROLE_ADMIN') or is_granted('ROLE_CURRENT_COURSE_TEACHER') or is_granted('ROLE_CURRENT_COURSE_SESSION_TEACHER')",
         ),
@@ -37,6 +53,21 @@ use Symfony\Component\Serializer\Attribute\Groups;
             read: false,
             deserialize: false,
             name: 'update_learning_path_builder_item_form',
+            parameters: [
+                'cid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Course identifier',
+                    required: true,
+                ),
+                'sid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Session identifier',
+                ),
+                'gid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Group identifier',
+                ),
+            ],
             processor: LearningPathBuilderMutationProcessor::class,
         ),
     ],

--- a/src/CoreBundle/ApiResource/LearningPath/LearningPathBuilderOrderInput.php
+++ b/src/CoreBundle/ApiResource/LearningPath/LearningPathBuilderOrderInput.php
@@ -9,6 +9,7 @@ namespace Chamilo\CoreBundle\ApiResource\LearningPath;
 use ApiPlatform\Metadata\ApiProperty;
 use ApiPlatform\Metadata\ApiResource;
 use ApiPlatform\Metadata\Post;
+use ApiPlatform\Metadata\QueryParameter;
 use Chamilo\CoreBundle\State\LearningPath\LearningPathBuilderMutationProcessor;
 use Symfony\Component\Serializer\Attribute\Groups;
 
@@ -20,6 +21,21 @@ use Symfony\Component\Serializer\Attribute\Groups;
             security: "is_granted('ROLE_ADMIN') or is_granted('ROLE_CURRENT_COURSE_TEACHER') or is_granted('ROLE_CURRENT_COURSE_SESSION_TEACHER')",
             read: false,
             name: 'reorder_learning_path_builder_items',
+            parameters: [
+                'cid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Course identifier',
+                    required: true,
+                ),
+                'sid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Session identifier',
+                ),
+                'gid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Group identifier',
+                ),
+            ],
             processor: LearningPathBuilderMutationProcessor::class,
         ),
     ],

--- a/src/CoreBundle/ApiResource/LearningPath/LearningPathBuilderPrerequisiteInput.php
+++ b/src/CoreBundle/ApiResource/LearningPath/LearningPathBuilderPrerequisiteInput.php
@@ -9,6 +9,7 @@ namespace Chamilo\CoreBundle\ApiResource\LearningPath;
 use ApiPlatform\Metadata\ApiProperty;
 use ApiPlatform\Metadata\ApiResource;
 use ApiPlatform\Metadata\Post;
+use ApiPlatform\Metadata\QueryParameter;
 use Chamilo\CoreBundle\State\LearningPath\LearningPathBuilderMutationProcessor;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Serializer\Attribute\Groups;
@@ -23,6 +24,21 @@ use Symfony\Component\Serializer\Attribute\Groups;
             output: false,
             read: false,
             name: 'update_learning_path_builder_prerequisites',
+            parameters: [
+                'cid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Course identifier',
+                    required: true,
+                ),
+                'sid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Session identifier',
+                ),
+                'gid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Group identifier',
+                ),
+            ],
             processor: LearningPathBuilderMutationProcessor::class,
         ),
     ],

--- a/src/CoreBundle/ApiResource/LearningPath/LearningPathBuilderQuickTestInput.php
+++ b/src/CoreBundle/ApiResource/LearningPath/LearningPathBuilderQuickTestInput.php
@@ -9,6 +9,7 @@ namespace Chamilo\CoreBundle\ApiResource\LearningPath;
 use ApiPlatform\Metadata\ApiProperty;
 use ApiPlatform\Metadata\ApiResource;
 use ApiPlatform\Metadata\Post;
+use ApiPlatform\Metadata\QueryParameter;
 use Chamilo\CoreBundle\State\LearningPath\LearningPathQuickTestProcessor;
 use Symfony\Component\Serializer\Attribute\Groups;
 
@@ -20,6 +21,21 @@ use Symfony\Component\Serializer\Attribute\Groups;
             security: "is_granted('ROLE_ADMIN') or is_granted('ROLE_CURRENT_COURSE_TEACHER') or is_granted('ROLE_CURRENT_COURSE_SESSION_TEACHER')",
             read: false,
             name: 'create_learning_path_builder_quick_test',
+            parameters: [
+                'cid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Course identifier',
+                    required: true,
+                ),
+                'sid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Session identifier',
+                ),
+                'gid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Group identifier',
+                ),
+            ],
             processor: LearningPathQuickTestProcessor::class,
         ),
     ],

--- a/src/CoreBundle/ApiResource/LearningPath/LearningPathBuilderResourceInput.php
+++ b/src/CoreBundle/ApiResource/LearningPath/LearningPathBuilderResourceInput.php
@@ -9,6 +9,7 @@ namespace Chamilo\CoreBundle\ApiResource\LearningPath;
 use ApiPlatform\Metadata\ApiProperty;
 use ApiPlatform\Metadata\ApiResource;
 use ApiPlatform\Metadata\Post;
+use ApiPlatform\Metadata\QueryParameter;
 use Chamilo\CoreBundle\State\LearningPath\LearningPathBuilderMutationProcessor;
 use Symfony\Component\Serializer\Attribute\Groups;
 
@@ -20,6 +21,21 @@ use Symfony\Component\Serializer\Attribute\Groups;
             security: "is_granted('ROLE_ADMIN') or is_granted('ROLE_CURRENT_COURSE_TEACHER') or is_granted('ROLE_CURRENT_COURSE_SESSION_TEACHER')",
             read: false,
             name: 'add_learning_path_builder_resource',
+            parameters: [
+                'cid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Course identifier',
+                    required: true,
+                ),
+                'sid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Session identifier',
+                ),
+                'gid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Group identifier',
+                ),
+            ],
             processor: LearningPathBuilderMutationProcessor::class,
         ),
     ],

--- a/src/CoreBundle/ApiResource/LearningPath/LearningPathCategoryInput.php
+++ b/src/CoreBundle/ApiResource/LearningPath/LearningPathCategoryInput.php
@@ -10,6 +10,7 @@ use ApiPlatform\Metadata\ApiProperty;
 use ApiPlatform\Metadata\ApiResource;
 use ApiPlatform\Metadata\Patch;
 use ApiPlatform\Metadata\Post;
+use ApiPlatform\Metadata\QueryParameter;
 use Chamilo\CoreBundle\State\LearningPath\LearningPathCategoryMutationProcessor;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Serializer\Attribute\Groups;
@@ -21,6 +22,21 @@ use Symfony\Component\Serializer\Attribute\Groups;
             status: Response::HTTP_NO_CONTENT,
             security: "is_granted('ROLE_ADMIN') or is_granted('ROLE_CURRENT_COURSE_TEACHER') or is_granted('ROLE_CURRENT_COURSE_SESSION_TEACHER')",
             output: false,
+            parameters: [
+                'cid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Course identifier',
+                    required: true,
+                ),
+                'sid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Session identifier',
+                ),
+                'gid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Group identifier',
+                ),
+            ],
             processor: LearningPathCategoryMutationProcessor::class,
         ),
         new Post(
@@ -30,6 +46,21 @@ use Symfony\Component\Serializer\Attribute\Groups;
             security: "is_granted('ROLE_ADMIN') or is_granted('ROLE_CURRENT_COURSE_TEACHER') or is_granted('ROLE_CURRENT_COURSE_SESSION_TEACHER')",
             output: false,
             read: false,
+            parameters: [
+                'cid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Course identifier',
+                    required: true,
+                ),
+                'sid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Session identifier',
+                ),
+                'gid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Group identifier',
+                ),
+            ],
             processor: LearningPathCategoryMutationProcessor::class,
         ),
         new Patch(
@@ -38,6 +69,21 @@ use Symfony\Component\Serializer\Attribute\Groups;
             status: Response::HTTP_NO_CONTENT,
             security: "is_granted('ROLE_ADMIN') or is_granted('ROLE_CURRENT_COURSE_TEACHER') or is_granted('ROLE_CURRENT_COURSE_SESSION_TEACHER')",
             output: false,
+            parameters: [
+                'cid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Course identifier',
+                    required: true,
+                ),
+                'sid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Session identifier',
+                ),
+                'gid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Group identifier',
+                ),
+            ],
             processor: LearningPathCategoryMutationProcessor::class,
         ),
     ],

--- a/src/CoreBundle/ApiResource/LearningPath/LearningPathCategorySubscription.php
+++ b/src/CoreBundle/ApiResource/LearningPath/LearningPathCategorySubscription.php
@@ -10,6 +10,7 @@ use ApiPlatform\Metadata\ApiProperty;
 use ApiPlatform\Metadata\ApiResource;
 use ApiPlatform\Metadata\Get;
 use ApiPlatform\Metadata\Patch;
+use ApiPlatform\Metadata\QueryParameter;
 use Chamilo\CoreBundle\State\LearningPath\LearningPathCategorySubscriptionProcessor;
 use Chamilo\CoreBundle\State\LearningPath\LearningPathCategorySubscriptionProvider;
 use Symfony\Component\HttpFoundation\Response;
@@ -21,6 +22,21 @@ use Symfony\Component\Serializer\Attribute\Groups;
             uriTemplate: '/learning_path_categories/{categoryId}/subscriptions',
             requirements: ['categoryId' => '\d+'],
             security: "is_granted('ROLE_ADMIN') or is_granted('ROLE_CURRENT_COURSE_TEACHER') or is_granted('ROLE_CURRENT_COURSE_SESSION_TEACHER')",
+            parameters: [
+                'cid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Course identifier',
+                    required: true,
+                ),
+                'sid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Session identifier',
+                ),
+                'gid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Group identifier',
+                ),
+            ],
             provider: LearningPathCategorySubscriptionProvider::class,
         ),
         new Patch(
@@ -30,6 +46,21 @@ use Symfony\Component\Serializer\Attribute\Groups;
             security: "is_granted('ROLE_ADMIN') or is_granted('ROLE_CURRENT_COURSE_TEACHER') or is_granted('ROLE_CURRENT_COURSE_SESSION_TEACHER')",
             output: false,
             read: false,
+            parameters: [
+                'cid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Course identifier',
+                    required: true,
+                ),
+                'sid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Session identifier',
+                ),
+                'gid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Group identifier',
+                ),
+            ],
             processor: LearningPathCategorySubscriptionProcessor::class,
         ),
     ],

--- a/src/CoreBundle/ApiResource/LearningPath/LearningPathConfiguration.php
+++ b/src/CoreBundle/ApiResource/LearningPath/LearningPathConfiguration.php
@@ -9,6 +9,7 @@ namespace Chamilo\CoreBundle\ApiResource\LearningPath;
 use ApiPlatform\Metadata\ApiResource;
 use ApiPlatform\Metadata\Get;
 use ApiPlatform\Metadata\Post;
+use ApiPlatform\Metadata\QueryParameter;
 use Chamilo\CoreBundle\Controller\Api\LearningPathConfigurationAction;
 use Chamilo\CoreBundle\State\LearningPath\LearningPathConfigurationProcessor;
 use Chamilo\CoreBundle\State\LearningPath\LearningPathConfigurationProvider;
@@ -19,6 +20,21 @@ use Symfony\Component\Serializer\Attribute\Groups;
         new Get(
             uriTemplate: '/learning_paths/configuration',
             security: "is_granted('ROLE_ADMIN') or is_granted('ROLE_CURRENT_COURSE_TEACHER') or is_granted('ROLE_CURRENT_COURSE_SESSION_TEACHER')",
+            parameters: [
+                'cid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Course identifier',
+                    required: true,
+                ),
+                'sid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Session identifier',
+                ),
+                'gid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Group identifier',
+                ),
+            ],
             provider: LearningPathConfigurationProvider::class,
         ),
         new Get(
@@ -26,6 +42,21 @@ use Symfony\Component\Serializer\Attribute\Groups;
             requirements: ['id' => '\d+'],
             security: "is_granted('ROLE_ADMIN') or is_granted('ROLE_CURRENT_COURSE_TEACHER') or is_granted('ROLE_CURRENT_COURSE_SESSION_TEACHER')",
             name: 'get_learning_path_configuration',
+            parameters: [
+                'cid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Course identifier',
+                    required: true,
+                ),
+                'sid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Session identifier',
+                ),
+                'gid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Group identifier',
+                ),
+            ],
             provider: LearningPathConfigurationProvider::class,
         ),
         new Post(
@@ -34,6 +65,21 @@ use Symfony\Component\Serializer\Attribute\Groups;
             security: "is_granted('ROLE_ADMIN') or is_granted('ROLE_CURRENT_COURSE_TEACHER') or is_granted('ROLE_CURRENT_COURSE_SESSION_TEACHER')",
             read: false,
             deserialize: false,
+            parameters: [
+                'cid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Course identifier',
+                    required: true,
+                ),
+                'sid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Session identifier',
+                ),
+                'gid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Group identifier',
+                ),
+            ],
             processor: LearningPathConfigurationProcessor::class,
         ),
         new Post(
@@ -44,6 +90,21 @@ use Symfony\Component\Serializer\Attribute\Groups;
             read: false,
             deserialize: false,
             name: 'update_learning_path_configuration',
+            parameters: [
+                'cid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Course identifier',
+                    required: true,
+                ),
+                'sid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Session identifier',
+                ),
+                'gid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Group identifier',
+                ),
+            ],
             processor: LearningPathConfigurationProcessor::class,
         ),
     ],

--- a/src/CoreBundle/ApiResource/LearningPath/LearningPathManagementInput.php
+++ b/src/CoreBundle/ApiResource/LearningPath/LearningPathManagementInput.php
@@ -9,6 +9,7 @@ namespace Chamilo\CoreBundle\ApiResource\LearningPath;
 use ApiPlatform\Metadata\ApiProperty;
 use ApiPlatform\Metadata\ApiResource;
 use ApiPlatform\Metadata\Post;
+use ApiPlatform\Metadata\QueryParameter;
 use Chamilo\CoreBundle\State\LearningPath\LearningPathManagementProcessor;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Serializer\Attribute\Groups;
@@ -23,6 +24,21 @@ use Symfony\Component\Serializer\Attribute\Groups;
             output: false,
             read: false,
             name: 'manage_learning_path',
+            parameters: [
+                'cid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Course identifier',
+                    required: true,
+                ),
+                'sid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Session identifier',
+                ),
+                'gid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Group identifier',
+                ),
+            ],
             processor: LearningPathManagementProcessor::class,
         ),
     ],

--- a/src/CoreBundle/ApiResource/LearningPath/LearningPathReporting.php
+++ b/src/CoreBundle/ApiResource/LearningPath/LearningPathReporting.php
@@ -10,6 +10,7 @@ use ApiPlatform\Metadata\ApiProperty;
 use ApiPlatform\Metadata\ApiResource;
 use ApiPlatform\Metadata\Get;
 use ApiPlatform\Metadata\Post;
+use ApiPlatform\Metadata\QueryParameter;
 use Chamilo\CoreBundle\State\LearningPath\LearningPathReportingProvider;
 use Chamilo\CoreBundle\State\LearningPath\LearningPathReportingRecalculateProcessor;
 use Chamilo\CoreBundle\State\LearningPath\LearningPathReportingResetProcessor;
@@ -22,6 +23,21 @@ use Symfony\Component\Serializer\Attribute\Groups;
             uriTemplate: '/learning_paths/{lpId}/reporting',
             requirements: ['lpId' => '\d+'],
             name: 'get_learning_path_reporting',
+            parameters: [
+                'cid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Course identifier',
+                    required: true,
+                ),
+                'sid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Session identifier',
+                ),
+                'gid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Group identifier',
+                ),
+            ],
             provider: LearningPathReportingProvider::class,
             security: "is_granted('ROLE_ADMIN') or is_granted('ROLE_CURRENT_COURSE_TEACHER') or is_granted('ROLE_CURRENT_COURSE_SESSION_TEACHER')",
         ),
@@ -34,6 +50,21 @@ use Symfony\Component\Serializer\Attribute\Groups;
             output: false,
             denormalizationContext: ['groups' => ['learning_path_reporting_recalculate:write']],
             name: 'recalculate_learning_path_reporting',
+            parameters: [
+                'cid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Course identifier',
+                    required: true,
+                ),
+                'sid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Session identifier',
+                ),
+                'gid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Group identifier',
+                ),
+            ],
             processor: LearningPathReportingRecalculateProcessor::class,
             security: "is_granted('ROLE_ADMIN') or is_granted('ROLE_CURRENT_COURSE_TEACHER') or is_granted('ROLE_CURRENT_COURSE_SESSION_TEACHER')",
         ),
@@ -46,6 +77,21 @@ use Symfony\Component\Serializer\Attribute\Groups;
             output: false,
             read: false,
             name: 'reset_learning_path_reporting',
+            parameters: [
+                'cid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Course identifier',
+                    required: true,
+                ),
+                'sid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Session identifier',
+                ),
+                'gid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Group identifier',
+                ),
+            ],
             processor: LearningPathReportingResetProcessor::class,
         ),
     ],

--- a/src/CoreBundle/ApiResource/LearningPath/LearningPathRuntime.php
+++ b/src/CoreBundle/ApiResource/LearningPath/LearningPathRuntime.php
@@ -9,6 +9,7 @@ namespace Chamilo\CoreBundle\ApiResource\LearningPath;
 use ApiPlatform\Metadata\ApiProperty;
 use ApiPlatform\Metadata\ApiResource;
 use ApiPlatform\Metadata\Get;
+use ApiPlatform\Metadata\QueryParameter;
 use Chamilo\CoreBundle\State\LearningPath\LearningPathRuntimeProvider;
 use Symfony\Component\Serializer\Attribute\Groups;
 
@@ -19,6 +20,21 @@ use Symfony\Component\Serializer\Attribute\Groups;
             requirements: ['lpId' => '\d+'],
             security: "is_granted('ROLE_ADMIN') or is_granted('ROLE_CURRENT_COURSE_STUDENT') or is_granted('ROLE_CURRENT_COURSE_SESSION_STUDENT') or is_granted('ROLE_CURRENT_COURSE_GROUP_STUDENT')",
             name: 'get_learning_path_runtime',
+            parameters: [
+                'cid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Course identifier',
+                    required: true,
+                ),
+                'sid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Session identifier',
+                ),
+                'gid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Group identifier',
+                ),
+            ],
             provider: LearningPathRuntimeProvider::class,
         ),
     ],

--- a/src/CoreBundle/ApiResource/LearningPath/LearningPathRuntimeItemInput.php
+++ b/src/CoreBundle/ApiResource/LearningPath/LearningPathRuntimeItemInput.php
@@ -9,6 +9,7 @@ namespace Chamilo\CoreBundle\ApiResource\LearningPath;
 use ApiPlatform\Metadata\ApiProperty;
 use ApiPlatform\Metadata\ApiResource;
 use ApiPlatform\Metadata\Post;
+use ApiPlatform\Metadata\QueryParameter;
 use Chamilo\CoreBundle\State\LearningPath\LearningPathRuntimeItemProcessor;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Serializer\Attribute\Groups;
@@ -23,6 +24,17 @@ use Symfony\Component\Serializer\Attribute\Groups;
             output: false,
             read: false,
             name: 'open_learning_path_runtime_item',
+            parameters: [
+                'cid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Course identifier',
+                    required: true,
+                ),
+                'sid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Session identifier',
+                ),
+            ],
             processor: LearningPathRuntimeItemProcessor::class,
         ),
     ],

--- a/src/CoreBundle/ApiResource/LearningPath/LearningPathRuntimeRestartInput.php
+++ b/src/CoreBundle/ApiResource/LearningPath/LearningPathRuntimeRestartInput.php
@@ -9,6 +9,7 @@ namespace Chamilo\CoreBundle\ApiResource\LearningPath;
 use ApiPlatform\Metadata\ApiProperty;
 use ApiPlatform\Metadata\ApiResource;
 use ApiPlatform\Metadata\Post;
+use ApiPlatform\Metadata\QueryParameter;
 use Chamilo\CoreBundle\State\LearningPath\LearningPathRuntimeRestartProcessor;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Serializer\Attribute\Groups;
@@ -23,6 +24,17 @@ use Symfony\Component\Serializer\Attribute\Groups;
             output: false,
             read: false,
             name: 'restart_learning_path_runtime',
+            parameters: [
+                'cid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Course identifier',
+                    required: true,
+                ),
+                'sid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Session identifier',
+                ),
+            ],
             processor: LearningPathRuntimeRestartProcessor::class,
         ),
     ],

--- a/src/CoreBundle/ApiResource/LearningPath/LearningPathRuntimeSyncInput.php
+++ b/src/CoreBundle/ApiResource/LearningPath/LearningPathRuntimeSyncInput.php
@@ -9,6 +9,7 @@ namespace Chamilo\CoreBundle\ApiResource\LearningPath;
 use ApiPlatform\Metadata\ApiProperty;
 use ApiPlatform\Metadata\ApiResource;
 use ApiPlatform\Metadata\Post;
+use ApiPlatform\Metadata\QueryParameter;
 use Chamilo\CoreBundle\State\LearningPath\LearningPathRuntimeSyncProcessor;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Serializer\Attribute\Groups;
@@ -23,6 +24,17 @@ use Symfony\Component\Serializer\Attribute\Groups;
             output: false,
             read: false,
             name: 'sync_learning_path_runtime',
+            parameters: [
+                'cid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Course identifier',
+                    required: true,
+                ),
+                'sid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Session identifier',
+                ),
+            ],
             processor: LearningPathRuntimeSyncProcessor::class,
         ),
     ],

--- a/src/CoreBundle/ApiResource/LearningPath/LearningPathScormCommitInput.php
+++ b/src/CoreBundle/ApiResource/LearningPath/LearningPathScormCommitInput.php
@@ -9,6 +9,7 @@ namespace Chamilo\CoreBundle\ApiResource\LearningPath;
 use ApiPlatform\Metadata\ApiProperty;
 use ApiPlatform\Metadata\ApiResource;
 use ApiPlatform\Metadata\Post;
+use ApiPlatform\Metadata\QueryParameter;
 use Chamilo\CoreBundle\State\LearningPath\LearningPathScormCommitProcessor;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Serializer\Attribute\Groups;
@@ -23,6 +24,17 @@ use Symfony\Component\Serializer\Attribute\Groups;
             output: false,
             read: false,
             name: 'commit_learning_path_scorm_runtime',
+            parameters: [
+                'cid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Course identifier',
+                    required: true,
+                ),
+                'sid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Session identifier',
+                ),
+            ],
             processor: LearningPathScormCommitProcessor::class,
         ),
     ],

--- a/src/CoreBundle/ApiResource/LearningPath/LearningPathScormImport.php
+++ b/src/CoreBundle/ApiResource/LearningPath/LearningPathScormImport.php
@@ -8,6 +8,7 @@ namespace Chamilo\CoreBundle\ApiResource\LearningPath;
 
 use ApiPlatform\Metadata\ApiResource;
 use ApiPlatform\Metadata\Post;
+use ApiPlatform\Metadata\QueryParameter;
 use ApiPlatform\OpenApi\Model\Operation;
 use ApiPlatform\OpenApi\Model\RequestBody;
 use ArrayObject;
@@ -52,6 +53,21 @@ use Chamilo\CoreBundle\State\LearningPath\LearningPathScormImportProcessor;
             output: false,
             read: false,
             deserialize: false,
+            parameters: [
+                'cid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Course identifier',
+                    required: true,
+                ),
+                'sid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Session identifier',
+                ),
+                'gid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Group identifier',
+                ),
+            ],
             processor: LearningPathScormImportProcessor::class,
         ),
     ],

--- a/src/CoreBundle/ApiResource/LearningPath/LearningPathScormUpdate.php
+++ b/src/CoreBundle/ApiResource/LearningPath/LearningPathScormUpdate.php
@@ -8,6 +8,7 @@ namespace Chamilo\CoreBundle\ApiResource\LearningPath;
 
 use ApiPlatform\Metadata\ApiResource;
 use ApiPlatform\Metadata\Post;
+use ApiPlatform\Metadata\QueryParameter;
 use ApiPlatform\OpenApi\Model\Operation;
 use ApiPlatform\OpenApi\Model\RequestBody;
 use ArrayObject;
@@ -45,6 +46,21 @@ use Chamilo\CoreBundle\State\LearningPath\LearningPathScormUpdateProcessor;
             output: false,
             read: false,
             deserialize: false,
+            parameters: [
+                'cid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Course identifier',
+                    required: true,
+                ),
+                'sid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Session identifier',
+                ),
+                'gid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Group identifier',
+                ),
+            ],
             processor: LearningPathScormUpdateProcessor::class,
         ),
     ],

--- a/src/CoreBundle/ApiResource/Portfolio/PortfolioAction.php
+++ b/src/CoreBundle/ApiResource/Portfolio/PortfolioAction.php
@@ -9,6 +9,7 @@ namespace Chamilo\CoreBundle\ApiResource\Portfolio;
 use ApiPlatform\Metadata\ApiProperty;
 use ApiPlatform\Metadata\ApiResource;
 use ApiPlatform\Metadata\Post;
+use ApiPlatform\Metadata\QueryParameter;
 use ApiPlatform\OpenApi\Model\Operation;
 use Chamilo\CoreBundle\State\Portfolio\PortfolioActionProcessor;
 use Symfony\Component\Serializer\Attribute\Groups;
@@ -23,6 +24,16 @@ use Symfony\Component\Serializer\Attribute\Groups;
             security: "is_granted('ROLE_USER')",
             read: false,
             name: 'post_portfolio_item_action',
+            parameters: [
+                'cid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Course identifier',
+                ),
+                'sid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Session identifier',
+                ),
+            ],
             processor: PortfolioActionProcessor::class,
         ),
     ],

--- a/src/CoreBundle/ApiResource/Portfolio/PortfolioCommentAction.php
+++ b/src/CoreBundle/ApiResource/Portfolio/PortfolioCommentAction.php
@@ -9,6 +9,7 @@ namespace Chamilo\CoreBundle\ApiResource\Portfolio;
 use ApiPlatform\Metadata\ApiProperty;
 use ApiPlatform\Metadata\ApiResource;
 use ApiPlatform\Metadata\Post;
+use ApiPlatform\Metadata\QueryParameter;
 use ApiPlatform\OpenApi\Model\Operation;
 use Chamilo\CoreBundle\State\Portfolio\PortfolioCommentActionProcessor;
 use Symfony\Component\Serializer\Attribute\Groups;
@@ -23,6 +24,16 @@ use Symfony\Component\Serializer\Attribute\Groups;
             security: "is_granted('ROLE_USER')",
             read: false,
             name: 'post_portfolio_comment_action',
+            parameters: [
+                'cid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Course identifier',
+                ),
+                'sid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Session identifier',
+                ),
+            ],
             processor: PortfolioCommentActionProcessor::class,
         ),
     ],

--- a/src/CoreBundle/ApiResource/Portfolio/PortfolioCommentForm.php
+++ b/src/CoreBundle/ApiResource/Portfolio/PortfolioCommentForm.php
@@ -9,6 +9,7 @@ namespace Chamilo\CoreBundle\ApiResource\Portfolio;
 use ApiPlatform\Metadata\ApiProperty;
 use ApiPlatform\Metadata\ApiResource;
 use ApiPlatform\Metadata\Post;
+use ApiPlatform\Metadata\QueryParameter;
 use ApiPlatform\OpenApi\Model\Operation;
 use Chamilo\CoreBundle\Controller\Api\PortfolioCommentFormAction;
 use Chamilo\CoreBundle\State\Portfolio\PortfolioCommentFormProcessor;
@@ -26,6 +27,16 @@ use Symfony\Component\Serializer\Attribute\Groups;
             read: false,
             deserialize: false,
             name: 'post_portfolio_comment',
+            parameters: [
+                'cid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Course identifier',
+                ),
+                'sid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Session identifier',
+                ),
+            ],
             processor: PortfolioCommentFormProcessor::class,
         ),
         new Post(
@@ -37,6 +48,16 @@ use Symfony\Component\Serializer\Attribute\Groups;
             read: false,
             deserialize: false,
             name: 'post_portfolio_comment_edit',
+            parameters: [
+                'cid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Course identifier',
+                ),
+                'sid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Session identifier',
+                ),
+            ],
             processor: PortfolioCommentFormProcessor::class,
         ),
     ],

--- a/src/CoreBundle/ApiResource/Portfolio/PortfolioDetails.php
+++ b/src/CoreBundle/ApiResource/Portfolio/PortfolioDetails.php
@@ -9,6 +9,7 @@ namespace Chamilo\CoreBundle\ApiResource\Portfolio;
 use ApiPlatform\Metadata\ApiProperty;
 use ApiPlatform\Metadata\ApiResource;
 use ApiPlatform\Metadata\Get;
+use ApiPlatform\Metadata\QueryParameter;
 use ApiPlatform\OpenApi\Model\Operation;
 use Chamilo\CoreBundle\State\Portfolio\PortfolioDetailsProvider;
 use Symfony\Component\Serializer\Attribute\Groups;
@@ -21,6 +22,16 @@ use Symfony\Component\Serializer\Attribute\Groups;
             openapi: new Operation(summary: 'Read Portfolio progress and scoring details'),
             security: "is_granted('ROLE_USER')",
             name: 'get_portfolio_details',
+            parameters: [
+                'cid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Course identifier',
+                ),
+                'sid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Session identifier',
+                ),
+            ],
             provider: PortfolioDetailsProvider::class,
         ),
     ],

--- a/src/CoreBundle/ApiResource/Portfolio/PortfolioForm.php
+++ b/src/CoreBundle/ApiResource/Portfolio/PortfolioForm.php
@@ -10,6 +10,7 @@ use ApiPlatform\Metadata\ApiProperty;
 use ApiPlatform\Metadata\ApiResource;
 use ApiPlatform\Metadata\Get;
 use ApiPlatform\Metadata\Post;
+use ApiPlatform\Metadata\QueryParameter;
 use ApiPlatform\OpenApi\Model\Operation;
 use ApiPlatform\OpenApi\Model\Parameter;
 use Chamilo\CoreBundle\Controller\Api\PortfolioFormAction;
@@ -25,12 +26,20 @@ use Symfony\Component\Serializer\Attribute\Groups;
             openapi: new Operation(
                 summary: 'Portfolio item create or edit form data',
                 parameters: [
-                    new Parameter(name: 'cid', in: 'query', required: false, schema: ['type' => 'integer']),
-                    new Parameter(name: 'sid', in: 'query', required: false, schema: ['type' => 'integer']),
                     new Parameter(name: 'id', in: 'query', required: false, schema: ['type' => 'integer']),
                 ],
             ),
             security: "is_granted('ROLE_USER')",
+            parameters: [
+                'cid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Course identifier',
+                ),
+                'sid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Session identifier',
+                ),
+            ],
             name: 'get_portfolio_form',
             provider: PortfolioFormProvider::class,
         ),
@@ -41,6 +50,16 @@ use Symfony\Component\Serializer\Attribute\Groups;
             security: "is_granted('ROLE_USER')",
             read: false,
             deserialize: false,
+            parameters: [
+                'cid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Course identifier',
+                ),
+                'sid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Session identifier',
+                ),
+            ],
             name: 'post_portfolio_item',
             processor: PortfolioFormProcessor::class,
         ),
@@ -52,6 +71,16 @@ use Symfony\Component\Serializer\Attribute\Groups;
             security: "is_granted('ROLE_USER')",
             read: false,
             deserialize: false,
+            parameters: [
+                'cid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Course identifier',
+                ),
+                'sid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Session identifier',
+                ),
+            ],
             name: 'post_portfolio_item_edit',
             processor: PortfolioFormProcessor::class,
         ),

--- a/src/CoreBundle/ApiResource/Portfolio/PortfolioItem.php
+++ b/src/CoreBundle/ApiResource/Portfolio/PortfolioItem.php
@@ -9,6 +9,7 @@ namespace Chamilo\CoreBundle\ApiResource\Portfolio;
 use ApiPlatform\Metadata\ApiProperty;
 use ApiPlatform\Metadata\ApiResource;
 use ApiPlatform\Metadata\Get;
+use ApiPlatform\Metadata\QueryParameter;
 use ApiPlatform\OpenApi\Model\Operation;
 use ApiPlatform\OpenApi\Model\Parameter;
 use Chamilo\CoreBundle\State\Portfolio\PortfolioItemProvider;
@@ -24,12 +25,20 @@ use Symfony\Component\Serializer\Attribute\Groups;
                 summary: 'Read a portfolio item and its visible comments',
                 parameters: [
                     new Parameter(name: 'id', in: 'path', required: true, schema: ['type' => 'integer']),
-                    new Parameter(name: 'cid', in: 'query', required: false, schema: ['type' => 'integer']),
-                    new Parameter(name: 'sid', in: 'query', required: false, schema: ['type' => 'integer']),
                     new Parameter(name: 'user', in: 'query', required: false, schema: ['type' => 'integer']),
                 ],
             ),
             security: "is_granted('ROLE_USER')",
+            parameters: [
+                'cid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Course identifier',
+                ),
+                'sid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Session identifier',
+                ),
+            ],
             name: 'get_portfolio_item',
             provider: PortfolioItemProvider::class,
         ),

--- a/src/CoreBundle/ApiResource/Portfolio/PortfolioList.php
+++ b/src/CoreBundle/ApiResource/Portfolio/PortfolioList.php
@@ -9,6 +9,7 @@ namespace Chamilo\CoreBundle\ApiResource\Portfolio;
 use ApiPlatform\Metadata\ApiProperty;
 use ApiPlatform\Metadata\ApiResource;
 use ApiPlatform\Metadata\Get;
+use ApiPlatform\Metadata\QueryParameter;
 use ApiPlatform\OpenApi\Model\Operation;
 use ApiPlatform\OpenApi\Model\Parameter;
 use Chamilo\CoreBundle\State\Portfolio\PortfolioListProvider;
@@ -22,8 +23,6 @@ use Symfony\Component\Serializer\Attribute\Groups;
             openapi: new Operation(
                 summary: 'List portfolio items in course or personal context',
                 parameters: [
-                    new Parameter(name: 'cid', in: 'query', required: false, schema: ['type' => 'integer']),
-                    new Parameter(name: 'sid', in: 'query', required: false, schema: ['type' => 'integer']),
                     new Parameter(name: 'user', in: 'query', required: false, schema: ['type' => 'integer']),
                     new Parameter(name: 'date', in: 'query', required: false, schema: ['type' => 'string', 'format' => 'date']),
                     new Parameter(name: 'text', in: 'query', required: false, schema: ['type' => 'string']),
@@ -40,6 +39,16 @@ use Symfony\Component\Serializer\Attribute\Groups;
                 ],
             ),
             security: "is_granted('ROLE_USER')",
+            parameters: [
+                'cid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Course identifier',
+                ),
+                'sid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Session identifier',
+                ),
+            ],
             name: 'get_portfolio_list',
             provider: PortfolioListProvider::class,
         ),

--- a/src/CoreBundle/ApiResource/Portfolio/PortfolioManagement.php
+++ b/src/CoreBundle/ApiResource/Portfolio/PortfolioManagement.php
@@ -10,6 +10,7 @@ use ApiPlatform\Metadata\ApiProperty;
 use ApiPlatform\Metadata\ApiResource;
 use ApiPlatform\Metadata\Get;
 use ApiPlatform\Metadata\Post;
+use ApiPlatform\Metadata\QueryParameter;
 use ApiPlatform\OpenApi\Model\Operation;
 use Chamilo\CoreBundle\State\Portfolio\PortfolioManagementProcessor;
 use Chamilo\CoreBundle\State\Portfolio\PortfolioManagementProvider;
@@ -23,6 +24,16 @@ use Symfony\Component\Serializer\Attribute\Groups;
             openapi: new Operation(summary: 'Read Portfolio category and tag management data'),
             security: "is_granted('ROLE_USER')",
             name: 'get_portfolio_management',
+            parameters: [
+                'cid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Course identifier',
+                ),
+                'sid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Session identifier',
+                ),
+            ],
             provider: PortfolioManagementProvider::class,
         ),
         new Post(
@@ -31,6 +42,16 @@ use Symfony\Component\Serializer\Attribute\Groups;
             security: "is_granted('ROLE_USER')",
             read: false,
             name: 'post_portfolio_management_action',
+            parameters: [
+                'cid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Course identifier',
+                ),
+                'sid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Session identifier',
+                ),
+            ],
             processor: PortfolioManagementProcessor::class,
         ),
     ],

--- a/src/CoreBundle/Controller/CStudioAiController.php
+++ b/src/CoreBundle/Controller/CStudioAiController.php
@@ -32,6 +32,13 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
 use Throwable;
 use TypeError;
 
+use const FILEINFO_MIME_TYPE;
+use const FILTER_FLAG_NO_PRIV_RANGE;
+use const FILTER_FLAG_NO_RES_RANGE;
+use const FILTER_VALIDATE_IP;
+use const FILTER_VALIDATE_URL;
+use const JSON_THROW_ON_ERROR;
+
 final class CStudioAiController extends AbstractController
 {
     private const int MAX_IMAGE_BYTES = 10 * 1024 * 1024;
@@ -308,7 +315,7 @@ final class CStudioAiController extends AbstractController
 
         $generationPrompt = \sprintf(
             "Write educational content in %s about the following request:\n%s\n\n"
-            ."Use approximately %d words. Return plain text only, with short readable paragraphs. "
+            .'Use approximately %d words. Return plain text only, with short readable paragraphs. '
             .'Do not include Markdown fences, a title unless requested, or comments about the generation process.',
             $language,
             $prompt,

--- a/src/CoreBundle/Controller/SecurityController.php
+++ b/src/CoreBundle/Controller/SecurityController.php
@@ -337,7 +337,7 @@ class SecurityController extends AbstractController
         // describe the server-side inactivity limit. In that standard Symfony
         // configuration, use PHP's session retention lifetime instead.
         if ($lifetime <= 1) {
-            $lifetime = max(0, (int) ini_get('session.gc_maxlifetime'));
+            $lifetime = max(0, (int) \ini_get('session.gc_maxlifetime'));
         }
 
         $configuredWarningSeconds = (int) $this->settingsManager->getSetting(

--- a/src/CoreBundle/Controller/UserController.php
+++ b/src/CoreBundle/Controller/UserController.php
@@ -31,8 +31,7 @@ class UserController extends AbstractController
         Request $request,
         EntityManagerInterface $em,
         CourseClassManager $courseClassManager,
-    ): Response
-    {
+    ): Response {
         $this->denyAccessUnlessGranted('IS_AUTHENTICATED_FULLY');
 
         $usergroupId = $request->query->getInt('usergroup');

--- a/src/CoreBundle/State/Ai/WysiwygTranslationAccessHelperTrait.php
+++ b/src/CoreBundle/State/Ai/WysiwygTranslationAccessHelperTrait.php
@@ -1,0 +1,41 @@
+<?php
+
+/* For licensing terms, see /license.txt */
+
+declare(strict_types=1);
+
+namespace Chamilo\CoreBundle\State\Ai;
+
+use Chamilo\CoreBundle\Entity\Course;
+use Chamilo\CoreBundle\Helpers\CidReqHelper;
+use Chamilo\CoreBundle\Security\Authorization\Voter\CourseVoter;
+use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+
+trait WysiwygTranslationAccessHelperTrait
+{
+    private function resolveCourseAndAssertAccess(CidReqHelper $cidReqHelper, Security $security): ?Course
+    {
+        $courseId = (int) ($cidReqHelper->getCourseId() ?? 0);
+        if ($courseId <= 0) {
+            if (!$security->isGranted('ROLE_ADMIN')) {
+                throw new AccessDeniedHttpException('Only administrators may use AI WYSIWYG translation outside a course.');
+            }
+
+            return null;
+        }
+
+        $course = $cidReqHelper->getDoctrineCourseEntity();
+        if (!$course instanceof Course) {
+            throw new NotFoundHttpException('The course was not found.');
+        }
+        if (!$security->isGranted(CourseVoter::EDIT, $course)
+            && !$security->isGranted('ROLE_CURRENT_COURSE_SESSION_TEACHER')
+        ) {
+            throw new AccessDeniedHttpException('You are not allowed to translate content in this course.');
+        }
+
+        return $course;
+    }
+}

--- a/src/CoreBundle/State/Ai/WysiwygTranslationProcessor.php
+++ b/src/CoreBundle/State/Ai/WysiwygTranslationProcessor.php
@@ -9,17 +9,12 @@ namespace Chamilo\CoreBundle\State\Ai;
 use ApiPlatform\Metadata\Operation;
 use ApiPlatform\State\ProcessorInterface;
 use Chamilo\CoreBundle\ApiResource\Ai\WysiwygTranslation;
-use Chamilo\CoreBundle\Entity\Course;
-use Chamilo\CoreBundle\Security\Authorization\Voter\CourseVoter;
+use Chamilo\CoreBundle\Helpers\CidReqHelper;
 use Chamilo\CoreBundle\Service\Ai\WysiwygTranslationService;
-use Doctrine\ORM\EntityManagerInterface;
 use RuntimeException;
 use Symfony\Bundle\SecurityBundle\Security;
-use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
-use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\HttpKernel\Exception\UnprocessableEntityHttpException;
 use Symfony\Component\Security\Csrf\CsrfToken;
 use Symfony\Component\Security\Csrf\CsrfTokenManagerInterface;
@@ -27,9 +22,10 @@ use Symfony\Component\Security\Csrf\CsrfTokenManagerInterface;
 /** @implements ProcessorInterface<WysiwygTranslation, WysiwygTranslation> */
 final readonly class WysiwygTranslationProcessor implements ProcessorInterface
 {
+    use WysiwygTranslationAccessHelperTrait;
+
     public function __construct(
-        private RequestStack $requestStack,
-        private EntityManagerInterface $entityManager,
+        private CidReqHelper $cidReqHelper,
         private Security $security,
         private CsrfTokenManagerInterface $csrfTokenManager,
         private WysiwygTranslationService $translationService,
@@ -49,12 +45,7 @@ final readonly class WysiwygTranslationProcessor implements ProcessorInterface
             throw new BadRequestHttpException('The WYSIWYG translation payload is invalid.');
         }
 
-        $request = $this->requestStack->getCurrentRequest();
-        if (!$request instanceof Request) {
-            throw new BadRequestHttpException('The current request is required.');
-        }
-
-        $course = $this->resolveCourseAndAssertAccess($request);
+        $course = $this->resolveCourseAndAssertAccess($this->cidReqHelper, $this->security);
         if (!$this->translationService->isEnabled()) {
             throw new AccessDeniedHttpException('AI WYSIWYG translation is disabled.');
         }
@@ -86,7 +77,7 @@ final readonly class WysiwygTranslationProcessor implements ProcessorInterface
                 activeLanguages: $activeLanguages,
                 provider: $data->provider,
                 courseId: (int) ($course?->getId() ?? 0),
-                sessionId: $request->query->getInt('sid'),
+                sessionId: (int) ($this->cidReqHelper->getSessionId() ?? 0),
             );
         } catch (RuntimeException $exception) {
             throw new UnprocessableEntityHttpException($exception->getMessage(), $exception);
@@ -100,29 +91,5 @@ final readonly class WysiwygTranslationProcessor implements ProcessorInterface
         $result->skippedLanguages = $translation['skipped'];
 
         return $result;
-    }
-
-    private function resolveCourseAndAssertAccess(Request $request): ?Course
-    {
-        $courseId = $request->query->getInt('cid');
-        if ($courseId <= 0) {
-            if (!$this->security->isGranted('ROLE_ADMIN')) {
-                throw new AccessDeniedHttpException('Only administrators may use AI WYSIWYG translation outside a course.');
-            }
-
-            return null;
-        }
-
-        $course = $this->entityManager->find(Course::class, $courseId);
-        if (!$course instanceof Course) {
-            throw new NotFoundHttpException('The course was not found.');
-        }
-        if (!$this->security->isGranted(CourseVoter::EDIT, $course)
-            && !$this->security->isGranted('ROLE_CURRENT_COURSE_SESSION_TEACHER')
-        ) {
-            throw new AccessDeniedHttpException('You are not allowed to translate content in this course.');
-        }
-
-        return $course;
     }
 }

--- a/src/CoreBundle/State/Ai/WysiwygTranslationProvider.php
+++ b/src/CoreBundle/State/Ai/WysiwygTranslationProvider.php
@@ -9,24 +9,18 @@ namespace Chamilo\CoreBundle\State\Ai;
 use ApiPlatform\Metadata\Operation;
 use ApiPlatform\State\ProviderInterface;
 use Chamilo\CoreBundle\ApiResource\Ai\WysiwygTranslation;
-use Chamilo\CoreBundle\Entity\Course;
-use Chamilo\CoreBundle\Security\Authorization\Voter\CourseVoter;
+use Chamilo\CoreBundle\Helpers\CidReqHelper;
 use Chamilo\CoreBundle\Service\Ai\WysiwygTranslationService;
-use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\SecurityBundle\Security;
-use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpFoundation\RequestStack;
-use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
-use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
-use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\Security\Csrf\CsrfTokenManagerInterface;
 
 /** @implements ProviderInterface<WysiwygTranslation> */
 final readonly class WysiwygTranslationProvider implements ProviderInterface
 {
+    use WysiwygTranslationAccessHelperTrait;
+
     public function __construct(
-        private RequestStack $requestStack,
-        private EntityManagerInterface $entityManager,
+        private CidReqHelper $cidReqHelper,
         private Security $security,
         private CsrfTokenManagerInterface $csrfTokenManager,
         private WysiwygTranslationService $translationService,
@@ -41,12 +35,7 @@ final readonly class WysiwygTranslationProvider implements ProviderInterface
         array $uriVariables = [],
         array $context = [],
     ): WysiwygTranslation {
-        $request = $this->requestStack->getCurrentRequest();
-        if (!$request instanceof Request) {
-            throw new BadRequestHttpException('The current request is required.');
-        }
-
-        $course = $this->resolveCourseAndAssertAccess($request);
+        $course = $this->resolveCourseAndAssertAccess($this->cidReqHelper, $this->security);
         $languages = $this->translationService->getActiveLanguages();
 
         $result = new WysiwygTranslation();
@@ -61,30 +50,6 @@ final readonly class WysiwygTranslationProvider implements ProviderInterface
         }
 
         return $result;
-    }
-
-    private function resolveCourseAndAssertAccess(Request $request): ?Course
-    {
-        $courseId = $request->query->getInt('cid');
-        if ($courseId <= 0) {
-            if (!$this->security->isGranted('ROLE_ADMIN')) {
-                throw new AccessDeniedHttpException('Only administrators may use AI WYSIWYG translation outside a course.');
-            }
-
-            return null;
-        }
-
-        $course = $this->entityManager->find(Course::class, $courseId);
-        if (!$course instanceof Course) {
-            throw new NotFoundHttpException('The course was not found.');
-        }
-        if (!$this->security->isGranted(CourseVoter::EDIT, $course)
-            && !$this->security->isGranted('ROLE_CURRENT_COURSE_SESSION_TEACHER')
-        ) {
-            throw new AccessDeniedHttpException('You are not allowed to translate content in this course.');
-        }
-
-        return $course;
     }
 
     /**

--- a/src/CoreBundle/State/CalendarEventStateProvider.php
+++ b/src/CoreBundle/State/CalendarEventStateProvider.php
@@ -12,12 +12,12 @@ use Chamilo\CoreBundle\Entity\AccessUrl;
 use Chamilo\CoreBundle\Entity\Session;
 use Chamilo\CoreBundle\Entity\User;
 use Chamilo\CoreBundle\Helpers\AccessUrlHelper;
+use Chamilo\CoreBundle\Helpers\CidReqHelper;
 use Chamilo\CoreBundle\Repository\Node\UsergroupRepository;
 use Chamilo\CoreBundle\Repository\SessionRepository;
 use Chamilo\CoreBundle\Settings\SettingsManager;
 use Chamilo\CourseBundle\Entity\CCalendarEvent;
 use Symfony\Bundle\SecurityBundle\Security;
-use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\Routing\RouterInterface;
 
 /**
@@ -32,7 +32,7 @@ final class CalendarEventStateProvider implements ProviderInterface
         private readonly Security $security,
         private readonly AccessUrlHelper $accessUrlHelper,
         private readonly SessionRepository $sessionRepository,
-        private readonly RequestStack $requestStack,
+        private readonly CidReqHelper $cidReqHelper,
         private readonly SettingsManager $settingsManager,
         private readonly RouterInterface $router,
         private readonly UsergroupRepository $usergroupRepository,
@@ -55,9 +55,8 @@ final class CalendarEventStateProvider implements ProviderInterface
         $cCalendarEvents = $this->collectionProvider->provide($operation, $uriVariables, $context);
         $userSessions = [];
 
-        $request = $this->requestStack->getMainRequest();
-        $courseId = $request->query->getInt('cid');
-        $sessionId = $request->query->getInt('sid');
+        $courseId = (int) ($this->cidReqHelper->getCourseId() ?? 0);
+        $sessionId = (int) ($this->cidReqHelper->getSessionId() ?? 0);
 
         $inCourseBase = !empty($courseId);
         $inSession = !empty($sessionId);
@@ -66,6 +65,7 @@ final class CalendarEventStateProvider implements ProviderInterface
         $inPersonalAgenda = !$inCourseBase && !$inCourseSession;
 
         if ($inPersonalAgenda
+            && $user instanceof User
             && 'true' === $this->settingsManager->getSetting('agenda.personal_calendar_show_sessions_occupation')
         ) {
             $userSessions = $this->getSessionList($user, $accessUrl, $context);

--- a/src/CoreBundle/State/CourseClass/CourseClassActionProcessor.php
+++ b/src/CoreBundle/State/CourseClass/CourseClassActionProcessor.php
@@ -31,8 +31,7 @@ final readonly class CourseClassActionProcessor implements ProcessorInterface
         Operation $operation,
         array $uriVariables = [],
         array $context = [],
-    ): CourseClassAction
-    {
+    ): CourseClassAction {
         if (!$data instanceof CourseClassAction) {
             throw new BadRequestHttpException('Invalid class action payload.');
         }

--- a/src/CoreBundle/State/CourseClass/CourseClassManager.php
+++ b/src/CoreBundle/State/CourseClass/CourseClassManager.php
@@ -429,9 +429,7 @@ final readonly class CourseClassManager
         }
 
         /** @var Usergroup[] $groups */
-        $groups = $queryBuilder->getQuery()->getResult();
-
-        return $groups;
+        return $queryBuilder->getQuery()->getResult();
     }
 
     /**
@@ -503,7 +501,7 @@ final readonly class CourseClassManager
         $sort = $sortMap[(string) $request->query->get('sort', 'title')] ?? 'title';
         $direction = 'desc' === strtolower((string) $request->query->get('order', 'asc')) ? -1 : 1;
 
-        \usort($items, static function (array $first, array $second) use ($sort, $direction): int {
+        usort($items, static function (array $first, array $second) use ($sort, $direction): int {
             $firstValue = $first[$sort] ?? '';
             $secondValue = $second[$sort] ?? '';
 

--- a/src/CoreBundle/State/CourseGroup/CourseGroupManager.php
+++ b/src/CoreBundle/State/CourseGroup/CourseGroupManager.php
@@ -195,10 +195,12 @@ final readonly class CourseGroupManager
 
         $groupQueryBuilder = $this->groupRepository->getResourcesByCourse($course, $session);
         $groupQueryBuilder->orderBy('resource.title', 'ASC');
+
         /** @var CGroup[] $groups */
         $groups = $groupQueryBuilder->getQuery()->getResult();
 
         $categoryQueryBuilder = $this->categoryRepository->getResourcesByCourse($course, $session);
+
         /** @var CGroupCategory[] $categories */
         $categories = $categoryQueryBuilder->getQuery()->getResult();
         if ([] === $categories && $allowCategories && $canManage) {
@@ -216,6 +218,7 @@ final readonly class CourseGroupManager
                 false,
                 1,
             );
+
             /** @var CGroupCategory[] $categories */
             $categories = $this->categoryRepository->getResourcesByCourse($course, $session)->getQuery()->getResult();
         }
@@ -224,8 +227,9 @@ final readonly class CourseGroupManager
         foreach (GroupManager::get_categories($course) as $position => $categoryData) {
             $categoryOrder[(int) ($categoryData['iid'] ?? 0)] = $position;
         }
-        usort($categories, static fn (CGroupCategory $first, CGroupCategory $second): int =>
-            ($categoryOrder[(int) $first->getIid()] ?? PHP_INT_MAX)
+        usort(
+            $categories,
+            static fn (CGroupCategory $first, CGroupCategory $second): int => ($categoryOrder[(int) $first->getIid()] ?? PHP_INT_MAX)
             <=> ($categoryOrder[(int) $second->getIid()] ?? PHP_INT_MAX)
         );
 
@@ -587,9 +591,7 @@ final readonly class CourseGroupManager
             && GroupManager::GROUP_PER_MEMBER_NO_LIMIT !== $groupsPerUser
             && GroupManager::get_current_max_groups_per_user($categoryId, $course->getCode()) > $groupsPerUser
         ) {
-            throw new BadRequestHttpException(
-                'The proposed group limit is lower than the number of groups currently assigned to a user.',
-            );
+            throw new BadRequestHttpException('The proposed group limit is lower than the number of groups currently assigned to a user.');
         }
 
         $arguments = [
@@ -746,9 +748,7 @@ final readonly class CourseGroupManager
             if (GroupManager::GROUP_PER_MEMBER_NO_LIMIT !== $groupsPerUser) {
                 foreach (array_diff($selectedIds, $currentMemberIds) as $userId) {
                     if (GroupManager::user_in_number_of_groups($userId, (int) ($category['iid'] ?? 0)) >= $groupsPerUser) {
-                        throw new BadRequestHttpException(
-                            'One or more selected users already reached the maximum number of groups allowed in this category.',
-                        );
+                        throw new BadRequestHttpException('One or more selected users already reached the maximum number of groups allowed in this category.');
                     }
                 }
             }
@@ -776,9 +776,7 @@ final readonly class CourseGroupManager
         $expectedIds = $selectedIds;
         sort($expectedIds);
         if ($savedIds !== $expectedIds) {
-            throw new BadRequestHttpException(
-                'The selected group members could not be saved completely. Check the group capacity and category membership limits.',
-            );
+            throw new BadRequestHttpException('The selected group members could not be saved completely. Check the group capacity and category membership limits.');
         }
     }
 
@@ -851,7 +849,6 @@ final readonly class CourseGroupManager
             }
             $tools[] = $definition;
         }
-
 
         return [
             'groupId' => $groupId,
@@ -1149,7 +1146,6 @@ final readonly class CourseGroupManager
             'spaceUrl' => $this->buildGroupSpaceUrl($course, $session, (int) $group->getIid()),
         ];
     }
-
 
     /**
      * @param array<int, array<string, mixed>> $items

--- a/src/CoreBundle/State/CourseInvitation/CourseInvitationAccessHelperTrait.php
+++ b/src/CoreBundle/State/CourseInvitation/CourseInvitationAccessHelperTrait.php
@@ -15,34 +15,14 @@ use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 
 trait CourseInvitationAccessHelperTrait
 {
+    /**
+     * CidReqListener already resolved and validated the course, so a missing entity here
+     * can only mean the request carried no course context at all.
+     */
     private function getCourse(CidReqHelper $cidReqHelper): Course
     {
-        $courseId = (int) ($cidReqHelper->getCourseId() ?? 0);
-        if ($courseId <= 0) {
-            throw new BadRequestHttpException('A valid course id is required.');
-        }
-
-        $course = $cidReqHelper->getDoctrineCourseEntity();
-        if (!$course instanceof Course) {
-            throw new BadRequestHttpException('The requested course was not found.');
-        }
-
-        return $course;
-    }
-
-    private function getSession(CidReqHelper $cidReqHelper): ?Session
-    {
-        $sessionId = (int) ($cidReqHelper->getSessionId() ?? 0);
-        if ($sessionId <= 0) {
-            return null;
-        }
-
-        $session = $cidReqHelper->getDoctrineSessionEntity();
-        if (!$session instanceof Session) {
-            throw new BadRequestHttpException('The requested session was not found.');
-        }
-
-        return $session;
+        return $cidReqHelper->getDoctrineCourseEntity()
+            ?? throw new BadRequestHttpException('A valid course id is required.');
     }
 
     private function assertSessionBelongsToCourse(?Session $session, Course $course): void

--- a/src/CoreBundle/State/CourseInvitation/CourseInvitationAccessHelperTrait.php
+++ b/src/CoreBundle/State/CourseInvitation/CourseInvitationAccessHelperTrait.php
@@ -9,21 +9,20 @@ namespace Chamilo\CoreBundle\State\CourseInvitation;
 use Chamilo\CoreBundle\Entity\Course;
 use Chamilo\CoreBundle\Entity\Session;
 use Chamilo\CoreBundle\Entity\User;
-use Doctrine\ORM\EntityManagerInterface;
+use Chamilo\CoreBundle\Helpers\CidReqHelper;
 use Symfony\Bundle\SecurityBundle\Security;
-use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 
 trait CourseInvitationAccessHelperTrait
 {
-    private function getCourse(Request $request, EntityManagerInterface $entityManager): Course
+    private function getCourse(CidReqHelper $cidReqHelper): Course
     {
-        $courseId = $request->query->getInt('cid');
+        $courseId = (int) ($cidReqHelper->getCourseId() ?? 0);
         if ($courseId <= 0) {
             throw new BadRequestHttpException('A valid course id is required.');
         }
 
-        $course = $entityManager->getRepository(Course::class)->find($courseId);
+        $course = $cidReqHelper->getDoctrineCourseEntity();
         if (!$course instanceof Course) {
             throw new BadRequestHttpException('The requested course was not found.');
         }
@@ -31,14 +30,14 @@ trait CourseInvitationAccessHelperTrait
         return $course;
     }
 
-    private function getSession(Request $request, EntityManagerInterface $entityManager): ?Session
+    private function getSession(CidReqHelper $cidReqHelper): ?Session
     {
-        $sessionId = $request->query->getInt('sid');
+        $sessionId = (int) ($cidReqHelper->getSessionId() ?? 0);
         if ($sessionId <= 0) {
             return null;
         }
 
-        $session = $entityManager->getRepository(Session::class)->find($sessionId);
+        $session = $cidReqHelper->getDoctrineSessionEntity();
         if (!$session instanceof Session) {
             throw new BadRequestHttpException('The requested session was not found.');
         }

--- a/src/CoreBundle/State/CourseInvitation/CourseInvitationProvider.php
+++ b/src/CoreBundle/State/CourseInvitation/CourseInvitationProvider.php
@@ -11,14 +11,11 @@ use ApiPlatform\Metadata\Operation;
 use ApiPlatform\State\ProviderInterface;
 use Chamilo\CoreBundle\ApiResource\CourseInvitation\CourseInvitationItem;
 use Chamilo\CoreBundle\Entity\CourseInvitation;
+use Chamilo\CoreBundle\Helpers\CidReqHelper;
 use Chamilo\CoreBundle\Repository\CourseInvitationRepository;
 use Chamilo\CoreBundle\Service\CourseInvitation\CourseInvitationTokenService;
-use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\SecurityBundle\Security;
-use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
-use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\Security\Csrf\CsrfTokenManagerInterface;
 
@@ -30,12 +27,11 @@ final readonly class CourseInvitationProvider implements ProviderInterface
     use CourseInvitationAccessHelperTrait;
 
     public function __construct(
-        private RequestStack $requestStack,
-        private EntityManagerInterface $entityManager,
         private CourseInvitationRepository $invitationRepository,
         private Security $security,
         private CsrfTokenManagerInterface $csrfTokenManager,
         private CourseInvitationTokenService $tokenService,
+        private CidReqHelper $cidReqHelper,
     ) {}
 
     /**
@@ -44,13 +40,8 @@ final readonly class CourseInvitationProvider implements ProviderInterface
      */
     public function provide(Operation $operation, array $uriVariables = [], array $context = []): array|CourseInvitationItem|null
     {
-        $request = $this->requestStack->getCurrentRequest();
-        if (!$request instanceof Request) {
-            throw new BadRequestHttpException('The current request is required.');
-        }
-
-        $course = $this->getCourse($request, $this->entityManager);
-        $session = $this->getSession($request, $this->entityManager);
+        $course = $this->getCourse($this->cidReqHelper);
+        $session = $this->getSession($this->cidReqHelper);
         $this->assertSessionBelongsToCourse($session, $course);
 
         if (!$this->canManageCourseInvitations($this->security, $course, $session)) {

--- a/src/CoreBundle/State/CourseInvitation/CourseInvitationProvider.php
+++ b/src/CoreBundle/State/CourseInvitation/CourseInvitationProvider.php
@@ -41,7 +41,7 @@ final readonly class CourseInvitationProvider implements ProviderInterface
     public function provide(Operation $operation, array $uriVariables = [], array $context = []): array|CourseInvitationItem|null
     {
         $course = $this->getCourse($this->cidReqHelper);
-        $session = $this->getSession($this->cidReqHelper);
+        $session = $this->cidReqHelper->getDoctrineSessionEntity();
         $this->assertSessionBelongsToCourse($session, $course);
 
         if (!$this->canManageCourseInvitations($this->security, $course, $session)) {

--- a/src/CoreBundle/State/CourseInvitation/CourseInvitationRevokeProcessor.php
+++ b/src/CoreBundle/State/CourseInvitation/CourseInvitationRevokeProcessor.php
@@ -11,9 +11,9 @@ use ApiPlatform\State\ProcessorInterface;
 use Chamilo\CoreBundle\ApiResource\CourseInvitation\CourseInvitationItem;
 use Chamilo\CoreBundle\Entity\CourseInvitation;
 use Chamilo\CoreBundle\Entity\User;
+use Chamilo\CoreBundle\Helpers\CidReqHelper;
 use Chamilo\CoreBundle\Repository\CourseInvitationRepository;
 use Chamilo\CoreBundle\Service\CourseInvitation\CourseInvitationTokenService;
-use Doctrine\ORM\EntityManagerInterface;
 use JsonException;
 use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\HttpFoundation\Request;
@@ -36,11 +36,11 @@ final readonly class CourseInvitationRevokeProcessor implements ProcessorInterfa
 
     public function __construct(
         private RequestStack $requestStack,
-        private EntityManagerInterface $entityManager,
         private CourseInvitationRepository $invitationRepository,
         private Security $security,
         private CsrfTokenManagerInterface $csrfTokenManager,
         private CourseInvitationTokenService $tokenService,
+        private CidReqHelper $cidReqHelper,
     ) {}
 
     /**
@@ -54,8 +54,8 @@ final readonly class CourseInvitationRevokeProcessor implements ProcessorInterfa
             throw new BadRequestHttpException('The current request is required.');
         }
 
-        $course = $this->getCourse($request, $this->entityManager);
-        $session = $this->getSession($request, $this->entityManager);
+        $course = $this->getCourse($this->cidReqHelper);
+        $session = $this->getSession($this->cidReqHelper);
         $this->assertSessionBelongsToCourse($session, $course);
 
         if (!$this->canManageCourseInvitations($this->security, $course, $session)) {

--- a/src/CoreBundle/State/CourseInvitation/CourseInvitationRevokeProcessor.php
+++ b/src/CoreBundle/State/CourseInvitation/CourseInvitationRevokeProcessor.php
@@ -55,7 +55,7 @@ final readonly class CourseInvitationRevokeProcessor implements ProcessorInterfa
         }
 
         $course = $this->getCourse($this->cidReqHelper);
-        $session = $this->getSession($this->cidReqHelper);
+        $session = $this->cidReqHelper->getDoctrineSessionEntity();
         $this->assertSessionBelongsToCourse($session, $course);
 
         if (!$this->canManageCourseInvitations($this->security, $course, $session)) {

--- a/src/CoreBundle/State/CourseInvitation/CourseInvitationSendProcessor.php
+++ b/src/CoreBundle/State/CourseInvitation/CourseInvitationSendProcessor.php
@@ -11,13 +11,11 @@ use ApiPlatform\State\ProcessorInterface;
 use Chamilo\CoreBundle\ApiResource\CourseInvitation\CourseInvitationItem;
 use Chamilo\CoreBundle\ApiResource\CourseInvitation\CourseInvitationWriteInput;
 use Chamilo\CoreBundle\Entity\User;
+use Chamilo\CoreBundle\Helpers\CidReqHelper;
 use Chamilo\CoreBundle\Repository\Node\UserRepository;
 use Chamilo\CoreBundle\Service\CourseInvitation\CourseInvitationMailer;
 use Chamilo\CoreBundle\Service\CourseInvitation\CourseInvitationTokenService;
-use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\SecurityBundle\Security;
-use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 use Symfony\Component\HttpKernel\Exception\ConflictHttpException;
@@ -34,13 +32,12 @@ final readonly class CourseInvitationSendProcessor implements ProcessorInterface
     public const string CSRF_TOKEN_ID = 'course_invitation';
 
     public function __construct(
-        private RequestStack $requestStack,
-        private EntityManagerInterface $entityManager,
         private Security $security,
         private CsrfTokenManagerInterface $csrfTokenManager,
         private UserRepository $userRepository,
         private CourseInvitationTokenService $tokenService,
         private CourseInvitationMailer $mailer,
+        private CidReqHelper $cidReqHelper,
     ) {}
 
     /**
@@ -53,13 +50,8 @@ final readonly class CourseInvitationSendProcessor implements ProcessorInterface
             throw new BadRequestHttpException('The request payload is invalid.');
         }
 
-        $request = $this->requestStack->getCurrentRequest();
-        if (!$request instanceof Request) {
-            throw new BadRequestHttpException('The current request is required.');
-        }
-
-        $course = $this->getCourse($request, $this->entityManager);
-        $session = $this->getSession($request, $this->entityManager);
+        $course = $this->getCourse($this->cidReqHelper);
+        $session = $this->getSession($this->cidReqHelper);
         $this->assertSessionBelongsToCourse($session, $course);
 
         if (!$this->canManageCourseInvitations($this->security, $course, $session)) {

--- a/src/CoreBundle/State/CourseInvitation/CourseInvitationSendProcessor.php
+++ b/src/CoreBundle/State/CourseInvitation/CourseInvitationSendProcessor.php
@@ -51,7 +51,7 @@ final readonly class CourseInvitationSendProcessor implements ProcessorInterface
         }
 
         $course = $this->getCourse($this->cidReqHelper);
-        $session = $this->getSession($this->cidReqHelper);
+        $session = $this->cidReqHelper->getDoctrineSessionEntity();
         $this->assertSessionBelongsToCourse($session, $course);
 
         if (!$this->canManageCourseInvitations($this->security, $course, $session)) {

--- a/src/CoreBundle/State/CourseSession/CourseSessionActionProcessor.php
+++ b/src/CoreBundle/State/CourseSession/CourseSessionActionProcessor.php
@@ -29,8 +29,7 @@ final readonly class CourseSessionActionProcessor implements ProcessorInterface
         Operation $operation,
         array $uriVariables = [],
         array $context = [],
-    ): CourseSessionAction
-    {
+    ): CourseSessionAction {
         if (!$data instanceof CourseSessionAction) {
             throw new BadRequestHttpException('Invalid session action payload.');
         }

--- a/src/CoreBundle/State/CourseSession/CourseSessionManager.php
+++ b/src/CoreBundle/State/CourseSession/CourseSessionManager.php
@@ -227,7 +227,7 @@ final readonly class CourseSessionManager
             ];
         }
 
-        \usort(
+        usort(
             $users,
             static fn (array $left, array $right): int => strcasecmp(
                 (string) $left['fullname'],
@@ -287,7 +287,7 @@ final readonly class CourseSessionManager
         $keyword = trim((string) $request->query->get('search', ''));
         $scope = 'no_session' === (string) $request->query->get('scope') ? 'no_session' : 'all';
         $firstLetter = mb_strtoupper(trim((string) $request->query->get('firstLetter', '')));
-        if (1 !== mb_strlen($firstLetter) || 1 !== \preg_match('/^[[:alpha:]]$/u', $firstLetter)) {
+        if (1 !== mb_strlen($firstLetter) || 1 !== preg_match('/^[[:alpha:]]$/u', $firstLetter)) {
             $firstLetter = '';
         }
 
@@ -487,9 +487,7 @@ final readonly class CourseSessionManager
         }
 
         if ([] !== $sessionCourseIds && \count($avoidedCourseIds) === \count($sessionCourseIds)) {
-            throw new UnprocessableEntityHttpException(
-                'A user cannot be blocked from every course in the session. Unsubscribe the user instead.',
-            );
+            throw new UnprocessableEntityHttpException('A user cannot be blocked from every course in the session. Unsubscribe the user instead.');
         }
 
         $currentAvoidedIds = array_map(
@@ -609,9 +607,7 @@ final readonly class CourseSessionManager
         }
 
         /** @var Session[] $sessions */
-        $sessions = $queryBuilder->getQuery()->getResult();
-
-        return $sessions;
+        return $queryBuilder->getQuery()->getResult();
     }
 
     /**
@@ -808,9 +804,7 @@ final readonly class CourseSessionManager
                 continue;
             }
 
-            throw new UnprocessableEntityHttpException(
-                CourseManager::getUsersPerCourseLimitCancelMessage($courseId).' '.$course->getTitle(),
-            );
+            throw new UnprocessableEntityHttpException(CourseManager::getUsersPerCourseLimitCancelMessage($courseId).' '.$course->getTitle());
         }
     }
 
@@ -831,11 +825,11 @@ final readonly class CourseSessionManager
             return false;
         }
 
-        if ('' !== $courses && (!\ctype_digit($courses) || (int) $courses !== (int) $item['nbrCourses'])) {
+        if ('' !== $courses && (!ctype_digit($courses) || (int) $courses !== (int) $item['nbrCourses'])) {
             return false;
         }
 
-        if ('' !== $users && (!\ctype_digit($users) || (int) $users !== (int) $item['nbrUsers'])) {
+        if ('' !== $users && (!ctype_digit($users) || (int) $users !== (int) $item['nbrUsers'])) {
             return false;
         }
 
@@ -1013,7 +1007,7 @@ final readonly class CourseSessionManager
         }
 
         $direction = 'desc' === strtolower((string) $request->query->get('order', 'asc')) ? -1 : 1;
-        \usort(
+        usort(
             $items,
             static fn (array $left, array $right): int => $direction * strnatcasecmp(
                 (string) ($left[$sort] ?? ''),

--- a/src/CoreBundle/State/Forum/ForumCategoryCollectionStateProvider.php
+++ b/src/CoreBundle/State/Forum/ForumCategoryCollectionStateProvider.php
@@ -12,6 +12,7 @@ use Chamilo\CoreBundle\Entity\Course;
 use Chamilo\CoreBundle\Entity\ExtraField;
 use Chamilo\CoreBundle\Entity\ExtraFieldValues;
 use Chamilo\CoreBundle\Entity\Session;
+use Chamilo\CoreBundle\Helpers\CidReqHelper;
 use Chamilo\CoreBundle\Repository\ExtraFieldRepository;
 use Chamilo\CoreBundle\Repository\ExtraFieldValuesRepository;
 use Chamilo\CoreBundle\Settings\SettingsManager;
@@ -37,6 +38,7 @@ final class ForumCategoryCollectionStateProvider implements ProviderInterface
         private readonly SettingsManager $settingsManager,
         private readonly ExtraFieldRepository $extraFieldRepository,
         private readonly ExtraFieldValuesRepository $extraFieldValuesRepository,
+        private readonly CidReqHelper $cidReqHelper,
     ) {}
 
     /**
@@ -75,9 +77,9 @@ final class ForumCategoryCollectionStateProvider implements ProviderInterface
     {
         $this->assertForumMemberAccess($this->security, 'You are not allowed to access forum categories.');
 
-        $course = $this->getCourse($this->entityManager, $request);
-        $session = $this->getSession($this->entityManager, $request);
-        $group = $this->getGroup($this->entityManager, $request);
+        $course = $this->getCourse($this->cidReqHelper);
+        $session = $this->getSession($this->entityManager, $this->cidReqHelper);
+        $group = $this->getGroup($this->entityManager, $this->cidReqHelper);
         $parentNode = $this->getParentNode($this->entityManager, $request);
         $showHidden = $this->canManageForumsInCurrentView($this->security, $request);
         $languageField = $this->getForumCategoryLanguageField();

--- a/src/CoreBundle/State/Forum/ForumCategoryCollectionStateProvider.php
+++ b/src/CoreBundle/State/Forum/ForumCategoryCollectionStateProvider.php
@@ -78,7 +78,7 @@ final class ForumCategoryCollectionStateProvider implements ProviderInterface
         $this->assertForumMemberAccess($this->security, 'You are not allowed to access forum categories.');
 
         $course = $this->getCourse($this->cidReqHelper);
-        $session = $this->getSession($this->entityManager, $this->cidReqHelper);
+        $session = $this->cidReqHelper->getDoctrineSessionEntity();
         $group = $this->getGroup($this->entityManager, $this->cidReqHelper);
         $parentNode = $this->getParentNode($this->entityManager, $request);
         $showHidden = $this->canManageForumsInCurrentView($this->security, $request);

--- a/src/CoreBundle/State/Forum/ForumCategoryProcessor.php
+++ b/src/CoreBundle/State/Forum/ForumCategoryProcessor.php
@@ -10,6 +10,7 @@ use ApiPlatform\Metadata\Operation;
 use ApiPlatform\State\ProcessorInterface;
 use Chamilo\CoreBundle\Entity\ExtraField;
 use Chamilo\CoreBundle\Entity\ExtraFieldValues;
+use Chamilo\CoreBundle\Helpers\CidReqHelper;
 use Chamilo\CoreBundle\Repository\ExtraFieldRepository;
 use Chamilo\CoreBundle\Repository\ExtraFieldValuesRepository;
 use Chamilo\CoreBundle\Repository\LanguageRepository;
@@ -40,6 +41,7 @@ final class ForumCategoryProcessor implements ProcessorInterface
         private readonly ExtraFieldRepository $extraFieldRepository,
         private readonly ExtraFieldValuesRepository $extraFieldValuesRepository,
         private readonly LanguageRepository $languageRepository,
+        private readonly CidReqHelper $cidReqHelper,
     ) {}
 
     public function process(mixed $data, Operation $operation, array $uriVariables = [], array $context = []): CForumCategory|JsonResponse
@@ -54,9 +56,9 @@ final class ForumCategoryProcessor implements ProcessorInterface
         $this->assertTeacher($this->security);
 
         if ('create_forum_category' === $operation->getName()) {
-            $course = $this->getCourse($this->entityManager, $request);
-            $session = $this->getSession($this->entityManager, $request);
-            $group = $this->getGroup($this->entityManager, $request);
+            $course = $this->getCourse($this->cidReqHelper);
+            $session = $this->getSession($this->entityManager, $this->cidReqHelper);
+            $group = $this->getGroup($this->entityManager, $this->cidReqHelper);
             $parentResourceNodeId = $this->getRequiredInt($payload, 'parentResourceNodeId');
             $this->assertParentResourceNodeIsWritableInForumContext(
                 $this->entityManager,
@@ -146,8 +148,8 @@ final class ForumCategoryProcessor implements ProcessorInterface
             throw new BadRequestHttpException('Request is missing.');
         }
 
-        $course = $this->getCourse($this->entityManager, $request);
-        $session = $this->getSession($this->entityManager, $request);
+        $course = $this->getCourse($this->cidReqHelper);
+        $session = $this->getSession($this->entityManager, $this->cidReqHelper);
         $targetVisible = $this->getTargetVisibility($payload, $category, $course, $session);
         $visible = $this->setForumResourceVisibility($category, $this->categoryRepository, $course, $session, $targetVisible);
         $this->entityManager->flush();
@@ -173,9 +175,9 @@ final class ForumCategoryProcessor implements ProcessorInterface
             throw new BadRequestHttpException('Request is missing.');
         }
 
-        $course = $this->getCourse($this->entityManager, $request);
-        $session = $this->getSession($this->entityManager, $request);
-        $group = $this->getGroup($this->entityManager, $request);
+        $course = $this->getCourse($this->cidReqHelper);
+        $session = $this->getSession($this->entityManager, $this->cidReqHelper);
+        $group = $this->getGroup($this->entityManager, $this->cidReqHelper);
         $position = $this->moveForumResource($category, $course, $session, $group, (string) ($payload['direction'] ?? ''));
         $this->entityManager->flush();
 

--- a/src/CoreBundle/State/Forum/ForumCategoryProcessor.php
+++ b/src/CoreBundle/State/Forum/ForumCategoryProcessor.php
@@ -57,7 +57,7 @@ final class ForumCategoryProcessor implements ProcessorInterface
 
         if ('create_forum_category' === $operation->getName()) {
             $course = $this->getCourse($this->cidReqHelper);
-            $session = $this->getSession($this->entityManager, $this->cidReqHelper);
+            $session = $this->cidReqHelper->getDoctrineSessionEntity();
             $group = $this->getGroup($this->entityManager, $this->cidReqHelper);
             $parentResourceNodeId = $this->getRequiredInt($payload, 'parentResourceNodeId');
             $this->assertParentResourceNodeIsWritableInForumContext(
@@ -149,7 +149,7 @@ final class ForumCategoryProcessor implements ProcessorInterface
         }
 
         $course = $this->getCourse($this->cidReqHelper);
-        $session = $this->getSession($this->entityManager, $this->cidReqHelper);
+        $session = $this->cidReqHelper->getDoctrineSessionEntity();
         $targetVisible = $this->getTargetVisibility($payload, $category, $course, $session);
         $visible = $this->setForumResourceVisibility($category, $this->categoryRepository, $course, $session, $targetVisible);
         $this->entityManager->flush();
@@ -176,7 +176,7 @@ final class ForumCategoryProcessor implements ProcessorInterface
         }
 
         $course = $this->getCourse($this->cidReqHelper);
-        $session = $this->getSession($this->entityManager, $this->cidReqHelper);
+        $session = $this->cidReqHelper->getDoctrineSessionEntity();
         $group = $this->getGroup($this->entityManager, $this->cidReqHelper);
         $position = $this->moveForumResource($category, $course, $session, $group, (string) ($payload['direction'] ?? ''));
         $this->entityManager->flush();

--- a/src/CoreBundle/State/Forum/ForumCollectionStateProvider.php
+++ b/src/CoreBundle/State/Forum/ForumCollectionStateProvider.php
@@ -12,6 +12,7 @@ use Chamilo\CoreBundle\Entity\Course;
 use Chamilo\CoreBundle\Entity\ResourceNode;
 use Chamilo\CoreBundle\Entity\Session;
 use Chamilo\CoreBundle\Entity\User;
+use Chamilo\CoreBundle\Helpers\CidReqHelper;
 use Chamilo\CoreBundle\Settings\SettingsManager;
 use Chamilo\CourseBundle\Entity\CForum;
 use Chamilo\CourseBundle\Entity\CForumCategory;
@@ -42,6 +43,7 @@ final class ForumCollectionStateProvider implements ProviderInterface
         private readonly CForumCategoryRepository $forumCategoryRepository,
         private readonly Security $security,
         private readonly SettingsManager $settingsManager,
+        private readonly CidReqHelper $cidReqHelper,
     ) {}
 
     /**
@@ -80,13 +82,13 @@ final class ForumCollectionStateProvider implements ProviderInterface
     {
         $this->assertForumMemberAccess($this->security, 'You are not allowed to access forums.');
 
-        $course = $this->getCourse($this->entityManager, $request);
-        $session = $this->getSession($this->entityManager, $request);
-        $group = $this->getGroup($this->entityManager, $request);
+        $course = $this->getCourse($this->cidReqHelper);
+        $session = $this->getSession($this->entityManager, $this->cidReqHelper);
+        $group = $this->getGroup($this->entityManager, $this->cidReqHelper);
         $parentNode = $this->getParentNode($this->entityManager, $request);
         $showHidden = $this->canManageForumsInCurrentView($this->security, $request);
         $user = $this->getCurrentUser();
-        $displayGroupForums = $this->shouldDisplayGroupForumsInGeneralTool($request);
+        $displayGroupForums = $this->shouldDisplayGroupForumsInGeneralTool($this->cidReqHelper);
 
         $categoryIds = $this->getCategoryIdsBelowParent(
             $course,
@@ -113,7 +115,7 @@ final class ForumCollectionStateProvider implements ProviderInterface
             if (
                 !$forum instanceof CForum
                 || !$this->forumBelongsToRequestedParent($forum, $parentNode->getId(), $categoryIds)
-                || !$this->canListForumWithCurrentSettings($forum, $request, $displayGroupForums)
+                || !$this->canListForumWithCurrentSettings($forum, $this->cidReqHelper, $displayGroupForums)
             ) {
                 continue;
             }
@@ -182,9 +184,9 @@ final class ForumCollectionStateProvider implements ProviderInterface
         return $parentNodeId === $forum->getResourceNode()?->getParent()?->getId();
     }
 
-    private function shouldDisplayGroupForumsInGeneralTool(Request $request): bool
+    private function shouldDisplayGroupForumsInGeneralTool(CidReqHelper $cidReqHelper): bool
     {
-        if ($request->query->getInt('gid') > 0) {
+        if ((int) ($cidReqHelper->getGroupId() ?? 0) > 0) {
             return true;
         }
 

--- a/src/CoreBundle/State/Forum/ForumCollectionStateProvider.php
+++ b/src/CoreBundle/State/Forum/ForumCollectionStateProvider.php
@@ -83,7 +83,7 @@ final class ForumCollectionStateProvider implements ProviderInterface
         $this->assertForumMemberAccess($this->security, 'You are not allowed to access forums.');
 
         $course = $this->getCourse($this->cidReqHelper);
-        $session = $this->getSession($this->entityManager, $this->cidReqHelper);
+        $session = $this->cidReqHelper->getDoctrineSessionEntity();
         $group = $this->getGroup($this->entityManager, $this->cidReqHelper);
         $parentNode = $this->getParentNode($this->entityManager, $request);
         $showHidden = $this->canManageForumsInCurrentView($this->security, $request);

--- a/src/CoreBundle/State/Forum/ForumDeleteProcessor.php
+++ b/src/CoreBundle/State/Forum/ForumDeleteProcessor.php
@@ -9,6 +9,7 @@ namespace Chamilo\CoreBundle\State\Forum;
 use ApiPlatform\Metadata\Operation;
 use ApiPlatform\State\ProcessorInterface;
 use Chamilo\CoreBundle\Entity\ResourceLink;
+use Chamilo\CoreBundle\Helpers\CidReqHelper;
 use Chamilo\CoreBundle\Repository\ResourceLinkRepository;
 use Chamilo\CourseBundle\Entity\CForum;
 use Chamilo\CourseBundle\Entity\CForumCategory;
@@ -35,6 +36,7 @@ final class ForumDeleteProcessor implements ProcessorInterface
         private readonly RequestStack $requestStack,
         private readonly Security $security,
         private readonly CsrfTokenManagerInterface $csrfTokenManager,
+        private readonly CidReqHelper $cidReqHelper,
     ) {}
 
     public function process(mixed $data, Operation $operation, array $uriVariables = [], array $context = []): void
@@ -52,9 +54,9 @@ final class ForumDeleteProcessor implements ProcessorInterface
             throw new BadRequestHttpException('Forum resource is required.');
         }
 
-        $course = $this->getCourse($this->entityManager, $request);
-        $session = $this->getSession($this->entityManager, $request);
-        $group = $this->getGroup($this->entityManager, $request);
+        $course = $this->getCourse($this->cidReqHelper);
+        $session = $this->getSession($this->entityManager, $this->cidReqHelper);
+        $group = $this->getGroup($this->entityManager, $this->cidReqHelper);
         $resourceNode = $data->getResourceNode();
 
         if (null === $resourceNode) {

--- a/src/CoreBundle/State/Forum/ForumDeleteProcessor.php
+++ b/src/CoreBundle/State/Forum/ForumDeleteProcessor.php
@@ -55,7 +55,7 @@ final class ForumDeleteProcessor implements ProcessorInterface
         }
 
         $course = $this->getCourse($this->cidReqHelper);
-        $session = $this->getSession($this->entityManager, $this->cidReqHelper);
+        $session = $this->cidReqHelper->getDoctrineSessionEntity();
         $group = $this->getGroup($this->entityManager, $this->cidReqHelper);
         $resourceNode = $data->getResourceNode();
 

--- a/src/CoreBundle/State/Forum/ForumGradingOptionsProvider.php
+++ b/src/CoreBundle/State/Forum/ForumGradingOptionsProvider.php
@@ -10,6 +10,7 @@ use ApiPlatform\Metadata\Operation;
 use ApiPlatform\State\ProviderInterface;
 use Chamilo\CoreBundle\ApiResource\Forum\ForumGradingOptions;
 use Chamilo\CoreBundle\Entity\GradebookCategory;
+use Chamilo\CoreBundle\Helpers\CidReqHelper;
 use Chamilo\CoreBundle\Repository\GradeBookCategoryRepository;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\SecurityBundle\Security;
@@ -28,6 +29,7 @@ final class ForumGradingOptionsProvider implements ProviderInterface
         private readonly EntityManagerInterface $entityManager,
         private readonly Security $security,
         private readonly GradeBookCategoryRepository $gradeBookCategoryRepository,
+        private readonly CidReqHelper $cidReqHelper,
     ) {}
 
     /**
@@ -45,8 +47,8 @@ final class ForumGradingOptionsProvider implements ProviderInterface
             throw new AccessDeniedHttpException('You are not allowed to manage forum grading.');
         }
 
-        $course = $this->getCourse($this->entityManager, $request);
-        $session = $this->getSession($this->entityManager, $request);
+        $course = $this->getCourse($this->cidReqHelper);
+        $session = $this->getSession($this->entityManager, $this->cidReqHelper);
         $courseId = (int) $course->getId();
         $sessionId = null === $session ? null : (int) $session->getId();
 

--- a/src/CoreBundle/State/Forum/ForumGradingOptionsProvider.php
+++ b/src/CoreBundle/State/Forum/ForumGradingOptionsProvider.php
@@ -12,7 +12,6 @@ use Chamilo\CoreBundle\ApiResource\Forum\ForumGradingOptions;
 use Chamilo\CoreBundle\Entity\GradebookCategory;
 use Chamilo\CoreBundle\Helpers\CidReqHelper;
 use Chamilo\CoreBundle\Repository\GradeBookCategoryRepository;
-use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
@@ -26,7 +25,6 @@ final class ForumGradingOptionsProvider implements ProviderInterface
 
     public function __construct(
         private readonly RequestStack $requestStack,
-        private readonly EntityManagerInterface $entityManager,
         private readonly Security $security,
         private readonly GradeBookCategoryRepository $gradeBookCategoryRepository,
         private readonly CidReqHelper $cidReqHelper,
@@ -48,7 +46,7 @@ final class ForumGradingOptionsProvider implements ProviderInterface
         }
 
         $course = $this->getCourse($this->cidReqHelper);
-        $session = $this->getSession($this->entityManager, $this->cidReqHelper);
+        $session = $this->cidReqHelper->getDoctrineSessionEntity();
         $courseId = (int) $course->getId();
         $sessionId = null === $session ? null : (int) $session->getId();
 

--- a/src/CoreBundle/State/Forum/ForumNotificationHelperTrait.php
+++ b/src/CoreBundle/State/Forum/ForumNotificationHelperTrait.php
@@ -10,6 +10,7 @@ use Chamilo\CoreBundle\Entity\Course;
 use Chamilo\CoreBundle\Entity\Session;
 use Chamilo\CoreBundle\Entity\SessionRelCourseRelUser;
 use Chamilo\CoreBundle\Entity\User;
+use Chamilo\CoreBundle\Helpers\CidReqHelper;
 use Chamilo\CoreBundle\Helpers\MessageHelper;
 use Chamilo\CourseBundle\Entity\CForum;
 use Chamilo\CourseBundle\Entity\CForumCategory;
@@ -259,6 +260,7 @@ trait ForumNotificationHelperTrait
         CForumPost $post,
         User $author,
         MessageHelper $messageHelper,
+        CidReqHelper $cidReqHelper,
     ): int {
         if (!$this->canSendForumNotification($course, $session, $forum, $thread, $post)) {
             return 0;
@@ -270,7 +272,7 @@ trait ForumNotificationHelperTrait
         }
 
         $subject = 'New forum post: '.$forum->getTitle().' - '.$thread->getTitle();
-        $content = $this->buildForumNotificationContent($request, $course, $session, $forum, $thread, $post, $author);
+        $content = $this->buildForumNotificationContent($request, $course, $session, $forum, $thread, $post, $author, $cidReqHelper);
         $sentCount = 0;
 
         foreach ($recipientIds as $recipientId) {
@@ -348,13 +350,14 @@ trait ForumNotificationHelperTrait
         CForumThread $thread,
         CForumPost $post,
         User $author,
+        CidReqHelper $cidReqHelper,
     ): string {
         $postText = trim(strip_tags((string) $post->getPostText()));
         if (mb_strlen($postText) > 100) {
             $postText = mb_substr($postText, 0, 100).'...';
         }
 
-        $threadUrl = $this->buildForumThreadUrl($request, $course, $session, $forum, $thread);
+        $threadUrl = $this->buildForumThreadUrl($request, $course, $session, $forum, $thread, $cidReqHelper);
         $authorName = htmlspecialchars($author->getFullName(), ENT_QUOTES, 'UTF-8');
         $forumTitle = htmlspecialchars($forum->getTitle(), ENT_QUOTES, 'UTF-8');
         $threadTitle = htmlspecialchars($thread->getTitle(), ENT_QUOTES, 'UTF-8');
@@ -378,12 +381,13 @@ trait ForumNotificationHelperTrait
         ?Session $session,
         CForum $forum,
         CForumThread $thread,
+        CidReqHelper $cidReqHelper,
     ): string {
         $parentNodeId = $forum->getResourceNode()?->getParent()?->getId() ?? $forum->getResourceNode()?->getId() ?? 0;
         $query = http_build_query([
             'cid' => $course->getId(),
             'sid' => $session?->getId() ?? 0,
-            'gid' => $request->query->getInt('gid'),
+            'gid' => (int) ($cidReqHelper->getGroupId() ?? 0),
         ]);
 
         return $request->getSchemeAndHttpHost().'/resources/forum/'.$parentNodeId.'/forum/'.$forum->getIid().'/thread/'.$thread->getIid().'?'.$query;

--- a/src/CoreBundle/State/Forum/ForumPostProcessor.php
+++ b/src/CoreBundle/State/Forum/ForumPostProcessor.php
@@ -12,6 +12,7 @@ use Chamilo\CoreBundle\Entity\Course;
 use Chamilo\CoreBundle\Entity\ResourceNode;
 use Chamilo\CoreBundle\Entity\Session;
 use Chamilo\CoreBundle\Entity\User;
+use Chamilo\CoreBundle\Helpers\CidReqHelper;
 use Chamilo\CoreBundle\Helpers\MessageHelper;
 use Chamilo\CoreBundle\Repository\ExtraFieldRepository;
 use Chamilo\CoreBundle\Repository\ExtraFieldValuesRepository;
@@ -73,6 +74,7 @@ final class ForumPostProcessor implements ProcessorInterface
         private readonly MessageHelper $messageHelper,
         private readonly ExtraFieldRepository $extraFieldRepository,
         private readonly ExtraFieldValuesRepository $extraFieldValuesRepository,
+        private readonly CidReqHelper $cidReqHelper,
     ) {}
 
     public function process(mixed $data, Operation $operation, array $uriVariables = [], array $context = []): JsonResponse
@@ -127,9 +129,9 @@ final class ForumPostProcessor implements ProcessorInterface
 
         $title = $this->getRequiredText($data, 'title', 250);
         $text = $this->getRequiredHtmlText($data, 'text');
-        $course = $this->getCourse($this->entityManager, $request);
-        $session = $this->getSession($this->entityManager, $request);
-        $group = $this->getGroup($this->entityManager, $request);
+        $course = $this->getCourse($this->cidReqHelper);
+        $session = $this->getSession($this->entityManager, $this->cidReqHelper);
+        $group = $this->getGroup($this->entityManager, $this->cidReqHelper);
         $this->assertResourceNodeInForumContext(
             $forum->getResourceNode(),
             $course,
@@ -191,7 +193,7 @@ final class ForumPostProcessor implements ProcessorInterface
         }
 
         if ($visible) {
-            $this->sendForumSubscriptionNotifications($this->entityManager, $request, $course, $session, $forum, $thread, $post, $user, $this->messageHelper);
+            $this->sendForumSubscriptionNotifications($this->entityManager, $request, $course, $session, $forum, $thread, $post, $user, $this->messageHelper, $this->cidReqHelper);
         }
 
         $this->registerForumEventLog('reply-thread', 'post', (string) $post->getIid());
@@ -223,7 +225,7 @@ final class ForumPostProcessor implements ProcessorInterface
         $this->assertVisibleResource($data->getResourceNode());
         $this->assertVisibleResource($thread->getResourceNode());
         $this->assertPostCanBeEdited($data, $forum, $thread);
-        $course = $this->getCourse($this->entityManager, $request);
+        $course = $this->getCourse($this->cidReqHelper);
         $this->assertForumThreadNotLockedByGradebook($this->entityManager, $this->settingsManager, $this->security, $course, $thread);
 
         $title = $this->getRequiredText($payload, 'title', 250);
@@ -273,7 +275,7 @@ final class ForumPostProcessor implements ProcessorInterface
         $this->assertVisibleResource($data->getResourceNode());
         $this->assertVisibleResource($thread->getResourceNode());
         $this->assertPostCanBeDeleted($data, $forum, $thread);
-        $course = $this->getCourse($this->entityManager, $request);
+        $course = $this->getCourse($this->cidReqHelper);
         $this->assertForumThreadNotLockedByGradebook($this->entityManager, $this->settingsManager, $this->security, $course, $thread);
 
         $postId = (int) $data->getIid();
@@ -350,7 +352,7 @@ final class ForumPostProcessor implements ProcessorInterface
         $this->assertEditableForumResource($data->getResourceNode(), $this->security);
         $this->assertEditableForumResource($thread->getResourceNode(), $this->security);
         $this->assertEditableForumResource($forum->getResourceNode(), $this->security);
-        $course = $this->getCourse($this->entityManager, $request);
+        $course = $this->getCourse($this->cidReqHelper);
         $this->assertForumThreadNotLockedByGradebook($this->entityManager, $this->settingsManager, $this->security, $course, $thread);
 
         $targetVisible = \array_key_exists('visible', $payload)
@@ -383,7 +385,7 @@ final class ForumPostProcessor implements ProcessorInterface
         $this->assertEditableForumResource($data->getResourceNode(), $this->security);
         $this->assertEditableForumResource($thread->getResourceNode(), $this->security);
         $this->assertEditableForumResource($forum->getResourceNode(), $this->security);
-        $course = $this->getCourse($this->entityManager, $request);
+        $course = $this->getCourse($this->cidReqHelper);
         $this->assertForumThreadNotLockedByGradebook($this->entityManager, $this->settingsManager, $this->security, $course, $thread);
 
         $wasVisible = $data->getVisible();
@@ -408,10 +410,10 @@ final class ForumPostProcessor implements ProcessorInterface
         $this->entityManager->persist($forum);
         $this->entityManager->flush();
 
-        $session = $this->getSession($this->entityManager, $request);
+        $session = $this->getSession($this->entityManager, $this->cidReqHelper);
         $author = $data->getUser();
         if (!$wasVisible && $author instanceof User) {
-            $this->sendForumSubscriptionNotifications($this->entityManager, $request, $course, $session, $forum, $thread, $data, $author, $this->messageHelper);
+            $this->sendForumSubscriptionNotifications($this->entityManager, $request, $course, $session, $forum, $thread, $data, $author, $this->messageHelper, $this->cidReqHelper);
         }
 
         $this->registerForumEventLog('approve-post', 'post', (string) $data->getIid());
@@ -439,7 +441,7 @@ final class ForumPostProcessor implements ProcessorInterface
         $this->assertEditableForumResource($data->getResourceNode(), $this->security);
         $this->assertEditableForumResource($thread->getResourceNode(), $this->security);
         $this->assertEditableForumResource($forum->getResourceNode(), $this->security);
-        $course = $this->getCourse($this->entityManager, $request);
+        $course = $this->getCourse($this->cidReqHelper);
         $this->assertForumThreadNotLockedByGradebook($this->entityManager, $this->settingsManager, $this->security, $course, $thread);
 
         $wasVisible = $data->getVisible();
@@ -524,7 +526,7 @@ final class ForumPostProcessor implements ProcessorInterface
         $this->assertVisibleResource($thread->getResourceNode());
         $this->assertVisibleResource($forum->getResourceNode());
 
-        $course = $this->getCourse($this->entityManager, $request);
+        $course = $this->getCourse($this->cidReqHelper);
         if (!$this->isReportAvailable((int) $course->getId())) {
             throw new AccessDeniedHttpException('Forum post reporting is disabled.');
         }
@@ -569,9 +571,9 @@ final class ForumPostProcessor implements ProcessorInterface
         $this->assertEditableForumResource($sourceThread->getResourceNode(), $this->security);
         $this->assertEditableForumResource($sourceForum->getResourceNode(), $this->security);
 
-        $course = $this->getCourse($this->entityManager, $request);
-        $session = $this->getSession($this->entityManager, $request);
-        $group = $this->getGroup($this->entityManager, $request);
+        $course = $this->getCourse($this->cidReqHelper);
+        $session = $this->getSession($this->entityManager, $this->cidReqHelper);
+        $group = $this->getGroup($this->entityManager, $this->cidReqHelper);
         $this->assertResourceNodeInForumContext(
             $sourceForum->getResourceNode(),
             $course,

--- a/src/CoreBundle/State/Forum/ForumPostProcessor.php
+++ b/src/CoreBundle/State/Forum/ForumPostProcessor.php
@@ -130,7 +130,7 @@ final class ForumPostProcessor implements ProcessorInterface
         $title = $this->getRequiredText($data, 'title', 250);
         $text = $this->getRequiredHtmlText($data, 'text');
         $course = $this->getCourse($this->cidReqHelper);
-        $session = $this->getSession($this->entityManager, $this->cidReqHelper);
+        $session = $this->cidReqHelper->getDoctrineSessionEntity();
         $group = $this->getGroup($this->entityManager, $this->cidReqHelper);
         $this->assertResourceNodeInForumContext(
             $forum->getResourceNode(),
@@ -410,7 +410,7 @@ final class ForumPostProcessor implements ProcessorInterface
         $this->entityManager->persist($forum);
         $this->entityManager->flush();
 
-        $session = $this->getSession($this->entityManager, $this->cidReqHelper);
+        $session = $this->cidReqHelper->getDoctrineSessionEntity();
         $author = $data->getUser();
         if (!$wasVisible && $author instanceof User) {
             $this->sendForumSubscriptionNotifications($this->entityManager, $request, $course, $session, $forum, $thread, $data, $author, $this->messageHelper, $this->cidReqHelper);
@@ -572,7 +572,7 @@ final class ForumPostProcessor implements ProcessorInterface
         $this->assertEditableForumResource($sourceForum->getResourceNode(), $this->security);
 
         $course = $this->getCourse($this->cidReqHelper);
-        $session = $this->getSession($this->entityManager, $this->cidReqHelper);
+        $session = $this->cidReqHelper->getDoctrineSessionEntity();
         $group = $this->getGroup($this->entityManager, $this->cidReqHelper);
         $this->assertResourceNodeInForumContext(
             $sourceForum->getResourceNode(),

--- a/src/CoreBundle/State/Forum/ForumPostProcessor.php
+++ b/src/CoreBundle/State/Forum/ForumPostProcessor.php
@@ -131,6 +131,7 @@ final class ForumPostProcessor implements ProcessorInterface
         $text = $this->getRequiredHtmlText($data, 'text');
         $course = $this->getCourse($this->cidReqHelper);
         $session = $this->cidReqHelper->getDoctrineSessionEntity();
+        $this->assertSessionBelongsToCourse($session, $course);
         $group = $this->getGroup($this->entityManager, $this->cidReqHelper);
         $this->assertResourceNodeInForumContext(
             $forum->getResourceNode(),
@@ -573,6 +574,7 @@ final class ForumPostProcessor implements ProcessorInterface
 
         $course = $this->getCourse($this->cidReqHelper);
         $session = $this->cidReqHelper->getDoctrineSessionEntity();
+        $this->assertSessionBelongsToCourse($session, $course);
         $group = $this->getGroup($this->entityManager, $this->cidReqHelper);
         $this->assertResourceNodeInForumContext(
             $sourceForum->getResourceNode(),

--- a/src/CoreBundle/State/Forum/ForumProcessor.php
+++ b/src/CoreBundle/State/Forum/ForumProcessor.php
@@ -75,7 +75,7 @@ final class ForumProcessor implements ProcessorInterface
 
         if ('create_forum' === $operationName) {
             $course = $this->getCourse($this->cidReqHelper);
-            $session = $this->getSession($this->entityManager, $this->cidReqHelper);
+            $session = $this->cidReqHelper->getDoctrineSessionEntity();
             $group = $this->getGroup($this->entityManager, $this->cidReqHelper);
             $parentResourceNodeId = $this->getRequiredInt($payload, 'parentResourceNodeId');
             $this->assertParentResourceNodeIsWritableInForumContext(
@@ -142,7 +142,7 @@ final class ForumProcessor implements ProcessorInterface
         }
 
         $course = $this->getCourse($this->cidReqHelper);
-        $session = $this->getSession($this->entityManager, $this->cidReqHelper);
+        $session = $this->cidReqHelper->getDoctrineSessionEntity();
         $group = $this->getGroup($this->entityManager, $this->cidReqHelper);
 
         $this->applyPayloadToForum($forum, $payload, false, $course, $session, $group);
@@ -185,7 +185,7 @@ final class ForumProcessor implements ProcessorInterface
         }
 
         $course = $this->getCourse($this->cidReqHelper);
-        $session = $this->getSession($this->entityManager, $this->cidReqHelper);
+        $session = $this->cidReqHelper->getDoctrineSessionEntity();
         $targetVisible = $this->getTargetVisibility($payload, $forum, $course, $session);
         $visible = $this->setForumResourceVisibility($forum, $this->forumRepository, $course, $session, $targetVisible);
         $this->entityManager->flush();
@@ -212,7 +212,7 @@ final class ForumProcessor implements ProcessorInterface
         }
 
         $course = $this->getCourse($this->cidReqHelper);
-        $session = $this->getSession($this->entityManager, $this->cidReqHelper);
+        $session = $this->cidReqHelper->getDoctrineSessionEntity();
         $group = $this->getGroup($this->entityManager, $this->cidReqHelper);
         $position = $this->moveForumResource($forum, $course, $session, $group, (string) ($payload['direction'] ?? ''));
         $this->entityManager->flush();

--- a/src/CoreBundle/State/Forum/ForumProcessor.php
+++ b/src/CoreBundle/State/Forum/ForumProcessor.php
@@ -11,6 +11,7 @@ use ApiPlatform\State\ProcessorInterface;
 use Chamilo\CoreBundle\Entity\Course;
 use Chamilo\CoreBundle\Entity\ResourceNode;
 use Chamilo\CoreBundle\Entity\Session;
+use Chamilo\CoreBundle\Helpers\CidReqHelper;
 use Chamilo\CoreBundle\Security\Upload\UploadFilenamePolicy;
 use Chamilo\CoreBundle\Settings\SettingsManager;
 use Chamilo\CourseBundle\Entity\CForum;
@@ -55,6 +56,7 @@ final class ForumProcessor implements ProcessorInterface
         private readonly CsrfTokenManagerInterface $csrfTokenManager,
         private readonly SettingsManager $settingsManager,
         private readonly UploadFilenamePolicy $uploadFilenamePolicy,
+        private readonly CidReqHelper $cidReqHelper,
     ) {}
 
     public function process(mixed $data, Operation $operation, array $uriVariables = [], array $context = []): CForum|JsonResponse
@@ -72,9 +74,9 @@ final class ForumProcessor implements ProcessorInterface
         }
 
         if ('create_forum' === $operationName) {
-            $course = $this->getCourse($this->entityManager, $request);
-            $session = $this->getSession($this->entityManager, $request);
-            $group = $this->getGroup($this->entityManager, $request);
+            $course = $this->getCourse($this->cidReqHelper);
+            $session = $this->getSession($this->entityManager, $this->cidReqHelper);
+            $group = $this->getGroup($this->entityManager, $this->cidReqHelper);
             $parentResourceNodeId = $this->getRequiredInt($payload, 'parentResourceNodeId');
             $this->assertParentResourceNodeIsWritableInForumContext(
                 $this->entityManager,
@@ -139,9 +141,9 @@ final class ForumProcessor implements ProcessorInterface
             throw new BadRequestHttpException('Request is missing.');
         }
 
-        $course = $this->getCourse($this->entityManager, $request);
-        $session = $this->getSession($this->entityManager, $request);
-        $group = $this->getGroup($this->entityManager, $request);
+        $course = $this->getCourse($this->cidReqHelper);
+        $session = $this->getSession($this->entityManager, $this->cidReqHelper);
+        $group = $this->getGroup($this->entityManager, $this->cidReqHelper);
 
         $this->applyPayloadToForum($forum, $payload, false, $course, $session, $group);
         $this->entityManager->persist($forum);
@@ -182,8 +184,8 @@ final class ForumProcessor implements ProcessorInterface
             throw new BadRequestHttpException('Request is missing.');
         }
 
-        $course = $this->getCourse($this->entityManager, $request);
-        $session = $this->getSession($this->entityManager, $request);
+        $course = $this->getCourse($this->cidReqHelper);
+        $session = $this->getSession($this->entityManager, $this->cidReqHelper);
         $targetVisible = $this->getTargetVisibility($payload, $forum, $course, $session);
         $visible = $this->setForumResourceVisibility($forum, $this->forumRepository, $course, $session, $targetVisible);
         $this->entityManager->flush();
@@ -209,9 +211,9 @@ final class ForumProcessor implements ProcessorInterface
             throw new BadRequestHttpException('Request is missing.');
         }
 
-        $course = $this->getCourse($this->entityManager, $request);
-        $session = $this->getSession($this->entityManager, $request);
-        $group = $this->getGroup($this->entityManager, $request);
+        $course = $this->getCourse($this->cidReqHelper);
+        $session = $this->getSession($this->entityManager, $this->cidReqHelper);
+        $group = $this->getGroup($this->entityManager, $this->cidReqHelper);
         $position = $this->moveForumResource($forum, $course, $session, $group, (string) ($payload['direction'] ?? ''));
         $this->entityManager->flush();
 
@@ -234,7 +236,7 @@ final class ForumProcessor implements ProcessorInterface
             throw new BadRequestHttpException('Request is missing.');
         }
 
-        $course = $this->getCourse($this->entityManager, $request);
+        $course = $this->getCourse($this->cidReqHelper);
         if ($this->areForumPostNotificationsHidden($this->entityManager, $course)) {
             throw new AccessDeniedHttpException('Forum notifications are disabled for this course.');
         }

--- a/src/CoreBundle/State/Forum/ForumSearchStateProvider.php
+++ b/src/CoreBundle/State/Forum/ForumSearchStateProvider.php
@@ -12,6 +12,7 @@ use Chamilo\CoreBundle\ApiResource\Forum\ForumSearchResult;
 use Chamilo\CoreBundle\Entity\AbstractResource;
 use Chamilo\CoreBundle\Entity\Course;
 use Chamilo\CoreBundle\Entity\Session;
+use Chamilo\CoreBundle\Helpers\CidReqHelper;
 use Chamilo\CoreBundle\Settings\SettingsManager;
 use Chamilo\CourseBundle\Entity\CForum;
 use Chamilo\CourseBundle\Entity\CForumCategory;
@@ -43,6 +44,7 @@ final class ForumSearchStateProvider implements ProviderInterface
         private readonly EntityManagerInterface $entityManager,
         private readonly Security $security,
         private readonly SettingsManager $settingsManager,
+        private readonly CidReqHelper $cidReqHelper,
     ) {}
 
     /**
@@ -86,10 +88,10 @@ final class ForumSearchStateProvider implements ProviderInterface
             ];
         }
 
-        $course = $this->getCourse($this->entityManager, $request);
-        $session = $this->getSession($this->entityManager, $request);
+        $course = $this->getCourse($this->cidReqHelper);
+        $session = $this->getSession($this->entityManager, $this->cidReqHelper);
         $showHidden = $this->canManageForumsInCurrentView($this->security, $request);
-        $displayGroupForums = $this->shouldDisplayGroupForumsInGeneralTool($request);
+        $displayGroupForums = $this->shouldDisplayGroupForumsInGeneralTool($this->cidReqHelper);
         $terms = $this->getSearchTerms($query);
         if ([] === $terms) {
             throw new BadRequestHttpException('Invalid search query.');
@@ -114,18 +116,18 @@ final class ForumSearchStateProvider implements ProviderInterface
         ];
     }
 
-    private function shouldDisplayGroupForumsInGeneralTool(Request $request): bool
+    private function shouldDisplayGroupForumsInGeneralTool(CidReqHelper $cidReqHelper): bool
     {
-        if ($request->query->getInt('gid') > 0) {
+        if ((int) ($cidReqHelper->getGroupId() ?? 0) > 0) {
             return true;
         }
 
         return 'false' !== (string) $this->settingsManager->getSetting('forum.display_groups_forum_in_general_tool', true);
     }
 
-    private function canListForumWithCurrentSettings(CForum $forum, Request $request, bool $displayGroupForums): bool
+    private function canListForumWithCurrentSettings(CForum $forum, CidReqHelper $cidReqHelper, bool $displayGroupForums): bool
     {
-        if ($displayGroupForums || $request->query->getInt('gid') > 0) {
+        if ($displayGroupForums || (int) ($cidReqHelper->getGroupId() ?? 0) > 0) {
             return true;
         }
 
@@ -173,7 +175,7 @@ final class ForumSearchStateProvider implements ProviderInterface
         $items = [];
         foreach ($queryBuilder->getQuery()->getResult() as $forum) {
             if (!$forum instanceof CForum
-                || !$this->canListForumWithCurrentSettings($forum, $request, $displayGroupForums)
+                || !$this->canListForumWithCurrentSettings($forum, $this->cidReqHelper, $displayGroupForums)
                 || !$this->canReadForum($forum, $course, $session, $showHidden)
             ) {
                 continue;
@@ -235,7 +237,7 @@ final class ForumSearchStateProvider implements ProviderInterface
             }
 
             $forum = $thread->getForum();
-            if (!$forum instanceof CForum || !$this->canListForumWithCurrentSettings($forum, $request, $displayGroupForums)) {
+            if (!$forum instanceof CForum || !$this->canListForumWithCurrentSettings($forum, $this->cidReqHelper, $displayGroupForums)) {
                 continue;
             }
 
@@ -298,7 +300,7 @@ final class ForumSearchStateProvider implements ProviderInterface
             $thread = $post->getThread();
             if (!$forum instanceof CForum
                 || !$thread instanceof CForumThread
-                || !$this->canListForumWithCurrentSettings($forum, $request, $displayGroupForums)
+                || !$this->canListForumWithCurrentSettings($forum, $this->cidReqHelper, $displayGroupForums)
             ) {
                 continue;
             }

--- a/src/CoreBundle/State/Forum/ForumSearchStateProvider.php
+++ b/src/CoreBundle/State/Forum/ForumSearchStateProvider.php
@@ -89,7 +89,7 @@ final class ForumSearchStateProvider implements ProviderInterface
         }
 
         $course = $this->getCourse($this->cidReqHelper);
-        $session = $this->getSession($this->entityManager, $this->cidReqHelper);
+        $session = $this->cidReqHelper->getDoctrineSessionEntity();
         $showHidden = $this->canManageForumsInCurrentView($this->security, $request);
         $displayGroupForums = $this->shouldDisplayGroupForumsInGeneralTool($this->cidReqHelper);
         $terms = $this->getSearchTerms($query);

--- a/src/CoreBundle/State/Forum/ForumStateHelperTrait.php
+++ b/src/CoreBundle/State/Forum/ForumStateHelperTrait.php
@@ -66,6 +66,20 @@ trait ForumStateHelperTrait
             ?? throw new BadRequestHttpException('Missing course id.');
     }
 
+    /**
+     * SessionVoter proves the course/session pairing for students and course coaches, but not
+     * for general coaches or admins. Assert it before persisting a resource link, so an
+     * unrelated pair can never be written.
+     */
+    private function assertSessionBelongsToCourse(?Session $session, Course $course): void
+    {
+        if (!$session instanceof Session || $session->hasCourse($course)) {
+            return;
+        }
+
+        throw new AccessDeniedHttpException('The requested session is not linked to this course.');
+    }
+
     private function getGroup(EntityManagerInterface $entityManager, CidReqHelper $cidReqHelper): ?CGroup
     {
         $groupId = (int) ($cidReqHelper->getGroupId() ?? 0);

--- a/src/CoreBundle/State/Forum/ForumStateHelperTrait.php
+++ b/src/CoreBundle/State/Forum/ForumStateHelperTrait.php
@@ -10,7 +10,6 @@ use Chamilo\CoreBundle\Entity\AbstractResource;
 use Chamilo\CoreBundle\Entity\Course;
 use Chamilo\CoreBundle\Entity\ResourceNode;
 use Chamilo\CoreBundle\Entity\Session;
-use Chamilo\CoreBundle\Entity\SessionRelCourse;
 use Chamilo\CoreBundle\Helpers\CidReqHelper;
 use Chamilo\CourseBundle\Entity\CForum;
 use Chamilo\CourseBundle\Entity\CGroup;
@@ -57,51 +56,14 @@ trait ForumStateHelperTrait
         return $this->isTeacher($security) && !$this->isStudentView($request);
     }
 
+    /**
+     * CidReqListener already resolved and validated the course, so a missing entity here
+     * can only mean the request carried no course context at all.
+     */
     private function getCourse(CidReqHelper $cidReqHelper): Course
     {
-        $courseId = (int) ($cidReqHelper->getCourseId() ?? 0);
-        if ($courseId <= 0) {
-            throw new BadRequestHttpException('Missing course id.');
-        }
-
-        $course = $cidReqHelper->getDoctrineCourseEntity();
-        if (!$course instanceof Course) {
-            throw new NotFoundHttpException('Course not found.');
-        }
-
-        return $course;
-    }
-
-    private function getSession(EntityManagerInterface $entityManager, CidReqHelper $cidReqHelper): ?Session
-    {
-        $sessionId = (int) ($cidReqHelper->getSessionId() ?? 0);
-        if ($sessionId <= 0) {
-            return null;
-        }
-
-        $session = $cidReqHelper->getDoctrineSessionEntity();
-        if (!$session instanceof Session) {
-            throw new NotFoundHttpException('Session not found.');
-        }
-
-        $courseId = (int) ($cidReqHelper->getCourseId() ?? 0);
-        if ($courseId > 0) {
-            $course = $cidReqHelper->getDoctrineCourseEntity();
-            if (!$course instanceof Course) {
-                throw new NotFoundHttpException('Course not found.');
-            }
-
-            $sessionCourse = $entityManager->getRepository(SessionRelCourse::class)->findOneBy([
-                'course' => $course,
-                'session' => $session,
-            ]);
-
-            if (!$sessionCourse instanceof SessionRelCourse) {
-                throw new AccessDeniedHttpException('The requested session is not linked to this course.');
-            }
-        }
-
-        return $session;
+        return $cidReqHelper->getDoctrineCourseEntity()
+            ?? throw new BadRequestHttpException('Missing course id.');
     }
 
     private function getGroup(EntityManagerInterface $entityManager, CidReqHelper $cidReqHelper): ?CGroup

--- a/src/CoreBundle/State/Forum/ForumStateHelperTrait.php
+++ b/src/CoreBundle/State/Forum/ForumStateHelperTrait.php
@@ -11,6 +11,7 @@ use Chamilo\CoreBundle\Entity\Course;
 use Chamilo\CoreBundle\Entity\ResourceNode;
 use Chamilo\CoreBundle\Entity\Session;
 use Chamilo\CoreBundle\Entity\SessionRelCourse;
+use Chamilo\CoreBundle\Helpers\CidReqHelper;
 use Chamilo\CourseBundle\Entity\CForum;
 use Chamilo\CourseBundle\Entity\CGroup;
 use DateTimeImmutable;
@@ -56,14 +57,14 @@ trait ForumStateHelperTrait
         return $this->isTeacher($security) && !$this->isStudentView($request);
     }
 
-    private function getCourse(EntityManagerInterface $entityManager, Request $request): Course
+    private function getCourse(CidReqHelper $cidReqHelper): Course
     {
-        $courseId = $request->query->getInt('cid');
+        $courseId = (int) ($cidReqHelper->getCourseId() ?? 0);
         if ($courseId <= 0) {
             throw new BadRequestHttpException('Missing course id.');
         }
 
-        $course = $entityManager->getRepository(Course::class)->find($courseId);
+        $course = $cidReqHelper->getDoctrineCourseEntity();
         if (!$course instanceof Course) {
             throw new NotFoundHttpException('Course not found.');
         }
@@ -71,21 +72,21 @@ trait ForumStateHelperTrait
         return $course;
     }
 
-    private function getSession(EntityManagerInterface $entityManager, Request $request): ?Session
+    private function getSession(EntityManagerInterface $entityManager, CidReqHelper $cidReqHelper): ?Session
     {
-        $sessionId = $request->query->getInt('sid');
+        $sessionId = (int) ($cidReqHelper->getSessionId() ?? 0);
         if ($sessionId <= 0) {
             return null;
         }
 
-        $session = $entityManager->getRepository(Session::class)->find($sessionId);
+        $session = $cidReqHelper->getDoctrineSessionEntity();
         if (!$session instanceof Session) {
             throw new NotFoundHttpException('Session not found.');
         }
 
-        $courseId = $request->query->getInt('cid');
+        $courseId = (int) ($cidReqHelper->getCourseId() ?? 0);
         if ($courseId > 0) {
-            $course = $entityManager->getRepository(Course::class)->find($courseId);
+            $course = $cidReqHelper->getDoctrineCourseEntity();
             if (!$course instanceof Course) {
                 throw new NotFoundHttpException('Course not found.');
             }
@@ -103,9 +104,9 @@ trait ForumStateHelperTrait
         return $session;
     }
 
-    private function getGroup(EntityManagerInterface $entityManager, Request $request): ?CGroup
+    private function getGroup(EntityManagerInterface $entityManager, CidReqHelper $cidReqHelper): ?CGroup
     {
-        $groupId = $request->query->getInt('gid');
+        $groupId = (int) ($cidReqHelper->getGroupId() ?? 0);
         if ($groupId <= 0) {
             return null;
         }
@@ -191,9 +192,9 @@ trait ForumStateHelperTrait
         }
     }
 
-    private function canListForumWithCurrentSettings(CForum $forum, Request $request, bool $displayGroupForums): bool
+    private function canListForumWithCurrentSettings(CForum $forum, CidReqHelper $cidReqHelper, bool $displayGroupForums): bool
     {
-        if ($displayGroupForums || $request->query->getInt('gid') > 0) {
+        if ($displayGroupForums || (int) ($cidReqHelper->getGroupId() ?? 0) > 0) {
             return true;
         }
 

--- a/src/CoreBundle/State/Forum/ForumThreadCollectionStateProvider.php
+++ b/src/CoreBundle/State/Forum/ForumThreadCollectionStateProvider.php
@@ -12,6 +12,7 @@ use Chamilo\CoreBundle\ApiResource\Forum\ForumThreadsByForum;
 use Chamilo\CoreBundle\Entity\Course;
 use Chamilo\CoreBundle\Entity\Session;
 use Chamilo\CoreBundle\Entity\User;
+use Chamilo\CoreBundle\Helpers\CidReqHelper;
 use Chamilo\CoreBundle\Repository\Node\IllustrationRepository;
 use Chamilo\CoreBundle\Security\Authorization\Voter\ResourceNodeVoter;
 use Chamilo\CoreBundle\Security\CourseAccessResolver;
@@ -54,6 +55,7 @@ final class ForumThreadCollectionStateProvider implements ProviderInterface
         private readonly SettingsManager $settingsManager,
         private readonly IllustrationRepository $illustrationRepository,
         private readonly CourseAccessResolver $courseAccessResolver,
+        private readonly CidReqHelper $cidReqHelper,
     ) {}
 
     /**
@@ -93,9 +95,9 @@ final class ForumThreadCollectionStateProvider implements ProviderInterface
     {
         $this->assertForumMemberAccess($this->security, 'You are not allowed to access this forum.');
 
-        $course = $this->getCourse($this->entityManager, $request);
-        $session = $this->getSession($this->entityManager, $request);
-        $group = $this->getGroup($this->entityManager, $request);
+        $course = $this->getCourse($this->cidReqHelper);
+        $session = $this->getSession($this->entityManager, $this->cidReqHelper);
+        $group = $this->getGroup($this->entityManager, $this->cidReqHelper);
         $forum = $this->forumRepository->find($forumId);
         if (!$forum instanceof CForum) {
             throw new NotFoundHttpException('Forum not found.');

--- a/src/CoreBundle/State/Forum/ForumThreadCollectionStateProvider.php
+++ b/src/CoreBundle/State/Forum/ForumThreadCollectionStateProvider.php
@@ -96,7 +96,7 @@ final class ForumThreadCollectionStateProvider implements ProviderInterface
         $this->assertForumMemberAccess($this->security, 'You are not allowed to access this forum.');
 
         $course = $this->getCourse($this->cidReqHelper);
-        $session = $this->getSession($this->entityManager, $this->cidReqHelper);
+        $session = $this->cidReqHelper->getDoctrineSessionEntity();
         $group = $this->getGroup($this->entityManager, $this->cidReqHelper);
         $forum = $this->forumRepository->find($forumId);
         if (!$forum instanceof CForum) {

--- a/src/CoreBundle/State/Forum/ForumThreadGradingProcessor.php
+++ b/src/CoreBundle/State/Forum/ForumThreadGradingProcessor.php
@@ -15,6 +15,7 @@ use Chamilo\CoreBundle\Entity\GradebookLink;
 use Chamilo\CoreBundle\Entity\Session;
 use Chamilo\CoreBundle\Entity\SessionRelCourseRelUser;
 use Chamilo\CoreBundle\Entity\User;
+use Chamilo\CoreBundle\Helpers\CidReqHelper;
 use Chamilo\CoreBundle\Settings\SettingsManager;
 use Chamilo\CourseBundle\Entity\CForum;
 use Chamilo\CourseBundle\Entity\CForumPost;
@@ -54,6 +55,7 @@ final class ForumThreadGradingProcessor implements ProcessorInterface
         private readonly Security $security,
         private readonly CsrfTokenManagerInterface $csrfTokenManager,
         private readonly SettingsManager $settingsManager,
+        private readonly CidReqHelper $cidReqHelper,
     ) {}
 
     public function process(mixed $data, Operation $operation, array $uriVariables = [], array $context = []): JsonResponse
@@ -80,7 +82,7 @@ final class ForumThreadGradingProcessor implements ProcessorInterface
         $thread = $this->getThread($uriVariables, $request);
         $this->assertEditableForumResource($thread->getResourceNode(), $this->security);
 
-        $course = $this->getCourse($this->entityManager, $request);
+        $course = $this->getCourse($this->cidReqHelper);
         $this->assertForumThreadNotLockedByGradebook($this->entityManager, $this->settingsManager, $this->security, $course, $thread);
         $enabled = $this->getBoolean($payload, 'enabled');
 
@@ -177,8 +179,8 @@ final class ForumThreadGradingProcessor implements ProcessorInterface
             throw new NotFoundHttpException('User not found.');
         }
 
-        $course = $this->getCourse($this->entityManager, $request);
-        $session = $this->getSession($this->entityManager, $request);
+        $course = $this->getCourse($this->cidReqHelper);
+        $session = $this->getSession($this->entityManager, $this->cidReqHelper);
         $qualifyUser = $this->security->getUser();
         if (!$qualifyUser instanceof User) {
             throw new AccessDeniedHttpException('A valid user is required.');

--- a/src/CoreBundle/State/Forum/ForumThreadGradingProcessor.php
+++ b/src/CoreBundle/State/Forum/ForumThreadGradingProcessor.php
@@ -180,7 +180,7 @@ final class ForumThreadGradingProcessor implements ProcessorInterface
         }
 
         $course = $this->getCourse($this->cidReqHelper);
-        $session = $this->getSession($this->entityManager, $this->cidReqHelper);
+        $session = $this->cidReqHelper->getDoctrineSessionEntity();
         $qualifyUser = $this->security->getUser();
         if (!$qualifyUser instanceof User) {
             throw new AccessDeniedHttpException('A valid user is required.');

--- a/src/CoreBundle/State/Forum/ForumThreadGradingProvider.php
+++ b/src/CoreBundle/State/Forum/ForumThreadGradingProvider.php
@@ -74,7 +74,7 @@ final class ForumThreadGradingProvider implements ProviderInterface
         }
 
         $course = $this->getCourse($this->cidReqHelper);
-        $session = $this->getSession($this->entityManager, $this->cidReqHelper);
+        $session = $this->cidReqHelper->getDoctrineSessionEntity();
         $currentUser = $this->security->getUser();
         if (!$currentUser instanceof User) {
             throw new AccessDeniedHttpException('A valid user is required.');

--- a/src/CoreBundle/State/Forum/ForumThreadGradingProvider.php
+++ b/src/CoreBundle/State/Forum/ForumThreadGradingProvider.php
@@ -16,6 +16,7 @@ use Chamilo\CoreBundle\Entity\GradebookLink;
 use Chamilo\CoreBundle\Entity\Session;
 use Chamilo\CoreBundle\Entity\SessionRelCourseRelUser;
 use Chamilo\CoreBundle\Entity\User;
+use Chamilo\CoreBundle\Helpers\CidReqHelper;
 use Chamilo\CoreBundle\Repository\GradeBookCategoryRepository;
 use Chamilo\CourseBundle\Entity\CForum;
 use Chamilo\CourseBundle\Entity\CForumPost;
@@ -47,6 +48,7 @@ final class ForumThreadGradingProvider implements ProviderInterface
         private readonly CForumThreadRepository $threadRepository,
         private readonly GradeBookCategoryRepository $gradebookCategoryRepository,
         private readonly Security $security,
+        private readonly CidReqHelper $cidReqHelper,
     ) {}
 
     /**
@@ -71,8 +73,8 @@ final class ForumThreadGradingProvider implements ProviderInterface
             throw new NotFoundHttpException('Forum not found.');
         }
 
-        $course = $this->getCourse($this->entityManager, $request);
-        $session = $this->getSession($this->entityManager, $request);
+        $course = $this->getCourse($this->cidReqHelper);
+        $session = $this->getSession($this->entityManager, $this->cidReqHelper);
         $currentUser = $this->security->getUser();
         if (!$currentUser instanceof User) {
             throw new AccessDeniedHttpException('A valid user is required.');

--- a/src/CoreBundle/State/Forum/ForumThreadPostsStateProvider.php
+++ b/src/CoreBundle/State/Forum/ForumThreadPostsStateProvider.php
@@ -13,6 +13,7 @@ use Chamilo\CoreBundle\Entity\Course;
 use Chamilo\CoreBundle\Entity\ResourceNode;
 use Chamilo\CoreBundle\Entity\Session;
 use Chamilo\CoreBundle\Entity\User;
+use Chamilo\CoreBundle\Helpers\CidReqHelper;
 use Chamilo\CoreBundle\Repository\ExtraFieldValuesRepository;
 use Chamilo\CoreBundle\Repository\Node\IllustrationRepository;
 use Chamilo\CoreBundle\Security\Authorization\Voter\ResourceNodeVoter;
@@ -64,6 +65,7 @@ final class ForumThreadPostsStateProvider implements ProviderInterface
         private readonly ExtraFieldValuesRepository $extraFieldValuesRepository,
         private readonly IllustrationRepository $illustrationRepository,
         private readonly CourseAccessResolver $courseAccessResolver,
+        private readonly CidReqHelper $cidReqHelper,
     ) {}
 
     /**
@@ -127,9 +129,9 @@ final class ForumThreadPostsStateProvider implements ProviderInterface
             throw new BadRequestHttpException('Forum does not match the requested thread.');
         }
 
-        $course = $this->getCourse($this->entityManager, $request);
-        $session = $this->getSession($this->entityManager, $request);
-        $group = $this->getGroup($this->entityManager, $request);
+        $course = $this->getCourse($this->cidReqHelper);
+        $session = $this->getSession($this->entityManager, $this->cidReqHelper);
+        $group = $this->getGroup($this->entityManager, $this->cidReqHelper);
         $canManage = $this->canManageForumsInCurrentView($this->security, $request);
         $user = $this->getCurrentUser();
         $canSubscribe = !$this->areForumPostNotificationsHidden($course);
@@ -620,7 +622,7 @@ final class ForumThreadPostsStateProvider implements ProviderInterface
         }
 
         try {
-            $course = $this->getCourse($this->entityManager, $request);
+            $course = $this->getCourse($this->cidReqHelper);
         } catch (Throwable) {
             return false;
         }

--- a/src/CoreBundle/State/Forum/ForumThreadPostsStateProvider.php
+++ b/src/CoreBundle/State/Forum/ForumThreadPostsStateProvider.php
@@ -130,7 +130,7 @@ final class ForumThreadPostsStateProvider implements ProviderInterface
         }
 
         $course = $this->getCourse($this->cidReqHelper);
-        $session = $this->getSession($this->entityManager, $this->cidReqHelper);
+        $session = $this->cidReqHelper->getDoctrineSessionEntity();
         $group = $this->getGroup($this->entityManager, $this->cidReqHelper);
         $canManage = $this->canManageForumsInCurrentView($this->security, $request);
         $user = $this->getCurrentUser();

--- a/src/CoreBundle/State/Forum/ForumThreadProcessor.php
+++ b/src/CoreBundle/State/Forum/ForumThreadProcessor.php
@@ -14,6 +14,7 @@ use Chamilo\CoreBundle\Entity\GradebookLink;
 use Chamilo\CoreBundle\Entity\ResourceNode;
 use Chamilo\CoreBundle\Entity\Session;
 use Chamilo\CoreBundle\Entity\User;
+use Chamilo\CoreBundle\Helpers\CidReqHelper;
 use Chamilo\CoreBundle\Helpers\MessageHelper;
 use Chamilo\CoreBundle\Security\Upload\UploadFilenamePolicy;
 use Chamilo\CoreBundle\Settings\SettingsManager;
@@ -70,6 +71,7 @@ final class ForumThreadProcessor implements ProcessorInterface
         private readonly UploadFilenamePolicy $uploadFilenamePolicy,
         private readonly SettingsManager $settingsManager,
         private readonly MessageHelper $messageHelper,
+        private readonly CidReqHelper $cidReqHelper,
     ) {}
 
     public function process(mixed $data, Operation $operation, array $uriVariables = [], array $context = []): JsonResponse
@@ -113,9 +115,9 @@ final class ForumThreadProcessor implements ProcessorInterface
 
         $title = $this->getRequiredText($data, 'title', 250);
         $text = $this->getRequiredHtmlText($data, 'text');
-        $course = $this->getCourse($this->entityManager, $request);
-        $session = $this->getSession($this->entityManager, $request);
-        $group = $this->getGroup($this->entityManager, $request);
+        $course = $this->getCourse($this->cidReqHelper);
+        $session = $this->getSession($this->entityManager, $this->cidReqHelper);
+        $group = $this->getGroup($this->entityManager, $this->cidReqHelper);
         $this->assertResourceNodeInForumContext(
             $forum->getResourceNode(),
             $course,
@@ -189,7 +191,7 @@ final class ForumThreadProcessor implements ProcessorInterface
         }
 
         if ($visible) {
-            $this->sendForumSubscriptionNotifications($this->entityManager, $request, $course, $session, $forum, $thread, $post, $user, $this->messageHelper);
+            $this->sendForumSubscriptionNotifications($this->entityManager, $request, $course, $session, $forum, $thread, $post, $user, $this->messageHelper, $this->cidReqHelper);
         }
 
         $this->registerForumEventLog('new-thread', 'thread', (string) $thread->getIid());
@@ -221,7 +223,7 @@ final class ForumThreadProcessor implements ProcessorInterface
         $this->assertEditableResource($data->getResourceNode(), 'edit');
         $this->assertEditableResource($forum->getResourceNode(), 'edit');
 
-        $course = $this->getCourse($this->entityManager, $request);
+        $course = $this->getCourse($this->cidReqHelper);
         $this->assertForumThreadNotLockedByGradebook($this->entityManager, $this->settingsManager, $this->security, $course, $data);
 
         $data->setTitle($this->getRequiredText($payload, 'title', 250));
@@ -260,7 +262,7 @@ final class ForumThreadProcessor implements ProcessorInterface
         $this->assertEditableResource($data->getResourceNode(), 'delete');
         $this->assertEditableResource($forum->getResourceNode(), 'delete');
 
-        $course = $this->getCourse($this->entityManager, $request);
+        $course = $this->getCourse($this->cidReqHelper);
         $this->assertForumThreadNotLockedByGradebook($this->entityManager, $this->settingsManager, $this->security, $course, $data);
 
         $threadId = (int) $data->getIid();
@@ -310,7 +312,7 @@ final class ForumThreadProcessor implements ProcessorInterface
 
         $this->assertEditableForumResource($data->getResourceNode(), $this->security);
         $this->assertEditableForumResource($forum->getResourceNode(), $this->security);
-        $course = $this->getCourse($this->entityManager, $request);
+        $course = $this->getCourse($this->cidReqHelper);
         $this->assertForumThreadNotLockedByGradebook($this->entityManager, $this->settingsManager, $this->security, $course, $data);
 
         $data->setLocked(0 === $data->getLocked() ? 1 : 0);
@@ -343,7 +345,7 @@ final class ForumThreadProcessor implements ProcessorInterface
 
         $this->assertEditableForumResource($data->getResourceNode(), $this->security);
         $this->assertEditableForumResource($forum->getResourceNode(), $this->security);
-        $course = $this->getCourse($this->entityManager, $request);
+        $course = $this->getCourse($this->cidReqHelper);
         $this->assertForumThreadNotLockedByGradebook($this->entityManager, $this->settingsManager, $this->security, $course, $data);
 
         $data->setThreadSticky(!$data->getThreadSticky());
@@ -377,8 +379,8 @@ final class ForumThreadProcessor implements ProcessorInterface
         $this->assertEditableForumResource($data->getResourceNode(), $this->security);
         $this->assertEditableForumResource($forum->getResourceNode(), $this->security);
 
-        $course = $this->getCourse($this->entityManager, $request);
-        $session = $this->getSession($this->entityManager, $request);
+        $course = $this->getCourse($this->cidReqHelper);
+        $session = $this->getSession($this->entityManager, $this->cidReqHelper);
         $this->assertForumThreadNotLockedByGradebook($this->entityManager, $this->settingsManager, $this->security, $course, $data);
         $targetVisible = $this->getTargetVisibility($payload, $data, $course, $session);
         $visible = $this->setForumResourceVisibility($data, $this->threadRepository, $course, $session, $targetVisible);
@@ -421,9 +423,9 @@ final class ForumThreadProcessor implements ProcessorInterface
         $this->assertEditableForumResource($sourceForum->getResourceNode(), $this->security);
         $this->assertEditableForumResource($targetForum->getResourceNode(), $this->security);
 
-        $course = $this->getCourse($this->entityManager, $request);
-        $session = $this->getSession($this->entityManager, $request);
-        $group = $this->getGroup($this->entityManager, $request);
+        $course = $this->getCourse($this->cidReqHelper);
+        $session = $this->getSession($this->entityManager, $this->cidReqHelper);
+        $group = $this->getGroup($this->entityManager, $this->cidReqHelper);
         $this->assertForumBelongsToCurrentContext($targetForum, $course, $session, $group);
         $this->assertForumThreadNotLockedByGradebook($this->entityManager, $this->settingsManager, $this->security, $course, $data);
 
@@ -455,7 +457,7 @@ final class ForumThreadProcessor implements ProcessorInterface
         $payload = $this->getJsonData($request);
         $this->validateCsrfToken($this->csrfTokenManager, $payload['csrfToken'] ?? null);
 
-        $course = $this->getCourse($this->entityManager, $request);
+        $course = $this->getCourse($this->cidReqHelper);
         if ($this->areForumPostNotificationsHidden($this->entityManager, $course)) {
             throw new AccessDeniedHttpException('Forum notifications are disabled for this course.');
         }

--- a/src/CoreBundle/State/Forum/ForumThreadProcessor.php
+++ b/src/CoreBundle/State/Forum/ForumThreadProcessor.php
@@ -117,6 +117,7 @@ final class ForumThreadProcessor implements ProcessorInterface
         $text = $this->getRequiredHtmlText($data, 'text');
         $course = $this->getCourse($this->cidReqHelper);
         $session = $this->cidReqHelper->getDoctrineSessionEntity();
+        $this->assertSessionBelongsToCourse($session, $course);
         $group = $this->getGroup($this->entityManager, $this->cidReqHelper);
         $this->assertResourceNodeInForumContext(
             $forum->getResourceNode(),

--- a/src/CoreBundle/State/Forum/ForumThreadProcessor.php
+++ b/src/CoreBundle/State/Forum/ForumThreadProcessor.php
@@ -116,7 +116,7 @@ final class ForumThreadProcessor implements ProcessorInterface
         $title = $this->getRequiredText($data, 'title', 250);
         $text = $this->getRequiredHtmlText($data, 'text');
         $course = $this->getCourse($this->cidReqHelper);
-        $session = $this->getSession($this->entityManager, $this->cidReqHelper);
+        $session = $this->cidReqHelper->getDoctrineSessionEntity();
         $group = $this->getGroup($this->entityManager, $this->cidReqHelper);
         $this->assertResourceNodeInForumContext(
             $forum->getResourceNode(),
@@ -380,7 +380,7 @@ final class ForumThreadProcessor implements ProcessorInterface
         $this->assertEditableForumResource($forum->getResourceNode(), $this->security);
 
         $course = $this->getCourse($this->cidReqHelper);
-        $session = $this->getSession($this->entityManager, $this->cidReqHelper);
+        $session = $this->cidReqHelper->getDoctrineSessionEntity();
         $this->assertForumThreadNotLockedByGradebook($this->entityManager, $this->settingsManager, $this->security, $course, $data);
         $targetVisible = $this->getTargetVisibility($payload, $data, $course, $session);
         $visible = $this->setForumResourceVisibility($data, $this->threadRepository, $course, $session, $targetVisible);
@@ -424,7 +424,7 @@ final class ForumThreadProcessor implements ProcessorInterface
         $this->assertEditableForumResource($targetForum->getResourceNode(), $this->security);
 
         $course = $this->getCourse($this->cidReqHelper);
-        $session = $this->getSession($this->entityManager, $this->cidReqHelper);
+        $session = $this->cidReqHelper->getDoctrineSessionEntity();
         $group = $this->getGroup($this->entityManager, $this->cidReqHelper);
         $this->assertForumBelongsToCurrentContext($targetForum, $course, $session, $group);
         $this->assertForumThreadNotLockedByGradebook($this->entityManager, $this->settingsManager, $this->security, $course, $data);

--- a/src/CoreBundle/State/LearningPath/LearningPathAiGeneratorProcessor.php
+++ b/src/CoreBundle/State/LearningPath/LearningPathAiGeneratorProcessor.php
@@ -68,7 +68,7 @@ final readonly class LearningPathAiGeneratorProcessor implements ProcessorInterf
         $this->assertLearningPathTeacher($this->security);
 
         $course = $this->getContextCourse($this->cidReqHelper);
-        $session = $this->getContextSession($this->entityManager, $this->cidReqHelper, $course);
+        $session = $this->cidReqHelper->getDoctrineSessionEntity();
         $group = $this->getContextGroup($this->entityManager, $this->cidReqHelper, $course);
 
         if (!$this->isFeatureEnabled($course)) {

--- a/src/CoreBundle/State/LearningPath/LearningPathAiGeneratorProcessor.php
+++ b/src/CoreBundle/State/LearningPath/LearningPathAiGeneratorProcessor.php
@@ -12,6 +12,7 @@ use Chamilo\CoreBundle\ApiResource\LearningPath\LearningPathAiGenerator;
 use Chamilo\CoreBundle\Entity\Course;
 use Chamilo\CoreBundle\Entity\ResourceNode;
 use Chamilo\CoreBundle\Helpers\AiDisclosureHelper;
+use Chamilo\CoreBundle\Helpers\CidReqHelper;
 use Chamilo\CoreBundle\Settings\SettingsManager;
 use Chamilo\CourseBundle\Entity\CGroup;
 use Chamilo\CourseBundle\Entity\CLp;
@@ -42,6 +43,7 @@ final readonly class LearningPathAiGeneratorProcessor implements ProcessorInterf
         private SettingsCourseManager $settingsCourseManager,
         private CLpRepository $lpRepository,
         private AiDisclosureHelper $aiDisclosureHelper,
+        private CidReqHelper $cidReqHelper,
     ) {}
 
     /**
@@ -65,9 +67,9 @@ final readonly class LearningPathAiGeneratorProcessor implements ProcessorInterf
 
         $this->assertLearningPathTeacher($this->security);
 
-        $course = $this->getContextCourse($this->entityManager, $request);
-        $session = $this->getContextSession($this->entityManager, $request, $course);
-        $group = $this->getContextGroup($this->entityManager, $request, $course);
+        $course = $this->getContextCourse($this->cidReqHelper);
+        $session = $this->getContextSession($this->entityManager, $this->cidReqHelper, $course);
+        $group = $this->getContextGroup($this->entityManager, $this->cidReqHelper, $course);
 
         if (!$this->isFeatureEnabled($course)) {
             throw new AccessDeniedHttpException('AI learning path generation is disabled in this course.');

--- a/src/CoreBundle/State/LearningPath/LearningPathAiGeneratorProvider.php
+++ b/src/CoreBundle/State/LearningPath/LearningPathAiGeneratorProvider.php
@@ -54,7 +54,7 @@ final readonly class LearningPathAiGeneratorProvider implements ProviderInterfac
         $this->assertLearningPathTeacher($this->security);
 
         $course = $this->getContextCourse($this->cidReqHelper);
-        $this->getContextSession($this->entityManager, $this->cidReqHelper, $course);
+        $this->cidReqHelper->getDoctrineSessionEntity();
         $this->getContextGroup($this->entityManager, $this->cidReqHelper, $course);
 
         $result = new LearningPathAiGenerator();

--- a/src/CoreBundle/State/LearningPath/LearningPathAiGeneratorProvider.php
+++ b/src/CoreBundle/State/LearningPath/LearningPathAiGeneratorProvider.php
@@ -11,6 +11,7 @@ use ApiPlatform\State\ProviderInterface;
 use Chamilo\CoreBundle\AiProvider\AiProviderFactory;
 use Chamilo\CoreBundle\ApiResource\LearningPath\LearningPathAiGenerator;
 use Chamilo\CoreBundle\Entity\Course;
+use Chamilo\CoreBundle\Helpers\CidReqHelper;
 use Chamilo\CoreBundle\Settings\SettingsManager;
 use Chamilo\CourseBundle\Settings\SettingsCourseManager;
 use Doctrine\ORM\EntityManagerInterface;
@@ -33,6 +34,7 @@ final readonly class LearningPathAiGeneratorProvider implements ProviderInterfac
         private SettingsManager $settingsManager,
         private SettingsCourseManager $settingsCourseManager,
         private AiProviderFactory $aiProviderFactory,
+        private CidReqHelper $cidReqHelper,
     ) {}
 
     /**
@@ -51,9 +53,9 @@ final readonly class LearningPathAiGeneratorProvider implements ProviderInterfac
 
         $this->assertLearningPathTeacher($this->security);
 
-        $course = $this->getContextCourse($this->entityManager, $request);
-        $this->getContextSession($this->entityManager, $request, $course);
-        $this->getContextGroup($this->entityManager, $request, $course);
+        $course = $this->getContextCourse($this->cidReqHelper);
+        $this->getContextSession($this->entityManager, $this->cidReqHelper, $course);
+        $this->getContextGroup($this->entityManager, $this->cidReqHelper, $course);
 
         $result = new LearningPathAiGenerator();
         $result->enabled = $this->isFeatureEnabled($course);

--- a/src/CoreBundle/State/LearningPath/LearningPathBuilderMutationProcessor.php
+++ b/src/CoreBundle/State/LearningPath/LearningPathBuilderMutationProcessor.php
@@ -104,7 +104,7 @@ final readonly class LearningPathBuilderMutationProcessor implements ProcessorIn
 
         $this->assertLearningPathTeacher($this->security);
         $course = $this->getContextCourse($this->cidReqHelper);
-        $session = $this->getContextSession($this->entityManager, $this->cidReqHelper, $course);
+        $session = $this->cidReqHelper->getDoctrineSessionEntity();
         $group = $this->getContextGroup($this->entityManager, $this->cidReqHelper, $course);
 
         if ($data instanceof LearningPathBuilderItemUpdateInput

--- a/src/CoreBundle/State/LearningPath/LearningPathBuilderMutationProcessor.php
+++ b/src/CoreBundle/State/LearningPath/LearningPathBuilderMutationProcessor.php
@@ -28,6 +28,7 @@ use Chamilo\CoreBundle\Entity\ResourceFile;
 use Chamilo\CoreBundle\Entity\ResourceLink;
 use Chamilo\CoreBundle\Entity\Session;
 use Chamilo\CoreBundle\Entity\User;
+use Chamilo\CoreBundle\Helpers\CidReqHelper;
 use Chamilo\CoreBundle\Repository\ExtraFieldRepository;
 use Chamilo\CoreBundle\Repository\ResourceNodeRepository;
 use Chamilo\CoreBundle\Settings\SettingsManager;
@@ -87,6 +88,7 @@ final readonly class LearningPathBuilderMutationProcessor implements ProcessorIn
         private CLpItemRepository $lpItemRepository,
         private ResourceNodeRepository $resourceNodeRepository,
         private ExtraFieldRepository $extraFieldRepository,
+        private CidReqHelper $cidReqHelper,
     ) {}
 
     /**
@@ -101,9 +103,9 @@ final readonly class LearningPathBuilderMutationProcessor implements ProcessorIn
         }
 
         $this->assertLearningPathTeacher($this->security);
-        $course = $this->getContextCourse($this->entityManager, $request);
-        $session = $this->getContextSession($this->entityManager, $request, $course);
-        $group = $this->getContextGroup($this->entityManager, $request, $course);
+        $course = $this->getContextCourse($this->cidReqHelper);
+        $session = $this->getContextSession($this->entityManager, $this->cidReqHelper, $course);
+        $group = $this->getContextGroup($this->entityManager, $this->cidReqHelper, $course);
 
         if ($data instanceof LearningPathBuilderItemUpdateInput
             && 'update_learning_path_builder_item_form' === $operation->getName()

--- a/src/CoreBundle/State/LearningPath/LearningPathBuilderProvider.php
+++ b/src/CoreBundle/State/LearningPath/LearningPathBuilderProvider.php
@@ -19,6 +19,7 @@ use Chamilo\CoreBundle\Entity\ResourceLink;
 use Chamilo\CoreBundle\Entity\Session;
 use Chamilo\CoreBundle\Entity\User;
 use Chamilo\CoreBundle\Helpers\AiFeatureAccessHelper;
+use Chamilo\CoreBundle\Helpers\CidReqHelper;
 use Chamilo\CoreBundle\Repository\ExtraFieldRepository;
 use Chamilo\CoreBundle\Repository\ResourceNodeRepository;
 use Chamilo\CoreBundle\Settings\SettingsManager;
@@ -40,8 +41,6 @@ use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\Filesystem\Exception\FileNotFoundException;
-use Symfony\Component\HttpFoundation\RequestStack;
-use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\Security\Csrf\CsrfTokenManagerInterface;
 
@@ -60,7 +59,6 @@ final readonly class LearningPathBuilderProvider implements ProviderInterface
 
     public function __construct(
         private EntityManagerInterface $entityManager,
-        private RequestStack $requestStack,
         private Security $security,
         private CsrfTokenManagerInterface $csrfTokenManager,
         private SettingsManager $settingsManager,
@@ -71,6 +69,7 @@ final readonly class LearningPathBuilderProvider implements ProviderInterface
         private ResourceNodeRepository $resourceNodeRepository,
         private AiFeatureAccessHelper $aiFeatureAccessHelper,
         private AiProviderFactory $aiProviderFactory,
+        private CidReqHelper $cidReqHelper,
     ) {}
 
     /**
@@ -79,15 +78,10 @@ final readonly class LearningPathBuilderProvider implements ProviderInterface
      */
     public function provide(Operation $operation, array $uriVariables = [], array $context = []): LearningPathBuilder
     {
-        $request = $this->requestStack->getCurrentRequest();
-        if (null === $request) {
-            throw new BadRequestHttpException('Request is missing.');
-        }
-
         $this->assertLearningPathTeacher($this->security);
-        $course = $this->getContextCourse($this->entityManager, $request);
-        $session = $this->getContextSession($this->entityManager, $request, $course);
-        $group = $this->getContextGroup($this->entityManager, $request, $course);
+        $course = $this->getContextCourse($this->cidReqHelper);
+        $session = $this->getContextSession($this->entityManager, $this->cidReqHelper, $course);
+        $group = $this->getContextGroup($this->entityManager, $this->cidReqHelper, $course);
 
         $lpId = (int) ($uriVariables['lpId'] ?? 0);
         $lp = $this->lpRepository->find($lpId);

--- a/src/CoreBundle/State/LearningPath/LearningPathBuilderProvider.php
+++ b/src/CoreBundle/State/LearningPath/LearningPathBuilderProvider.php
@@ -80,7 +80,7 @@ final readonly class LearningPathBuilderProvider implements ProviderInterface
     {
         $this->assertLearningPathTeacher($this->security);
         $course = $this->getContextCourse($this->cidReqHelper);
-        $session = $this->getContextSession($this->entityManager, $this->cidReqHelper, $course);
+        $session = $this->cidReqHelper->getDoctrineSessionEntity();
         $group = $this->getContextGroup($this->entityManager, $this->cidReqHelper, $course);
 
         $lpId = (int) ($uriVariables['lpId'] ?? 0);

--- a/src/CoreBundle/State/LearningPath/LearningPathCategoryCollectionProvider.php
+++ b/src/CoreBundle/State/LearningPath/LearningPathCategoryCollectionProvider.php
@@ -81,7 +81,7 @@ final readonly class LearningPathCategoryCollectionProvider implements ProviderI
             }
         }
 
-        $group = $this->getValidatedGroupFromContext($this->entityManager, $this->cidReqHelper, $course);
+        $group = $this->getContextGroup($this->entityManager, $this->cidReqHelper, $course);
         $canManage = $this->canManageLearningPaths($this->security)
             && !$this->isStudentViewRequest($this->requestStack);
 

--- a/src/CoreBundle/State/LearningPath/LearningPathCategoryMutationProcessor.php
+++ b/src/CoreBundle/State/LearningPath/LearningPathCategoryMutationProcessor.php
@@ -14,6 +14,7 @@ use Chamilo\CoreBundle\Entity\ResourceLink;
 use Chamilo\CoreBundle\Entity\ResourceNode;
 use Chamilo\CoreBundle\Entity\Session;
 use Chamilo\CoreBundle\Entity\User;
+use Chamilo\CoreBundle\Helpers\CidReqHelper;
 use Chamilo\CoreBundle\Repository\ResourceLinkRepository;
 use Chamilo\CoreBundle\Settings\SettingsManager;
 use Chamilo\CourseBundle\Entity\CGroup;
@@ -21,7 +22,6 @@ use Chamilo\CourseBundle\Entity\CLpCategory;
 use Chamilo\CourseBundle\Repository\CShortcutRepository;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\SecurityBundle\Security;
-use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
@@ -34,24 +34,20 @@ final readonly class LearningPathCategoryMutationProcessor implements ProcessorI
 
     public function __construct(
         private EntityManagerInterface $entityManager,
-        private RequestStack $requestStack,
         private Security $security,
         private CsrfTokenManagerInterface $csrfTokenManager,
         private CShortcutRepository $shortcutRepository,
         private ResourceLinkRepository $resourceLinkRepository,
         private SettingsManager $settingsManager,
+        private CidReqHelper $cidReqHelper,
     ) {}
 
     public function process(mixed $data, Operation $operation, array $uriVariables = [], array $context = []): void
     {
-        $request = $this->requestStack->getCurrentRequest();
-        if (null === $request) {
-            throw new BadRequestHttpException('Request is missing.');
-        }
         $this->assertLearningPathTeacher($this->security);
-        $course = $this->getContextCourse($this->entityManager, $request);
-        $session = $this->getContextSession($this->entityManager, $request, $course);
-        $group = $this->getContextGroup($this->entityManager, $request, $course);
+        $course = $this->getContextCourse($this->cidReqHelper);
+        $session = $this->getContextSession($this->entityManager, $this->cidReqHelper, $course);
+        $group = $this->getContextGroup($this->entityManager, $this->cidReqHelper, $course);
         $categoryId = (int) ($uriVariables['id'] ?? 0);
         $category = $categoryId > 0 ? $this->entityManager->getRepository(CLpCategory::class)->find($categoryId) : new CLpCategory();
         if (!$category instanceof CLpCategory) {

--- a/src/CoreBundle/State/LearningPath/LearningPathCategoryMutationProcessor.php
+++ b/src/CoreBundle/State/LearningPath/LearningPathCategoryMutationProcessor.php
@@ -46,7 +46,7 @@ final readonly class LearningPathCategoryMutationProcessor implements ProcessorI
     {
         $this->assertLearningPathTeacher($this->security);
         $course = $this->getContextCourse($this->cidReqHelper);
-        $session = $this->getContextSession($this->entityManager, $this->cidReqHelper, $course);
+        $session = $this->cidReqHelper->getDoctrineSessionEntity();
         $group = $this->getContextGroup($this->entityManager, $this->cidReqHelper, $course);
         $categoryId = (int) ($uriVariables['id'] ?? 0);
         $category = $categoryId > 0 ? $this->entityManager->getRepository(CLpCategory::class)->find($categoryId) : new CLpCategory();

--- a/src/CoreBundle/State/LearningPath/LearningPathCategoryReorderProcessor.php
+++ b/src/CoreBundle/State/LearningPath/LearningPathCategoryReorderProcessor.php
@@ -9,6 +9,7 @@ namespace Chamilo\CoreBundle\State\LearningPath;
 use ApiPlatform\Metadata\Operation;
 use ApiPlatform\State\ProcessorInterface;
 use Chamilo\CoreBundle\Entity\ResourceLink;
+use Chamilo\CoreBundle\Helpers\CidReqHelper;
 use Chamilo\CourseBundle\Entity\CLpCategory;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\SecurityBundle\Security;
@@ -30,6 +31,7 @@ final readonly class LearningPathCategoryReorderProcessor implements ProcessorIn
         private RequestStack $requestStack,
         private Security $security,
         private CsrfTokenManagerInterface $csrfTokenManager,
+        private CidReqHelper $cidReqHelper,
     ) {}
 
     public function process(mixed $data, Operation $operation, array $uriVariables = [], array $context = []): JsonResponse
@@ -43,9 +45,9 @@ final readonly class LearningPathCategoryReorderProcessor implements ProcessorIn
         $this->validateActionToken($this->csrfTokenManager, $payload['csrfToken'] ?? null);
         $this->assertLearningPathTeacher($this->security);
 
-        $course = $this->getContextCourse($this->entityManager, $request);
-        $session = $this->getContextSession($this->entityManager, $request, $course);
-        $group = $this->getContextGroup($this->entityManager, $request, $course);
+        $course = $this->getContextCourse($this->cidReqHelper);
+        $session = $this->getContextSession($this->entityManager, $this->cidReqHelper, $course);
+        $group = $this->getContextGroup($this->entityManager, $this->cidReqHelper, $course);
 
         $order = $payload['order'] ?? null;
         if (!\is_array($order) || [] === $order) {

--- a/src/CoreBundle/State/LearningPath/LearningPathCategoryReorderProcessor.php
+++ b/src/CoreBundle/State/LearningPath/LearningPathCategoryReorderProcessor.php
@@ -46,7 +46,7 @@ final readonly class LearningPathCategoryReorderProcessor implements ProcessorIn
         $this->assertLearningPathTeacher($this->security);
 
         $course = $this->getContextCourse($this->cidReqHelper);
-        $session = $this->getContextSession($this->entityManager, $this->cidReqHelper, $course);
+        $session = $this->cidReqHelper->getDoctrineSessionEntity();
         $group = $this->getContextGroup($this->entityManager, $this->cidReqHelper, $course);
 
         $order = $payload['order'] ?? null;

--- a/src/CoreBundle/State/LearningPath/LearningPathCategorySubscriptionProcessor.php
+++ b/src/CoreBundle/State/LearningPath/LearningPathCategorySubscriptionProcessor.php
@@ -17,6 +17,7 @@ use Chamilo\CoreBundle\Entity\Session;
 use Chamilo\CoreBundle\Entity\SessionRelCourseRelUser;
 use Chamilo\CoreBundle\Entity\User;
 use Chamilo\CoreBundle\Entity\Usergroup;
+use Chamilo\CoreBundle\Helpers\CidReqHelper;
 use Chamilo\CoreBundle\Settings\SettingsManager;
 use Chamilo\CourseBundle\Entity\CGroup;
 use Chamilo\CourseBundle\Entity\CLpCategory;
@@ -51,6 +52,7 @@ final readonly class LearningPathCategorySubscriptionProcessor implements Proces
         private Security $security,
         private SettingsManager $settingsManager,
         private CsrfTokenManagerInterface $csrfTokenManager,
+        private CidReqHelper $cidReqHelper,
     ) {}
 
     /**
@@ -70,9 +72,9 @@ final readonly class LearningPathCategorySubscriptionProcessor implements Proces
 
         $this->assertLearningPathTeacher($this->security);
         $this->validateActionToken($this->csrfTokenManager, $data->csrfTokenInput);
-        $course = $this->getContextCourse($this->entityManager, $request);
-        $session = $this->getContextSession($this->entityManager, $request, $course);
-        $group = $this->getContextGroup($this->entityManager, $request, $course);
+        $course = $this->getContextCourse($this->cidReqHelper);
+        $session = $this->getContextSession($this->entityManager, $this->cidReqHelper, $course);
+        $group = $this->getContextGroup($this->entityManager, $this->cidReqHelper, $course);
         $category = $this->getCategory($uriVariables);
         $this->assertCategoryContext($category, $course, $session, $group);
         $this->assertCategorySubscriptionsEnabled();

--- a/src/CoreBundle/State/LearningPath/LearningPathCategorySubscriptionProcessor.php
+++ b/src/CoreBundle/State/LearningPath/LearningPathCategorySubscriptionProcessor.php
@@ -73,7 +73,7 @@ final readonly class LearningPathCategorySubscriptionProcessor implements Proces
         $this->assertLearningPathTeacher($this->security);
         $this->validateActionToken($this->csrfTokenManager, $data->csrfTokenInput);
         $course = $this->getContextCourse($this->cidReqHelper);
-        $session = $this->getContextSession($this->entityManager, $this->cidReqHelper, $course);
+        $session = $this->cidReqHelper->getDoctrineSessionEntity();
         $group = $this->getContextGroup($this->entityManager, $this->cidReqHelper, $course);
         $category = $this->getCategory($uriVariables);
         $this->assertCategoryContext($category, $course, $session, $group);

--- a/src/CoreBundle/State/LearningPath/LearningPathCategorySubscriptionProvider.php
+++ b/src/CoreBundle/State/LearningPath/LearningPathCategorySubscriptionProvider.php
@@ -17,6 +17,7 @@ use Chamilo\CoreBundle\Entity\Session;
 use Chamilo\CoreBundle\Entity\SessionRelCourseRelUser;
 use Chamilo\CoreBundle\Entity\User;
 use Chamilo\CoreBundle\Entity\Usergroup;
+use Chamilo\CoreBundle\Helpers\CidReqHelper;
 use Chamilo\CoreBundle\Settings\SettingsManager;
 use Chamilo\CourseBundle\Entity\CGroup;
 use Chamilo\CourseBundle\Entity\CLpCategory;
@@ -44,6 +45,7 @@ final readonly class LearningPathCategorySubscriptionProvider implements Provide
         private Security $security,
         private SettingsManager $settingsManager,
         private CsrfTokenManagerInterface $csrfTokenManager,
+        private CidReqHelper $cidReqHelper,
     ) {}
 
     /**
@@ -58,9 +60,9 @@ final readonly class LearningPathCategorySubscriptionProvider implements Provide
         }
 
         $this->assertLearningPathTeacher($this->security);
-        $course = $this->getContextCourse($this->entityManager, $request);
-        $session = $this->getContextSession($this->entityManager, $request, $course);
-        $group = $this->getContextGroup($this->entityManager, $request, $course);
+        $course = $this->getContextCourse($this->cidReqHelper);
+        $session = $this->getContextSession($this->entityManager, $this->cidReqHelper, $course);
+        $group = $this->getContextGroup($this->entityManager, $this->cidReqHelper, $course);
         $category = $this->getCategory($uriVariables);
         $this->assertCategoryContext($category, $course, $session, $group);
         $this->assertCategorySubscriptionsEnabled();

--- a/src/CoreBundle/State/LearningPath/LearningPathCategorySubscriptionProvider.php
+++ b/src/CoreBundle/State/LearningPath/LearningPathCategorySubscriptionProvider.php
@@ -61,7 +61,7 @@ final readonly class LearningPathCategorySubscriptionProvider implements Provide
 
         $this->assertLearningPathTeacher($this->security);
         $course = $this->getContextCourse($this->cidReqHelper);
-        $session = $this->getContextSession($this->entityManager, $this->cidReqHelper, $course);
+        $session = $this->cidReqHelper->getDoctrineSessionEntity();
         $group = $this->getContextGroup($this->entityManager, $this->cidReqHelper, $course);
         $category = $this->getCategory($uriVariables);
         $this->assertCategoryContext($category, $course, $session, $group);

--- a/src/CoreBundle/State/LearningPath/LearningPathCollectionProvider.php
+++ b/src/CoreBundle/State/LearningPath/LearningPathCollectionProvider.php
@@ -88,7 +88,7 @@ readonly class LearningPathCollectionProvider implements ProviderInterface
             }
         }
 
-        $group = $this->getValidatedGroupFromContext($this->entityManager, $this->cidReqHelper, $course);
+        $group = $this->getContextGroup($this->entityManager, $this->cidReqHelper, $course);
         $title = isset($filters['title']) ? trim((string) $filters['title']) : null;
         $canManage = $this->canManageLearningPaths($this->security)
             && !$this->isStudentViewRequest($this->requestStack);

--- a/src/CoreBundle/State/LearningPath/LearningPathConfigurationProcessor.php
+++ b/src/CoreBundle/State/LearningPath/LearningPathConfigurationProcessor.php
@@ -21,6 +21,7 @@ use Chamilo\CoreBundle\Entity\SkillRelItem;
 use Chamilo\CoreBundle\Entity\User;
 use Chamilo\CoreBundle\Event\Events;
 use Chamilo\CoreBundle\Event\LearningPathCreatedEvent;
+use Chamilo\CoreBundle\Helpers\CidReqHelper;
 use Chamilo\CoreBundle\Helpers\ThemeHelper;
 use Chamilo\CoreBundle\Repository\ExtraFieldRepository;
 use Chamilo\CoreBundle\Repository\ExtraFieldValuesRepository;
@@ -83,6 +84,7 @@ final readonly class LearningPathConfigurationProcessor implements ProcessorInte
         private ThemeHelper $themeHelper,
         #[Autowire(service: 'oneup_flysystem.themes_filesystem')]
         private FilesystemOperator $themesFilesystem,
+        private CidReqHelper $cidReqHelper,
     ) {}
 
     public function process(mixed $data, Operation $operation, array $uriVariables = [], array $context = []): LearningPathConfiguration
@@ -96,9 +98,9 @@ final readonly class LearningPathConfigurationProcessor implements ProcessorInte
         $this->validateActionToken($this->csrfTokenManager, $payload['csrfToken'] ?? null);
         $this->assertLearningPathTeacher($this->security);
 
-        $course = $this->getContextCourse($this->entityManager, $request);
-        $session = $this->getContextSession($this->entityManager, $request, $course);
-        $group = $this->getContextGroup($this->entityManager, $request, $course);
+        $course = $this->getContextCourse($this->cidReqHelper);
+        $session = $this->getContextSession($this->entityManager, $this->cidReqHelper, $course);
+        $group = $this->getContextGroup($this->entityManager, $this->cidReqHelper, $course);
         $lpId = (int) ($uriVariables['id'] ?? 0);
         $isEdit = $lpId > 0;
 

--- a/src/CoreBundle/State/LearningPath/LearningPathConfigurationProcessor.php
+++ b/src/CoreBundle/State/LearningPath/LearningPathConfigurationProcessor.php
@@ -99,7 +99,7 @@ final readonly class LearningPathConfigurationProcessor implements ProcessorInte
         $this->assertLearningPathTeacher($this->security);
 
         $course = $this->getContextCourse($this->cidReqHelper);
-        $session = $this->getContextSession($this->entityManager, $this->cidReqHelper, $course);
+        $session = $this->cidReqHelper->getDoctrineSessionEntity();
         $group = $this->getContextGroup($this->entityManager, $this->cidReqHelper, $course);
         $lpId = (int) ($uriVariables['id'] ?? 0);
         $isEdit = $lpId > 0;

--- a/src/CoreBundle/State/LearningPath/LearningPathConfigurationProvider.php
+++ b/src/CoreBundle/State/LearningPath/LearningPathConfigurationProvider.php
@@ -16,6 +16,7 @@ use Chamilo\CoreBundle\Entity\Language;
 use Chamilo\CoreBundle\Entity\Session;
 use Chamilo\CoreBundle\Entity\SkillRelCourse;
 use Chamilo\CoreBundle\Entity\SkillRelItem;
+use Chamilo\CoreBundle\Helpers\CidReqHelper;
 use Chamilo\CoreBundle\Helpers\ThemeHelper;
 use Chamilo\CoreBundle\Repository\ExtraFieldRepository;
 use Chamilo\CoreBundle\Repository\ExtraFieldValuesRepository;
@@ -33,8 +34,6 @@ use League\Flysystem\FilesystemException;
 use League\Flysystem\FilesystemOperator;
 use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
-use Symfony\Component\HttpFoundation\RequestStack;
-use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\Security\Csrf\CsrfTokenManagerInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
@@ -51,7 +50,6 @@ final readonly class LearningPathConfigurationProvider implements ProviderInterf
 
     public function __construct(
         private EntityManagerInterface $entityManager,
-        private RequestStack $requestStack,
         private Security $security,
         private CsrfTokenManagerInterface $csrfTokenManager,
         private CLpRepository $lpRepository,
@@ -65,19 +63,15 @@ final readonly class LearningPathConfigurationProvider implements ProviderInterf
         private TranslatorInterface $translator,
         #[Autowire(service: 'oneup_flysystem.themes_filesystem')]
         private FilesystemOperator $themesFilesystem,
+        private CidReqHelper $cidReqHelper,
     ) {}
 
     public function provide(Operation $operation, array $uriVariables = [], array $context = []): LearningPathConfiguration
     {
-        $request = $this->requestStack->getCurrentRequest();
-        if (null === $request) {
-            throw new BadRequestHttpException('Request is missing.');
-        }
-
         $this->assertLearningPathTeacher($this->security);
-        $course = $this->getContextCourse($this->entityManager, $request);
-        $session = $this->getContextSession($this->entityManager, $request, $course);
-        $group = $this->getContextGroup($this->entityManager, $request, $course);
+        $course = $this->getContextCourse($this->cidReqHelper);
+        $session = $this->getContextSession($this->entityManager, $this->cidReqHelper, $course);
+        $group = $this->getContextGroup($this->entityManager, $this->cidReqHelper, $course);
 
         $lpId = (int) ($uriVariables['id'] ?? 0);
         $lp = null;

--- a/src/CoreBundle/State/LearningPath/LearningPathConfigurationProvider.php
+++ b/src/CoreBundle/State/LearningPath/LearningPathConfigurationProvider.php
@@ -70,7 +70,7 @@ final readonly class LearningPathConfigurationProvider implements ProviderInterf
     {
         $this->assertLearningPathTeacher($this->security);
         $course = $this->getContextCourse($this->cidReqHelper);
-        $session = $this->getContextSession($this->entityManager, $this->cidReqHelper, $course);
+        $session = $this->cidReqHelper->getDoctrineSessionEntity();
         $group = $this->getContextGroup($this->entityManager, $this->cidReqHelper, $course);
 
         $lpId = (int) ($uriVariables['id'] ?? 0);

--- a/src/CoreBundle/State/LearningPath/LearningPathLayoutProcessor.php
+++ b/src/CoreBundle/State/LearningPath/LearningPathLayoutProcessor.php
@@ -9,12 +9,12 @@ namespace Chamilo\CoreBundle\State\LearningPath;
 use ApiPlatform\Metadata\Operation;
 use ApiPlatform\State\ProcessorInterface;
 use Chamilo\CoreBundle\ApiResource\LearningPath\LearningPathLayoutInput;
+use Chamilo\CoreBundle\Helpers\CidReqHelper;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\ParameterType;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\HttpFoundation\JsonResponse;
-use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 use Symfony\Component\Security\Csrf\CsrfTokenManagerInterface;
@@ -28,9 +28,9 @@ final readonly class LearningPathLayoutProcessor implements ProcessorInterface
 
     public function __construct(
         private EntityManagerInterface $entityManager,
-        private RequestStack $requestStack,
         private Security $security,
         private CsrfTokenManagerInterface $csrfTokenManager,
+        private CidReqHelper $cidReqHelper,
     ) {}
 
     public function process(mixed $data, Operation $operation, array $uriVariables = [], array $context = []): JsonResponse
@@ -39,17 +39,12 @@ final readonly class LearningPathLayoutProcessor implements ProcessorInterface
             throw new BadRequestHttpException('The learning path layout payload is invalid.');
         }
 
-        $request = $this->requestStack->getCurrentRequest();
-        if (null === $request) {
-            throw new BadRequestHttpException('Request is missing.');
-        }
-
         $this->validateActionToken($this->csrfTokenManager, $data->csrfToken);
         $this->assertLearningPathTeacher($this->security);
 
-        $course = $this->getContextCourse($this->entityManager, $request);
-        $session = $this->getContextSession($this->entityManager, $request, $course);
-        $group = $this->getContextGroup($this->entityManager, $request, $course);
+        $course = $this->getContextCourse($this->cidReqHelper);
+        $session = $this->getContextSession($this->entityManager, $this->cidReqHelper, $course);
+        $group = $this->getContextGroup($this->entityManager, $this->cidReqHelper, $course);
 
         if (null !== $session || null !== $group) {
             throw new AccessDeniedHttpException('Learning path category layout can only be changed in the base course context.');

--- a/src/CoreBundle/State/LearningPath/LearningPathLayoutProcessor.php
+++ b/src/CoreBundle/State/LearningPath/LearningPathLayoutProcessor.php
@@ -43,7 +43,7 @@ final readonly class LearningPathLayoutProcessor implements ProcessorInterface
         $this->assertLearningPathTeacher($this->security);
 
         $course = $this->getContextCourse($this->cidReqHelper);
-        $session = $this->getContextSession($this->entityManager, $this->cidReqHelper, $course);
+        $session = $this->cidReqHelper->getDoctrineSessionEntity();
         $group = $this->getContextGroup($this->entityManager, $this->cidReqHelper, $course);
 
         if (null !== $session || null !== $group) {

--- a/src/CoreBundle/State/LearningPath/LearningPathManagementProcessor.php
+++ b/src/CoreBundle/State/LearningPath/LearningPathManagementProcessor.php
@@ -79,7 +79,7 @@ final readonly class LearningPathManagementProcessor implements ProcessorInterfa
         $this->validateActionToken($this->csrfTokenManager, $data->csrfToken);
 
         $course = $this->getContextCourse($this->cidReqHelper);
-        $session = $this->getContextSession($this->entityManager, $this->cidReqHelper, $course);
+        $session = $this->cidReqHelper->getDoctrineSessionEntity();
         $group = $this->getContextGroup($this->entityManager, $this->cidReqHelper, $course);
 
         $lpId = (int) ($uriVariables['lpId'] ?? $data->lpId ?? 0);

--- a/src/CoreBundle/State/LearningPath/LearningPathManagementProcessor.php
+++ b/src/CoreBundle/State/LearningPath/LearningPathManagementProcessor.php
@@ -16,6 +16,7 @@ use Chamilo\CoreBundle\Entity\ResourceNode;
 use Chamilo\CoreBundle\Entity\Session;
 use Chamilo\CoreBundle\Entity\SkillRelItem;
 use Chamilo\CoreBundle\Entity\User;
+use Chamilo\CoreBundle\Helpers\CidReqHelper;
 use Chamilo\CoreBundle\Helpers\ResourceHelper;
 use Chamilo\CoreBundle\Repository\AssetRepository;
 use Chamilo\CoreBundle\Repository\ResourceLinkRepository;
@@ -31,7 +32,6 @@ use DateTime;
 use Doctrine\ORM\EntityManagerInterface;
 use Psr\Log\LoggerInterface;
 use Symfony\Bundle\SecurityBundle\Security;
-use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
@@ -57,7 +57,6 @@ final readonly class LearningPathManagementProcessor implements ProcessorInterfa
         private LearningPathCopyService $learningPathCopyService,
         private CLpRepository $learningPathRepository,
         private CShortcutRepository $shortcutRepository,
-        private RequestStack $requestStack,
         private Security $security,
         private CsrfTokenManagerInterface $csrfTokenManager,
         private SettingsManager $settingsManager,
@@ -67,6 +66,7 @@ final readonly class LearningPathManagementProcessor implements ProcessorInterfa
         private ResourceHelper $resourceHelper,
         private CDocumentRepository $documentRepository,
         private LoggerInterface $logger,
+        private CidReqHelper $cidReqHelper,
     ) {}
 
     public function process(mixed $data, Operation $operation, array $uriVariables = [], array $context = []): void
@@ -75,17 +75,12 @@ final readonly class LearningPathManagementProcessor implements ProcessorInterfa
             throw new BadRequestHttpException('Learning path management data is required.');
         }
 
-        $request = $this->requestStack->getCurrentRequest();
-        if (null === $request) {
-            throw new BadRequestHttpException('Request is missing.');
-        }
-
         $this->assertLearningPathTeacher($this->security);
         $this->validateActionToken($this->csrfTokenManager, $data->csrfToken);
 
-        $course = $this->getContextCourse($this->entityManager, $request);
-        $session = $this->getContextSession($this->entityManager, $request, $course);
-        $group = $this->getContextGroup($this->entityManager, $request, $course);
+        $course = $this->getContextCourse($this->cidReqHelper);
+        $session = $this->getContextSession($this->entityManager, $this->cidReqHelper, $course);
+        $group = $this->getContextGroup($this->entityManager, $this->cidReqHelper, $course);
 
         $lpId = (int) ($uriVariables['lpId'] ?? $data->lpId ?? 0);
         if ($lpId <= 0) {

--- a/src/CoreBundle/State/LearningPath/LearningPathQuickTestProcessor.php
+++ b/src/CoreBundle/State/LearningPath/LearningPathQuickTestProcessor.php
@@ -10,6 +10,7 @@ use ApiPlatform\Metadata\Operation;
 use ApiPlatform\State\ProcessorInterface;
 use Chamilo\CoreBundle\ApiResource\LearningPath\LearningPathBuilderQuickTestInput;
 use Chamilo\CoreBundle\Entity\ResourceLink;
+use Chamilo\CoreBundle\Helpers\CidReqHelper;
 use Chamilo\CoreBundle\Service\LearningPath\LearningPathQuickTestService;
 use Chamilo\CourseBundle\Entity\CDocument;
 use Chamilo\CourseBundle\Entity\CLp;
@@ -45,6 +46,7 @@ final readonly class LearningPathQuickTestProcessor implements ProcessorInterfac
         private CLpItemRepository $lpItemRepository,
         private CDocumentRepository $documentRepository,
         private LearningPathQuickTestService $quickTestService,
+        private CidReqHelper $cidReqHelper,
     ) {}
 
     /**
@@ -69,9 +71,9 @@ final readonly class LearningPathQuickTestProcessor implements ProcessorInterfac
         $this->assertLearningPathTeacher($this->security);
         $this->validateActionToken($this->csrfTokenManager, $data->csrfToken);
 
-        $course = $this->getContextCourse($this->entityManager, $request);
-        $session = $this->getContextSession($this->entityManager, $request, $course);
-        $group = $this->getContextGroup($this->entityManager, $request, $course);
+        $course = $this->getContextCourse($this->cidReqHelper);
+        $session = $this->getContextSession($this->entityManager, $this->cidReqHelper, $course);
+        $group = $this->getContextGroup($this->entityManager, $this->cidReqHelper, $course);
 
         $lp = $this->lpRepository->find($data->lpId);
         if (!$lp instanceof CLp) {

--- a/src/CoreBundle/State/LearningPath/LearningPathQuickTestProcessor.php
+++ b/src/CoreBundle/State/LearningPath/LearningPathQuickTestProcessor.php
@@ -72,7 +72,7 @@ final readonly class LearningPathQuickTestProcessor implements ProcessorInterfac
         $this->validateActionToken($this->csrfTokenManager, $data->csrfToken);
 
         $course = $this->getContextCourse($this->cidReqHelper);
-        $session = $this->getContextSession($this->entityManager, $this->cidReqHelper, $course);
+        $session = $this->cidReqHelper->getDoctrineSessionEntity();
         $group = $this->getContextGroup($this->entityManager, $this->cidReqHelper, $course);
 
         $lp = $this->lpRepository->find($data->lpId);

--- a/src/CoreBundle/State/LearningPath/LearningPathQuickTestProcessor.php
+++ b/src/CoreBundle/State/LearningPath/LearningPathQuickTestProcessor.php
@@ -73,6 +73,7 @@ final readonly class LearningPathQuickTestProcessor implements ProcessorInterfac
 
         $course = $this->getContextCourse($this->cidReqHelper);
         $session = $this->cidReqHelper->getDoctrineSessionEntity();
+        $this->assertSessionBelongsToCourse($session, $course);
         $group = $this->getContextGroup($this->entityManager, $this->cidReqHelper, $course);
 
         $lp = $this->lpRepository->find($data->lpId);

--- a/src/CoreBundle/State/LearningPath/LearningPathReorderProcessor.php
+++ b/src/CoreBundle/State/LearningPath/LearningPathReorderProcessor.php
@@ -8,6 +8,7 @@ namespace Chamilo\CoreBundle\State\LearningPath;
 
 use ApiPlatform\Metadata\Operation;
 use ApiPlatform\State\ProcessorInterface;
+use Chamilo\CoreBundle\Helpers\CidReqHelper;
 use Chamilo\CourseBundle\Repository\CLpRepository;
 use Doctrine\ORM\EntityManagerInterface;
 use InvalidArgumentException;
@@ -30,6 +31,7 @@ final readonly class LearningPathReorderProcessor implements ProcessorInterface
         private RequestStack $requestStack,
         private Security $security,
         private CsrfTokenManagerInterface $csrfTokenManager,
+        private CidReqHelper $cidReqHelper,
     ) {}
 
     public function process(mixed $data, Operation $operation, array $uriVariables = [], array $context = []): JsonResponse
@@ -43,9 +45,9 @@ final readonly class LearningPathReorderProcessor implements ProcessorInterface
         $this->validateActionToken($this->csrfTokenManager, $payload['csrfToken'] ?? null);
         $this->assertLearningPathTeacher($this->security);
 
-        $course = $this->getContextCourse($this->entityManager, $request);
-        $session = $this->getContextSession($this->entityManager, $request, $course);
-        $group = $this->getContextGroup($this->entityManager, $request, $course);
+        $course = $this->getContextCourse($this->cidReqHelper);
+        $session = $this->getContextSession($this->entityManager, $this->cidReqHelper, $course);
+        $group = $this->getContextGroup($this->entityManager, $this->cidReqHelper, $course);
 
         $order = $payload['order'] ?? $payload['ids'] ?? null;
         if (!\is_array($order) || [] === $order) {

--- a/src/CoreBundle/State/LearningPath/LearningPathReorderProcessor.php
+++ b/src/CoreBundle/State/LearningPath/LearningPathReorderProcessor.php
@@ -46,7 +46,7 @@ final readonly class LearningPathReorderProcessor implements ProcessorInterface
         $this->assertLearningPathTeacher($this->security);
 
         $course = $this->getContextCourse($this->cidReqHelper);
-        $session = $this->getContextSession($this->entityManager, $this->cidReqHelper, $course);
+        $session = $this->cidReqHelper->getDoctrineSessionEntity();
         $group = $this->getContextGroup($this->entityManager, $this->cidReqHelper, $course);
 
         $order = $payload['order'] ?? $payload['ids'] ?? null;

--- a/src/CoreBundle/State/LearningPath/LearningPathReportingProvider.php
+++ b/src/CoreBundle/State/LearningPath/LearningPathReportingProvider.php
@@ -20,6 +20,7 @@ use Chamilo\CoreBundle\Entity\TrackEExercise;
 use Chamilo\CoreBundle\Entity\User;
 use Chamilo\CoreBundle\Entity\Usergroup;
 use Chamilo\CoreBundle\Entity\UsergroupRelUser;
+use Chamilo\CoreBundle\Helpers\CidReqHelper;
 use Chamilo\CoreBundle\Repository\ExtraFieldValuesRepository;
 use Chamilo\CoreBundle\Settings\SettingsManager;
 use Chamilo\CourseBundle\Entity\CGroup;
@@ -58,6 +59,7 @@ final readonly class LearningPathReportingProvider implements ProviderInterface
         private CsrfTokenManagerInterface $csrfTokenManager,
         private CGroupRepository $groupRepository,
         private ExtraFieldValuesRepository $extraFieldValuesRepository,
+        private CidReqHelper $cidReqHelper,
     ) {}
 
     /**
@@ -72,9 +74,9 @@ final readonly class LearningPathReportingProvider implements ProviderInterface
         }
 
         $this->assertLearningPathTeacher($this->security);
-        $course = $this->getContextCourse($this->entityManager, $request);
-        $session = $this->getContextSession($this->entityManager, $request, $course);
-        $group = $this->getContextGroup($this->entityManager, $request, $course);
+        $course = $this->getContextCourse($this->cidReqHelper);
+        $session = $this->getContextSession($this->entityManager, $this->cidReqHelper, $course);
+        $group = $this->getContextGroup($this->entityManager, $this->cidReqHelper, $course);
         $lp = $this->getLearningPath($uriVariables);
         $this->getEditableResourceLink($lp, $course, $session, $group, $this->security);
 

--- a/src/CoreBundle/State/LearningPath/LearningPathReportingProvider.php
+++ b/src/CoreBundle/State/LearningPath/LearningPathReportingProvider.php
@@ -75,7 +75,7 @@ final readonly class LearningPathReportingProvider implements ProviderInterface
 
         $this->assertLearningPathTeacher($this->security);
         $course = $this->getContextCourse($this->cidReqHelper);
-        $session = $this->getContextSession($this->entityManager, $this->cidReqHelper, $course);
+        $session = $this->cidReqHelper->getDoctrineSessionEntity();
         $group = $this->getContextGroup($this->entityManager, $this->cidReqHelper, $course);
         $lp = $this->getLearningPath($uriVariables);
         $this->getEditableResourceLink($lp, $course, $session, $group, $this->security);

--- a/src/CoreBundle/State/LearningPath/LearningPathReportingRecalculateProcessor.php
+++ b/src/CoreBundle/State/LearningPath/LearningPathReportingRecalculateProcessor.php
@@ -61,7 +61,7 @@ final readonly class LearningPathReportingRecalculateProcessor implements Proces
 
         $this->assertLearningPathTeacher($this->security);
         $course = $this->getContextCourse($this->cidReqHelper);
-        $session = $this->getContextSession($this->entityManager, $this->cidReqHelper, $course);
+        $session = $this->cidReqHelper->getDoctrineSessionEntity();
         $group = $this->getContextGroup($this->entityManager, $this->cidReqHelper, $course);
         $lp = $this->getLearningPath($uriVariables);
         $this->getEditableResourceLink($lp, $course, $session, $group, $this->security);

--- a/src/CoreBundle/State/LearningPath/LearningPathReportingRecalculateProcessor.php
+++ b/src/CoreBundle/State/LearningPath/LearningPathReportingRecalculateProcessor.php
@@ -10,6 +10,7 @@ use ApiPlatform\Metadata\Operation;
 use ApiPlatform\State\ProcessorInterface;
 use Chamilo\CoreBundle\ApiResource\LearningPath\LearningPathReportingRecalculateInput;
 use Chamilo\CoreBundle\Entity\TrackEExercise;
+use Chamilo\CoreBundle\Helpers\CidReqHelper;
 use Chamilo\CourseBundle\Entity\CLp;
 use Chamilo\CourseBundle\Entity\CLpItem;
 use Doctrine\ORM\EntityManagerInterface;
@@ -36,6 +37,7 @@ final readonly class LearningPathReportingRecalculateProcessor implements Proces
         private CsrfTokenManagerInterface $csrfTokenManager,
         private LearningPathReportingProvider $reportingProvider,
         private LoggerInterface $logger,
+        private CidReqHelper $cidReqHelper,
     ) {}
 
     /**
@@ -58,9 +60,9 @@ final readonly class LearningPathReportingRecalculateProcessor implements Proces
         }
 
         $this->assertLearningPathTeacher($this->security);
-        $course = $this->getContextCourse($this->entityManager, $request);
-        $session = $this->getContextSession($this->entityManager, $request, $course);
-        $group = $this->getContextGroup($this->entityManager, $request, $course);
+        $course = $this->getContextCourse($this->cidReqHelper);
+        $session = $this->getContextSession($this->entityManager, $this->cidReqHelper, $course);
+        $group = $this->getContextGroup($this->entityManager, $this->cidReqHelper, $course);
         $lp = $this->getLearningPath($uriVariables);
         $this->getEditableResourceLink($lp, $course, $session, $group, $this->security);
         $this->validateActionToken($this->csrfTokenManager, $data->csrfToken);

--- a/src/CoreBundle/State/LearningPath/LearningPathReportingResetProcessor.php
+++ b/src/CoreBundle/State/LearningPath/LearningPathReportingResetProcessor.php
@@ -72,7 +72,7 @@ final readonly class LearningPathReportingResetProcessor implements ProcessorInt
 
         $this->assertLearningPathTeacher($this->security);
         $course = $this->getContextCourse($this->cidReqHelper);
-        $session = $this->getContextSession($this->entityManager, $this->cidReqHelper, $course);
+        $session = $this->cidReqHelper->getDoctrineSessionEntity();
         $group = $this->getContextGroup($this->entityManager, $this->cidReqHelper, $course);
         $lp = $this->getLearningPath($uriVariables);
         $this->getEditableResourceLink($lp, $course, $session, $group, $this->security);

--- a/src/CoreBundle/State/LearningPath/LearningPathReportingResetProcessor.php
+++ b/src/CoreBundle/State/LearningPath/LearningPathReportingResetProcessor.php
@@ -14,6 +14,7 @@ use Chamilo\CoreBundle\Entity\ExtraField;
 use Chamilo\CoreBundle\Entity\ExtraFieldValues;
 use Chamilo\CoreBundle\Entity\Session;
 use Chamilo\CoreBundle\Entity\TrackEExercise;
+use Chamilo\CoreBundle\Helpers\CidReqHelper;
 use Chamilo\CoreBundle\Repository\ExtraFieldValuesRepository;
 use Chamilo\CoreBundle\Settings\SettingsManager;
 use Chamilo\CourseBundle\Entity\CLp;
@@ -47,6 +48,7 @@ final readonly class LearningPathReportingResetProcessor implements ProcessorInt
         private SettingsManager $settingsManager,
         private LearningPathReportingProvider $reportingProvider,
         private ExtraFieldValuesRepository $extraFieldValuesRepository,
+        private CidReqHelper $cidReqHelper,
     ) {}
 
     /**
@@ -69,9 +71,9 @@ final readonly class LearningPathReportingResetProcessor implements ProcessorInt
         }
 
         $this->assertLearningPathTeacher($this->security);
-        $course = $this->getContextCourse($this->entityManager, $request);
-        $session = $this->getContextSession($this->entityManager, $request, $course);
-        $group = $this->getContextGroup($this->entityManager, $request, $course);
+        $course = $this->getContextCourse($this->cidReqHelper);
+        $session = $this->getContextSession($this->entityManager, $this->cidReqHelper, $course);
+        $group = $this->getContextGroup($this->entityManager, $this->cidReqHelper, $course);
         $lp = $this->getLearningPath($uriVariables);
         $this->getEditableResourceLink($lp, $course, $session, $group, $this->security);
         $this->validateActionToken($this->csrfTokenManager, $data->csrfToken);

--- a/src/CoreBundle/State/LearningPath/LearningPathRuntimeItemProcessor.php
+++ b/src/CoreBundle/State/LearningPath/LearningPathRuntimeItemProcessor.php
@@ -10,6 +10,7 @@ use ApiPlatform\Metadata\Operation;
 use ApiPlatform\State\ProcessorInterface;
 use Chamilo\CoreBundle\ApiResource\LearningPath\LearningPathRuntimeItemInput;
 use Chamilo\CoreBundle\Entity\User;
+use Chamilo\CoreBundle\Helpers\CidReqHelper;
 use Chamilo\CoreBundle\Service\LearningPath\LearningPathFinalItemManager;
 use Chamilo\CourseBundle\Entity\CLp;
 use Chamilo\CourseBundle\Entity\CLpItem;
@@ -42,6 +43,7 @@ final readonly class LearningPathRuntimeItemProcessor implements ProcessorInterf
         private LearningPathFinalItemManager $finalItemManager,
         private CLpRepository $lpRepository,
         private CLpItemRepository $lpItemRepository,
+        private CidReqHelper $cidReqHelper,
     ) {}
 
     public function process(mixed $data, Operation $operation, array $uriVariables = [], array $context = []): void
@@ -74,8 +76,8 @@ final readonly class LearningPathRuntimeItemProcessor implements ProcessorInterf
             throw new AccessDeniedHttpException('The learning path item is not available.');
         }
 
-        $course = $this->getContextCourse($this->entityManager, $request);
-        $session = $this->getContextSession($this->entityManager, $request, $course);
+        $course = $this->getContextCourse($this->cidReqHelper);
+        $session = $this->getContextSession($this->entityManager, $this->cidReqHelper, $course);
         $lp = $this->lpRepository->find($lpId);
         $item = $this->lpItemRepository->find($data->itemId);
         $user = $this->security->getUser();

--- a/src/CoreBundle/State/LearningPath/LearningPathRuntimeItemProcessor.php
+++ b/src/CoreBundle/State/LearningPath/LearningPathRuntimeItemProcessor.php
@@ -77,7 +77,7 @@ final readonly class LearningPathRuntimeItemProcessor implements ProcessorInterf
         }
 
         $course = $this->getContextCourse($this->cidReqHelper);
-        $session = $this->getContextSession($this->entityManager, $this->cidReqHelper, $course);
+        $session = $this->cidReqHelper->getDoctrineSessionEntity();
         $lp = $this->lpRepository->find($lpId);
         $item = $this->lpItemRepository->find($data->itemId);
         $user = $this->security->getUser();

--- a/src/CoreBundle/State/LearningPath/LearningPathRuntimeProvider.php
+++ b/src/CoreBundle/State/LearningPath/LearningPathRuntimeProvider.php
@@ -14,6 +14,7 @@ use Chamilo\CoreBundle\Entity\Course;
 use Chamilo\CoreBundle\Entity\ResourceLink;
 use Chamilo\CoreBundle\Entity\Session;
 use Chamilo\CoreBundle\Entity\User;
+use Chamilo\CoreBundle\Helpers\CidReqHelper;
 use Chamilo\CoreBundle\Helpers\LpAdvancedAccessHelper;
 use Chamilo\CoreBundle\Repository\ResourceNodeRepository;
 use Chamilo\CoreBundle\Service\LearningPath\LearningPathAccessChecker;
@@ -76,6 +77,7 @@ final readonly class LearningPathRuntimeProvider implements ProviderInterface
         private LearningPathRuntimeProgressManager $progressManager,
         private CLpRepository $lpRepository,
         private CLpItemRepository $lpItemRepository,
+        private CidReqHelper $cidReqHelper,
     ) {}
 
     /**
@@ -89,9 +91,9 @@ final readonly class LearningPathRuntimeProvider implements ProviderInterface
             throw new BadRequestHttpException('Request is missing.');
         }
 
-        $course = $this->getContextCourse($this->entityManager, $request);
-        $session = $this->getContextSession($this->entityManager, $request, $course);
-        $group = $this->getContextGroup($this->entityManager, $request, $course);
+        $course = $this->getContextCourse($this->cidReqHelper);
+        $session = $this->getContextSession($this->entityManager, $this->cidReqHelper, $course);
+        $group = $this->getContextGroup($this->entityManager, $this->cidReqHelper, $course);
         $lp = $this->getLearningPath((int) ($uriVariables['lpId'] ?? 0));
         $user = $this->security->getUser();
         if (!$user instanceof User) {

--- a/src/CoreBundle/State/LearningPath/LearningPathRuntimeProvider.php
+++ b/src/CoreBundle/State/LearningPath/LearningPathRuntimeProvider.php
@@ -92,7 +92,7 @@ final readonly class LearningPathRuntimeProvider implements ProviderInterface
         }
 
         $course = $this->getContextCourse($this->cidReqHelper);
-        $session = $this->getContextSession($this->entityManager, $this->cidReqHelper, $course);
+        $session = $this->cidReqHelper->getDoctrineSessionEntity();
         $group = $this->getContextGroup($this->entityManager, $this->cidReqHelper, $course);
         $lp = $this->getLearningPath((int) ($uriVariables['lpId'] ?? 0));
         $user = $this->security->getUser();

--- a/src/CoreBundle/State/LearningPath/LearningPathRuntimeRestartProcessor.php
+++ b/src/CoreBundle/State/LearningPath/LearningPathRuntimeRestartProcessor.php
@@ -64,7 +64,7 @@ final readonly class LearningPathRuntimeRestartProcessor implements ProcessorInt
         }
 
         $course = $this->getContextCourse($this->cidReqHelper);
-        $session = $this->getContextSession($this->entityManager, $this->cidReqHelper, $course);
+        $session = $this->cidReqHelper->getDoctrineSessionEntity();
         $lp = $this->lpRepository->find($lpId);
         $user = $this->security->getUser();
 

--- a/src/CoreBundle/State/LearningPath/LearningPathRuntimeRestartProcessor.php
+++ b/src/CoreBundle/State/LearningPath/LearningPathRuntimeRestartProcessor.php
@@ -10,6 +10,7 @@ use ApiPlatform\Metadata\Operation;
 use ApiPlatform\State\ProcessorInterface;
 use Chamilo\CoreBundle\ApiResource\LearningPath\LearningPathRuntimeRestartInput;
 use Chamilo\CoreBundle\Entity\User;
+use Chamilo\CoreBundle\Helpers\CidReqHelper;
 use Chamilo\CourseBundle\Entity\CLp;
 use Chamilo\CourseBundle\Entity\CLpView;
 use Chamilo\CourseBundle\Repository\CLpRepository;
@@ -36,6 +37,7 @@ final readonly class LearningPathRuntimeRestartProcessor implements ProcessorInt
         private LearningPathRuntimeProvider $runtimeProvider,
         private LearningPathRuntimeProgressManager $progressManager,
         private CLpRepository $lpRepository,
+        private CidReqHelper $cidReqHelper,
     ) {}
 
     public function process(mixed $data, Operation $operation, array $uriVariables = [], array $context = []): void
@@ -61,8 +63,8 @@ final readonly class LearningPathRuntimeRestartProcessor implements ProcessorInt
             throw new BadRequestHttpException('This learning path runtime is not supported by the Vue player yet.');
         }
 
-        $course = $this->getContextCourse($this->entityManager, $request);
-        $session = $this->getContextSession($this->entityManager, $request, $course);
+        $course = $this->getContextCourse($this->cidReqHelper);
+        $session = $this->getContextSession($this->entityManager, $this->cidReqHelper, $course);
         $lp = $this->lpRepository->find($lpId);
         $user = $this->security->getUser();
 

--- a/src/CoreBundle/State/LearningPath/LearningPathRuntimeSyncProcessor.php
+++ b/src/CoreBundle/State/LearningPath/LearningPathRuntimeSyncProcessor.php
@@ -66,7 +66,7 @@ final readonly class LearningPathRuntimeSyncProcessor implements ProcessorInterf
         }
 
         $course = $this->getContextCourse($this->cidReqHelper);
-        $session = $this->getContextSession($this->entityManager, $this->cidReqHelper, $course);
+        $session = $this->cidReqHelper->getDoctrineSessionEntity();
         $lp = $this->lpRepository->find($lpId);
         $user = $this->security->getUser();
 

--- a/src/CoreBundle/State/LearningPath/LearningPathRuntimeSyncProcessor.php
+++ b/src/CoreBundle/State/LearningPath/LearningPathRuntimeSyncProcessor.php
@@ -10,6 +10,7 @@ use ApiPlatform\Metadata\Operation;
 use ApiPlatform\State\ProcessorInterface;
 use Chamilo\CoreBundle\ApiResource\LearningPath\LearningPathRuntimeSyncInput;
 use Chamilo\CoreBundle\Entity\User;
+use Chamilo\CoreBundle\Helpers\CidReqHelper;
 use Chamilo\CourseBundle\Entity\CLp;
 use Chamilo\CourseBundle\Entity\CLpView;
 use Chamilo\CourseBundle\Repository\CLpRepository;
@@ -34,6 +35,7 @@ final readonly class LearningPathRuntimeSyncProcessor implements ProcessorInterf
         private LearningPathRuntimeProvider $runtimeProvider,
         private LearningPathRuntimeProgressManager $progressManager,
         private CLpRepository $lpRepository,
+        private CidReqHelper $cidReqHelper,
     ) {}
 
     public function process(mixed $data, Operation $operation, array $uriVariables = [], array $context = []): void
@@ -63,8 +65,8 @@ final readonly class LearningPathRuntimeSyncProcessor implements ProcessorInterf
             throw new AccessDeniedHttpException('The learning path item is not available.');
         }
 
-        $course = $this->getContextCourse($this->entityManager, $request);
-        $session = $this->getContextSession($this->entityManager, $request, $course);
+        $course = $this->getContextCourse($this->cidReqHelper);
+        $session = $this->getContextSession($this->entityManager, $this->cidReqHelper, $course);
         $lp = $this->lpRepository->find($lpId);
         $user = $this->security->getUser();
 

--- a/src/CoreBundle/State/LearningPath/LearningPathScormCommitProcessor.php
+++ b/src/CoreBundle/State/LearningPath/LearningPathScormCommitProcessor.php
@@ -81,7 +81,7 @@ final readonly class LearningPathScormCommitProcessor implements ProcessorInterf
         }
 
         $course = $this->getContextCourse($this->cidReqHelper);
-        $session = $this->getContextSession($this->entityManager, $this->cidReqHelper, $course);
+        $session = $this->cidReqHelper->getDoctrineSessionEntity();
         $lp = $this->lpRepository->find($lpId);
         $item = $this->lpItemRepository->find($itemId);
         $user = $this->security->getUser();

--- a/src/CoreBundle/State/LearningPath/LearningPathScormCommitProcessor.php
+++ b/src/CoreBundle/State/LearningPath/LearningPathScormCommitProcessor.php
@@ -10,6 +10,7 @@ use ApiPlatform\Metadata\Operation;
 use ApiPlatform\State\ProcessorInterface;
 use Chamilo\CoreBundle\ApiResource\LearningPath\LearningPathScormCommitInput;
 use Chamilo\CoreBundle\Entity\User;
+use Chamilo\CoreBundle\Helpers\CidReqHelper;
 use Chamilo\CoreBundle\Service\LearningPath\ScormRuntimeManager;
 use Chamilo\CourseBundle\Entity\CLp;
 use Chamilo\CourseBundle\Entity\CLpItem;
@@ -41,6 +42,7 @@ final readonly class LearningPathScormCommitProcessor implements ProcessorInterf
         private ScormRuntimeManager $runtimeManager,
         private CLpRepository $lpRepository,
         private CLpItemRepository $lpItemRepository,
+        private CidReqHelper $cidReqHelper,
     ) {}
 
     public function process(
@@ -78,8 +80,8 @@ final readonly class LearningPathScormCommitProcessor implements ProcessorInterf
             throw new BadRequestHttpException('The current item is not an active SCORM SCO.');
         }
 
-        $course = $this->getContextCourse($this->entityManager, $request);
-        $session = $this->getContextSession($this->entityManager, $request, $course);
+        $course = $this->getContextCourse($this->cidReqHelper);
+        $session = $this->getContextSession($this->entityManager, $this->cidReqHelper, $course);
         $lp = $this->lpRepository->find($lpId);
         $item = $this->lpItemRepository->find($itemId);
         $user = $this->security->getUser();

--- a/src/CoreBundle/State/LearningPath/LearningPathScormImportProcessor.php
+++ b/src/CoreBundle/State/LearningPath/LearningPathScormImportProcessor.php
@@ -8,6 +8,7 @@ namespace Chamilo\CoreBundle\State\LearningPath;
 
 use ApiPlatform\Metadata\Operation;
 use ApiPlatform\State\ProcessorInterface;
+use Chamilo\CoreBundle\Helpers\CidReqHelper;
 use Chamilo\CoreBundle\Service\LearningPath\ScormPackageImporter;
 use Chamilo\CoreBundle\Settings\SettingsManager;
 use Doctrine\ORM\EntityManagerInterface;
@@ -32,6 +33,7 @@ final readonly class LearningPathScormImportProcessor implements ProcessorInterf
         private CsrfTokenManagerInterface $csrfTokenManager,
         private SettingsManager $settingsManager,
         private ScormPackageImporter $packageImporter,
+        private CidReqHelper $cidReqHelper,
     ) {}
 
     public function process(
@@ -48,15 +50,15 @@ final readonly class LearningPathScormImportProcessor implements ProcessorInterf
         $this->assertLearningPathTeacher($this->security);
         $this->validateActionToken($this->csrfTokenManager, $request->request->get('csrfToken'));
 
-        $course = $this->getContextCourse($this->entityManager, $request);
+        $course = $this->getContextCourse($this->cidReqHelper);
         $requestedNodeId = $request->query->getInt('node');
         $courseNodeId = (int) ($course->getResourceNode()?->getId() ?? 0);
         if ($requestedNodeId > 0 && $requestedNodeId !== $courseNodeId) {
             throw new AccessDeniedHttpException('The requested resource node does not belong to this course.');
         }
 
-        $session = $this->getContextSession($this->entityManager, $request, $course);
-        $group = $this->getContextGroup($this->entityManager, $request, $course);
+        $session = $this->getContextSession($this->entityManager, $this->cidReqHelper, $course);
+        $group = $this->getContextGroup($this->entityManager, $this->cidReqHelper, $course);
 
         $package = $request->files->get('package');
         if (!$package instanceof UploadedFile) {

--- a/src/CoreBundle/State/LearningPath/LearningPathScormImportProcessor.php
+++ b/src/CoreBundle/State/LearningPath/LearningPathScormImportProcessor.php
@@ -57,7 +57,7 @@ final readonly class LearningPathScormImportProcessor implements ProcessorInterf
             throw new AccessDeniedHttpException('The requested resource node does not belong to this course.');
         }
 
-        $session = $this->getContextSession($this->entityManager, $this->cidReqHelper, $course);
+        $session = $this->cidReqHelper->getDoctrineSessionEntity();
         $group = $this->getContextGroup($this->entityManager, $this->cidReqHelper, $course);
 
         $package = $request->files->get('package');

--- a/src/CoreBundle/State/LearningPath/LearningPathScormUpdateProcessor.php
+++ b/src/CoreBundle/State/LearningPath/LearningPathScormUpdateProcessor.php
@@ -60,7 +60,7 @@ final readonly class LearningPathScormUpdateProcessor implements ProcessorInterf
             throw new AccessDeniedHttpException('The requested resource node does not belong to this course.');
         }
 
-        $session = $this->getContextSession($this->entityManager, $this->cidReqHelper, $course);
+        $session = $this->cidReqHelper->getDoctrineSessionEntity();
         $group = $this->getContextGroup($this->entityManager, $this->cidReqHelper, $course);
 
         $learningPathId = (int) ($uriVariables['lpId'] ?? 0);

--- a/src/CoreBundle/State/LearningPath/LearningPathScormUpdateProcessor.php
+++ b/src/CoreBundle/State/LearningPath/LearningPathScormUpdateProcessor.php
@@ -9,6 +9,7 @@ namespace Chamilo\CoreBundle\State\LearningPath;
 use ApiPlatform\Metadata\Operation;
 use ApiPlatform\State\ProcessorInterface;
 use Chamilo\CoreBundle\Entity\ResourceNode;
+use Chamilo\CoreBundle\Helpers\CidReqHelper;
 use Chamilo\CoreBundle\Service\LearningPath\ScormPackageImporter;
 use Chamilo\CourseBundle\Entity\CLp;
 use Chamilo\CourseBundle\Repository\CLpRepository;
@@ -35,6 +36,7 @@ final readonly class LearningPathScormUpdateProcessor implements ProcessorInterf
         private CsrfTokenManagerInterface $csrfTokenManager,
         private CLpRepository $learningPathRepository,
         private ScormPackageImporter $packageImporter,
+        private CidReqHelper $cidReqHelper,
     ) {}
 
     public function process(
@@ -51,15 +53,15 @@ final readonly class LearningPathScormUpdateProcessor implements ProcessorInterf
         $this->assertLearningPathTeacher($this->security);
         $this->validateActionToken($this->csrfTokenManager, $request->request->get('csrfToken'));
 
-        $course = $this->getContextCourse($this->entityManager, $request);
+        $course = $this->getContextCourse($this->cidReqHelper);
         $requestedNodeId = $request->query->getInt('node');
         $courseNodeId = (int) ($course->getResourceNode()?->getId() ?? 0);
         if ($requestedNodeId > 0 && $requestedNodeId !== $courseNodeId) {
             throw new AccessDeniedHttpException('The requested resource node does not belong to this course.');
         }
 
-        $session = $this->getContextSession($this->entityManager, $request, $course);
-        $group = $this->getContextGroup($this->entityManager, $request, $course);
+        $session = $this->getContextSession($this->entityManager, $this->cidReqHelper, $course);
+        $group = $this->getContextGroup($this->entityManager, $this->cidReqHelper, $course);
 
         $learningPathId = (int) ($uriVariables['lpId'] ?? 0);
         if ($learningPathId <= 0) {

--- a/src/CoreBundle/State/LearningPath/LearningPathStateHelperTrait.php
+++ b/src/CoreBundle/State/LearningPath/LearningPathStateHelperTrait.php
@@ -95,6 +95,20 @@ trait LearningPathStateHelperTrait
             ?? throw new BadRequestHttpException('Missing course id.');
     }
 
+    /**
+     * SessionVoter proves the course/session pairing for students and course coaches, but not
+     * for general coaches or admins. Assert it before persisting a resource link, so an
+     * unrelated pair can never be written.
+     */
+    private function assertSessionBelongsToCourse(?Session $session, Course $course): void
+    {
+        if (!$session instanceof Session || $session->hasCourse($course)) {
+            return;
+        }
+
+        throw new AccessDeniedHttpException('The requested session is not linked to this course.');
+    }
+
     private function getContextGroup(
         EntityManagerInterface $entityManager,
         CidReqHelper $cidReqHelper,

--- a/src/CoreBundle/State/LearningPath/LearningPathStateHelperTrait.php
+++ b/src/CoreBundle/State/LearningPath/LearningPathStateHelperTrait.php
@@ -11,7 +11,6 @@ use Chamilo\CoreBundle\Entity\Course;
 use Chamilo\CoreBundle\Entity\ResourceLink;
 use Chamilo\CoreBundle\Entity\ResourceNode;
 use Chamilo\CoreBundle\Entity\Session;
-use Chamilo\CoreBundle\Entity\SessionRelCourse;
 use Chamilo\CoreBundle\Helpers\CidReqHelper;
 use Chamilo\CourseBundle\Entity\CGroup;
 use Doctrine\ORM\EntityManagerInterface;
@@ -86,46 +85,14 @@ trait LearningPathStateHelperTrait
             || $security->isGranted('ROLE_CURRENT_COURSE_SESSION_TEACHER');
     }
 
+    /**
+     * CidReqListener already resolved and validated the course, so a missing entity here
+     * can only mean the request carried no course context at all.
+     */
     private function getContextCourse(CidReqHelper $cidReqHelper): Course
     {
-        $courseId = (int) ($cidReqHelper->getCourseId() ?? 0);
-        if ($courseId <= 0) {
-            throw new BadRequestHttpException('Missing course id.');
-        }
-
-        $course = $cidReqHelper->getDoctrineCourseEntity();
-        if (!$course instanceof Course) {
-            throw new NotFoundHttpException('Course not found.');
-        }
-
-        return $course;
-    }
-
-    private function getContextSession(
-        EntityManagerInterface $entityManager,
-        CidReqHelper $cidReqHelper,
-        Course $course,
-    ): ?Session {
-        $sessionId = (int) ($cidReqHelper->getSessionId() ?? 0);
-        if ($sessionId <= 0) {
-            return null;
-        }
-
-        $session = $cidReqHelper->getDoctrineSessionEntity();
-        if (!$session instanceof Session) {
-            throw new NotFoundHttpException('Session not found.');
-        }
-
-        $sessionCourse = $entityManager->getRepository(SessionRelCourse::class)->findOneBy([
-            'course' => $course,
-            'session' => $session,
-        ]);
-
-        if (!$sessionCourse instanceof SessionRelCourse) {
-            throw new AccessDeniedHttpException('The requested session is not linked to this course.');
-        }
-
-        return $session;
+        return $cidReqHelper->getDoctrineCourseEntity()
+            ?? throw new BadRequestHttpException('Missing course id.');
     }
 
     private function getContextGroup(

--- a/src/CoreBundle/State/LearningPath/LearningPathStateHelperTrait.php
+++ b/src/CoreBundle/State/LearningPath/LearningPathStateHelperTrait.php
@@ -86,14 +86,14 @@ trait LearningPathStateHelperTrait
             || $security->isGranted('ROLE_CURRENT_COURSE_SESSION_TEACHER');
     }
 
-    private function getContextCourse(EntityManagerInterface $entityManager, Request $request): Course
+    private function getContextCourse(CidReqHelper $cidReqHelper): Course
     {
-        $courseId = $request->query->getInt('cid');
+        $courseId = (int) ($cidReqHelper->getCourseId() ?? 0);
         if ($courseId <= 0) {
             throw new BadRequestHttpException('Missing course id.');
         }
 
-        $course = $entityManager->getRepository(Course::class)->find($courseId);
+        $course = $cidReqHelper->getDoctrineCourseEntity();
         if (!$course instanceof Course) {
             throw new NotFoundHttpException('Course not found.');
         }
@@ -101,14 +101,17 @@ trait LearningPathStateHelperTrait
         return $course;
     }
 
-    private function getContextSession(EntityManagerInterface $entityManager, Request $request, Course $course): ?Session
-    {
-        $sessionId = $request->query->getInt('sid');
+    private function getContextSession(
+        EntityManagerInterface $entityManager,
+        CidReqHelper $cidReqHelper,
+        Course $course,
+    ): ?Session {
+        $sessionId = (int) ($cidReqHelper->getSessionId() ?? 0);
         if ($sessionId <= 0) {
             return null;
         }
 
-        $session = $entityManager->getRepository(Session::class)->find($sessionId);
+        $session = $cidReqHelper->getDoctrineSessionEntity();
         if (!$session instanceof Session) {
             throw new NotFoundHttpException('Session not found.');
         }
@@ -125,14 +128,7 @@ trait LearningPathStateHelperTrait
         return $session;
     }
 
-    private function getContextGroup(EntityManagerInterface $entityManager, Request $request, Course $course): ?CGroup
-    {
-        $groupId = $request->query->getInt('gid');
-
-        return $groupId > 0 ? $this->findValidatedGroup($entityManager, $groupId, $course) : null;
-    }
-
-    private function getValidatedGroupFromContext(
+    private function getContextGroup(
         EntityManagerInterface $entityManager,
         CidReqHelper $cidReqHelper,
         Course $course,

--- a/src/CoreBundle/State/LearningPath/LearningPathVisibilityProcessor.php
+++ b/src/CoreBundle/State/LearningPath/LearningPathVisibilityProcessor.php
@@ -54,7 +54,7 @@ final readonly class LearningPathVisibilityProcessor implements ProcessorInterfa
         $this->assertLearningPathTeacher($this->security);
 
         $course = $this->getContextCourse($this->cidReqHelper);
-        $session = $this->getContextSession($this->entityManager, $this->cidReqHelper, $course);
+        $session = $this->cidReqHelper->getDoctrineSessionEntity();
         $group = $this->getContextGroup($this->entityManager, $this->cidReqHelper, $course);
         $resourceLink = $this->getEditableResourceLink($data, $course, $session, $group, $this->security);
         $visible = $this->getTargetVisibility($payload, $resourceLink);

--- a/src/CoreBundle/State/LearningPath/LearningPathVisibilityProcessor.php
+++ b/src/CoreBundle/State/LearningPath/LearningPathVisibilityProcessor.php
@@ -9,6 +9,7 @@ namespace Chamilo\CoreBundle\State\LearningPath;
 use ApiPlatform\Metadata\Operation;
 use ApiPlatform\State\ProcessorInterface;
 use Chamilo\CoreBundle\Entity\ResourceLink;
+use Chamilo\CoreBundle\Helpers\CidReqHelper;
 use Chamilo\CourseBundle\Entity\CLp;
 use Chamilo\CourseBundle\Entity\CLpCategory;
 use Doctrine\ORM\EntityManagerInterface;
@@ -30,6 +31,7 @@ final readonly class LearningPathVisibilityProcessor implements ProcessorInterfa
         private RequestStack $requestStack,
         private Security $security,
         private CsrfTokenManagerInterface $csrfTokenManager,
+        private CidReqHelper $cidReqHelper,
     ) {}
 
     public function process(mixed $data, Operation $operation, array $uriVariables = [], array $context = []): JsonResponse
@@ -51,9 +53,9 @@ final readonly class LearningPathVisibilityProcessor implements ProcessorInterfa
         }
         $this->assertLearningPathTeacher($this->security);
 
-        $course = $this->getContextCourse($this->entityManager, $request);
-        $session = $this->getContextSession($this->entityManager, $request, $course);
-        $group = $this->getContextGroup($this->entityManager, $request, $course);
+        $course = $this->getContextCourse($this->cidReqHelper);
+        $session = $this->getContextSession($this->entityManager, $this->cidReqHelper, $course);
+        $group = $this->getContextGroup($this->entityManager, $this->cidReqHelper, $course);
         $resourceLink = $this->getEditableResourceLink($data, $course, $session, $group, $this->security);
         $visible = $this->getTargetVisibility($payload, $resourceLink);
 

--- a/src/CoreBundle/State/Portfolio/PortfolioAccessHelperTrait.php
+++ b/src/CoreBundle/State/Portfolio/PortfolioAccessHelperTrait.php
@@ -14,7 +14,6 @@ use Chamilo\CoreBundle\Entity\ResourceFile;
 use Chamilo\CoreBundle\Entity\ResourceLink;
 use Chamilo\CoreBundle\Entity\Session;
 use Chamilo\CoreBundle\Entity\User;
-use Chamilo\CoreBundle\Helpers\CidReqHelper;
 use Chamilo\CoreBundle\Helpers\UserHelper;
 use Chamilo\CoreBundle\Repository\ResourceNodeRepository;
 use Chamilo\CoreBundle\Security\Authorization\Voter\CourseVoter;
@@ -46,46 +45,6 @@ trait PortfolioAccessHelperTrait
         }
 
         return $user;
-    }
-
-    private function getPortfolioCourse(CidReqHelper $cidReqHelper): ?Course
-    {
-        $courseId = (int) ($cidReqHelper->getCourseId() ?? 0);
-        if ($courseId <= 0) {
-            return null;
-        }
-
-        $course = $cidReqHelper->getDoctrineCourseEntity();
-        if (!$course instanceof Course) {
-            throw new BadRequestHttpException('The requested course was not found.');
-        }
-
-        return $course;
-    }
-
-    private function getPortfolioSession(
-        CidReqHelper $cidReqHelper,
-        ?Course $course,
-    ): ?Session {
-        $sessionId = (int) ($cidReqHelper->getSessionId() ?? 0);
-        if ($sessionId <= 0) {
-            return null;
-        }
-
-        if (!$course instanceof Course) {
-            throw new BadRequestHttpException('A session requires a course context.');
-        }
-
-        $session = $cidReqHelper->getDoctrineSessionEntity();
-        if (!$session instanceof Session) {
-            throw new BadRequestHttpException('The requested session was not found.');
-        }
-
-        if (!$session->hasCourse($course)) {
-            throw new AccessDeniedHttpException('The requested session does not contain the current course.');
-        }
-
-        return $session;
     }
 
     private function getPortfolioRequestedUser(

--- a/src/CoreBundle/State/Portfolio/PortfolioAccessHelperTrait.php
+++ b/src/CoreBundle/State/Portfolio/PortfolioAccessHelperTrait.php
@@ -14,6 +14,7 @@ use Chamilo\CoreBundle\Entity\ResourceFile;
 use Chamilo\CoreBundle\Entity\ResourceLink;
 use Chamilo\CoreBundle\Entity\Session;
 use Chamilo\CoreBundle\Entity\User;
+use Chamilo\CoreBundle\Helpers\CidReqHelper;
 use Chamilo\CoreBundle\Helpers\UserHelper;
 use Chamilo\CoreBundle\Repository\ResourceNodeRepository;
 use Chamilo\CoreBundle\Security\Authorization\Voter\CourseVoter;
@@ -47,14 +48,14 @@ trait PortfolioAccessHelperTrait
         return $user;
     }
 
-    private function getPortfolioCourse(EntityManagerInterface $entityManager, Request $request): ?Course
+    private function getPortfolioCourse(CidReqHelper $cidReqHelper): ?Course
     {
-        $courseId = $request->query->getInt('cid');
+        $courseId = (int) ($cidReqHelper->getCourseId() ?? 0);
         if ($courseId <= 0) {
             return null;
         }
 
-        $course = $entityManager->getRepository(Course::class)->find($courseId);
+        $course = $cidReqHelper->getDoctrineCourseEntity();
         if (!$course instanceof Course) {
             throw new BadRequestHttpException('The requested course was not found.');
         }
@@ -63,11 +64,10 @@ trait PortfolioAccessHelperTrait
     }
 
     private function getPortfolioSession(
-        EntityManagerInterface $entityManager,
-        Request $request,
+        CidReqHelper $cidReqHelper,
         ?Course $course,
     ): ?Session {
-        $sessionId = $request->query->getInt('sid');
+        $sessionId = (int) ($cidReqHelper->getSessionId() ?? 0);
         if ($sessionId <= 0) {
             return null;
         }
@@ -76,7 +76,7 @@ trait PortfolioAccessHelperTrait
             throw new BadRequestHttpException('A session requires a course context.');
         }
 
-        $session = $entityManager->getRepository(Session::class)->find($sessionId);
+        $session = $cidReqHelper->getDoctrineSessionEntity();
         if (!$session instanceof Session) {
             throw new BadRequestHttpException('The requested session was not found.');
         }

--- a/src/CoreBundle/State/Portfolio/PortfolioActionProcessor.php
+++ b/src/CoreBundle/State/Portfolio/PortfolioActionProcessor.php
@@ -72,8 +72,8 @@ final readonly class PortfolioActionProcessor implements ProcessorInterface
         $this->validatePortfolioCsrfToken($this->csrfTokenManager, ['csrfToken' => $data->csrfToken]);
 
         $currentUser = $this->getPortfolioCurrentUser($this->userHelper);
-        $course = $this->getPortfolioCourse($this->cidReqHelper);
-        $session = $this->getPortfolioSession($this->cidReqHelper, $course);
+        $course = $this->cidReqHelper->getDoctrineCourseEntity();
+        $session = $this->cidReqHelper->getDoctrineSessionEntity();
         $advancedSharing = $course instanceof Course && $this->portfolioBoolean(
             $this->settingsManager->getSetting('platform.portfolio_advanced_sharing', true),
         );

--- a/src/CoreBundle/State/Portfolio/PortfolioActionProcessor.php
+++ b/src/CoreBundle/State/Portfolio/PortfolioActionProcessor.php
@@ -18,6 +18,7 @@ use Chamilo\CoreBundle\Event\PortfolioItemDeletedEvent;
 use Chamilo\CoreBundle\Event\PortfolioItemHighlightedEvent;
 use Chamilo\CoreBundle\Event\PortfolioItemScoredEvent;
 use Chamilo\CoreBundle\Event\PortfolioItemVisibilityChangedEvent;
+use Chamilo\CoreBundle\Helpers\CidReqHelper;
 use Chamilo\CoreBundle\Helpers\UserHelper;
 use Chamilo\CoreBundle\Repository\Node\PortfolioRepository;
 use Chamilo\CoreBundle\Repository\ResourceLinkRepository;
@@ -48,6 +49,7 @@ final readonly class PortfolioActionProcessor implements ProcessorInterface
         private SettingsManager $settingsManager,
         private CsrfTokenManagerInterface $csrfTokenManager,
         private EventDispatcherInterface $eventDispatcher,
+        private CidReqHelper $cidReqHelper,
     ) {}
 
     /**
@@ -70,8 +72,8 @@ final readonly class PortfolioActionProcessor implements ProcessorInterface
         $this->validatePortfolioCsrfToken($this->csrfTokenManager, ['csrfToken' => $data->csrfToken]);
 
         $currentUser = $this->getPortfolioCurrentUser($this->userHelper);
-        $course = $this->getPortfolioCourse($this->entityManager, $request);
-        $session = $this->getPortfolioSession($this->entityManager, $request, $course);
+        $course = $this->getPortfolioCourse($this->cidReqHelper);
+        $session = $this->getPortfolioSession($this->cidReqHelper, $course);
         $advancedSharing = $course instanceof Course && $this->portfolioBoolean(
             $this->settingsManager->getSetting('platform.portfolio_advanced_sharing', true),
         );

--- a/src/CoreBundle/State/Portfolio/PortfolioCommentActionProcessor.php
+++ b/src/CoreBundle/State/Portfolio/PortfolioCommentActionProcessor.php
@@ -68,8 +68,8 @@ final readonly class PortfolioCommentActionProcessor implements ProcessorInterfa
         $this->validatePortfolioCsrfToken($this->csrfTokenManager, ['csrfToken' => $data->csrfToken]);
 
         $currentUser = $this->getPortfolioCurrentUser($this->userHelper);
-        $course = $this->getPortfolioCourse($this->cidReqHelper);
-        $session = $this->getPortfolioSession($this->cidReqHelper, $course);
+        $course = $this->cidReqHelper->getDoctrineCourseEntity();
+        $session = $this->cidReqHelper->getDoctrineSessionEntity();
         $advancedSharing = $course instanceof Course && $this->portfolioBoolean(
             $this->settingsManager->getSetting('platform.portfolio_advanced_sharing', true),
         );

--- a/src/CoreBundle/State/Portfolio/PortfolioCommentActionProcessor.php
+++ b/src/CoreBundle/State/Portfolio/PortfolioCommentActionProcessor.php
@@ -16,6 +16,7 @@ use Chamilo\CoreBundle\Entity\Session;
 use Chamilo\CoreBundle\Entity\User;
 use Chamilo\CoreBundle\Event\Events;
 use Chamilo\CoreBundle\Event\PortfolioCommentScoredEvent;
+use Chamilo\CoreBundle\Helpers\CidReqHelper;
 use Chamilo\CoreBundle\Helpers\UserHelper;
 use Chamilo\CoreBundle\Repository\ResourceLinkRepository;
 use Chamilo\CoreBundle\Settings\SettingsManager;
@@ -44,6 +45,7 @@ final readonly class PortfolioCommentActionProcessor implements ProcessorInterfa
         private SettingsManager $settingsManager,
         private CsrfTokenManagerInterface $csrfTokenManager,
         private EventDispatcherInterface $eventDispatcher,
+        private CidReqHelper $cidReqHelper,
     ) {}
 
     /**
@@ -66,8 +68,8 @@ final readonly class PortfolioCommentActionProcessor implements ProcessorInterfa
         $this->validatePortfolioCsrfToken($this->csrfTokenManager, ['csrfToken' => $data->csrfToken]);
 
         $currentUser = $this->getPortfolioCurrentUser($this->userHelper);
-        $course = $this->getPortfolioCourse($this->entityManager, $request);
-        $session = $this->getPortfolioSession($this->entityManager, $request, $course);
+        $course = $this->getPortfolioCourse($this->cidReqHelper);
+        $session = $this->getPortfolioSession($this->cidReqHelper, $course);
         $advancedSharing = $course instanceof Course && $this->portfolioBoolean(
             $this->settingsManager->getSetting('platform.portfolio_advanced_sharing', true),
         );

--- a/src/CoreBundle/State/Portfolio/PortfolioCommentFormProcessor.php
+++ b/src/CoreBundle/State/Portfolio/PortfolioCommentFormProcessor.php
@@ -16,6 +16,7 @@ use Chamilo\CoreBundle\Entity\Session;
 use Chamilo\CoreBundle\Event\Events;
 use Chamilo\CoreBundle\Event\PortfolioCommentEditedEvent;
 use Chamilo\CoreBundle\Event\PortfolioItemCommentedEvent;
+use Chamilo\CoreBundle\Helpers\CidReqHelper;
 use Chamilo\CoreBundle\Helpers\UserHelper;
 use Chamilo\CoreBundle\Repository\Node\PortfolioCommentRepository;
 use Chamilo\CoreBundle\Repository\Node\PortfolioRepository;
@@ -53,6 +54,7 @@ final readonly class PortfolioCommentFormProcessor implements ProcessorInterface
         private CsrfTokenManagerInterface $csrfTokenManager,
         private UploadFilenamePolicy $uploadFilenamePolicy,
         private EventDispatcherInterface $eventDispatcher,
+        private CidReqHelper $cidReqHelper,
     ) {}
 
     /**
@@ -69,8 +71,8 @@ final readonly class PortfolioCommentFormProcessor implements ProcessorInterface
         $this->validatePortfolioCsrfToken($this->csrfTokenManager, $payload);
 
         $currentUser = $this->getPortfolioCurrentUser($this->userHelper);
-        $course = $this->getPortfolioCourse($this->entityManager, $request);
-        $session = $this->getPortfolioSession($this->entityManager, $request, $course);
+        $course = $this->getPortfolioCourse($this->cidReqHelper);
+        $session = $this->getPortfolioSession($this->cidReqHelper, $course);
         if ($course instanceof Course && !$this->canReadPortfolioCourse(
             $this->security,
             $this->userHelper,

--- a/src/CoreBundle/State/Portfolio/PortfolioCommentFormProcessor.php
+++ b/src/CoreBundle/State/Portfolio/PortfolioCommentFormProcessor.php
@@ -71,8 +71,8 @@ final readonly class PortfolioCommentFormProcessor implements ProcessorInterface
         $this->validatePortfolioCsrfToken($this->csrfTokenManager, $payload);
 
         $currentUser = $this->getPortfolioCurrentUser($this->userHelper);
-        $course = $this->getPortfolioCourse($this->cidReqHelper);
-        $session = $this->getPortfolioSession($this->cidReqHelper, $course);
+        $course = $this->cidReqHelper->getDoctrineCourseEntity();
+        $session = $this->cidReqHelper->getDoctrineSessionEntity();
         if ($course instanceof Course && !$this->canReadPortfolioCourse(
             $this->security,
             $this->userHelper,

--- a/src/CoreBundle/State/Portfolio/PortfolioDetailsProvider.php
+++ b/src/CoreBundle/State/Portfolio/PortfolioDetailsProvider.php
@@ -14,6 +14,7 @@ use Chamilo\CoreBundle\Entity\Portfolio;
 use Chamilo\CoreBundle\Entity\PortfolioComment;
 use Chamilo\CoreBundle\Entity\Session;
 use Chamilo\CoreBundle\Entity\User;
+use Chamilo\CoreBundle\Helpers\CidReqHelper;
 use Chamilo\CoreBundle\Helpers\UserHelper;
 use Chamilo\CoreBundle\Repository\Node\PortfolioCommentRepository;
 use Chamilo\CoreBundle\Repository\Node\PortfolioRepository;
@@ -42,6 +43,7 @@ final readonly class PortfolioDetailsProvider implements ProviderInterface
         private Security $security,
         private UserHelper $userHelper,
         private SettingsManager $settingsManager,
+        private CidReqHelper $cidReqHelper,
     ) {}
 
     /**
@@ -55,8 +57,8 @@ final readonly class PortfolioDetailsProvider implements ProviderInterface
             throw new BadRequestHttpException('The current request is required.');
         }
         $currentUser = $this->getPortfolioCurrentUser($this->userHelper);
-        $course = $this->getPortfolioCourse($this->entityManager, $request);
-        $session = $this->getPortfolioSession($this->entityManager, $request, $course);
+        $course = $this->getPortfolioCourse($this->cidReqHelper);
+        $session = $this->getPortfolioSession($this->cidReqHelper, $course);
         if ($course instanceof Course && !$this->canReadPortfolioCourse(
             $this->security,
             $this->userHelper,

--- a/src/CoreBundle/State/Portfolio/PortfolioDetailsProvider.php
+++ b/src/CoreBundle/State/Portfolio/PortfolioDetailsProvider.php
@@ -57,8 +57,8 @@ final readonly class PortfolioDetailsProvider implements ProviderInterface
             throw new BadRequestHttpException('The current request is required.');
         }
         $currentUser = $this->getPortfolioCurrentUser($this->userHelper);
-        $course = $this->getPortfolioCourse($this->cidReqHelper);
-        $session = $this->getPortfolioSession($this->cidReqHelper, $course);
+        $course = $this->cidReqHelper->getDoctrineCourseEntity();
+        $session = $this->cidReqHelper->getDoctrineSessionEntity();
         if ($course instanceof Course && !$this->canReadPortfolioCourse(
             $this->security,
             $this->userHelper,

--- a/src/CoreBundle/State/Portfolio/PortfolioFormProcessor.php
+++ b/src/CoreBundle/State/Portfolio/PortfolioFormProcessor.php
@@ -73,8 +73,8 @@ final readonly class PortfolioFormProcessor implements ProcessorInterface
         $this->validatePortfolioCsrfToken($this->csrfTokenManager, $payload);
 
         $currentUser = $this->getPortfolioCurrentUser($this->userHelper);
-        $course = $this->getPortfolioCourse($this->cidReqHelper);
-        $session = $this->getPortfolioSession($this->cidReqHelper, $course);
+        $course = $this->cidReqHelper->getDoctrineCourseEntity();
+        $session = $this->cidReqHelper->getDoctrineSessionEntity();
         if ($course instanceof Course && !$this->canReadPortfolioCourse(
             $this->security,
             $this->userHelper,

--- a/src/CoreBundle/State/Portfolio/PortfolioFormProcessor.php
+++ b/src/CoreBundle/State/Portfolio/PortfolioFormProcessor.php
@@ -16,6 +16,7 @@ use Chamilo\CoreBundle\Entity\Session;
 use Chamilo\CoreBundle\Event\Events;
 use Chamilo\CoreBundle\Event\PortfolioItemAddedEvent;
 use Chamilo\CoreBundle\Event\PortfolioItemEditedEvent;
+use Chamilo\CoreBundle\Helpers\CidReqHelper;
 use Chamilo\CoreBundle\Helpers\UserHelper;
 use Chamilo\CoreBundle\Repository\ExtraFieldValuesRepository;
 use Chamilo\CoreBundle\Repository\Node\PortfolioRepository;
@@ -54,6 +55,7 @@ final readonly class PortfolioFormProcessor implements ProcessorInterface
         private CsrfTokenManagerInterface $csrfTokenManager,
         private UploadFilenamePolicy $uploadFilenamePolicy,
         private EventDispatcherInterface $eventDispatcher,
+        private CidReqHelper $cidReqHelper,
     ) {}
 
     /**
@@ -71,8 +73,8 @@ final readonly class PortfolioFormProcessor implements ProcessorInterface
         $this->validatePortfolioCsrfToken($this->csrfTokenManager, $payload);
 
         $currentUser = $this->getPortfolioCurrentUser($this->userHelper);
-        $course = $this->getPortfolioCourse($this->entityManager, $request);
-        $session = $this->getPortfolioSession($this->entityManager, $request, $course);
+        $course = $this->getPortfolioCourse($this->cidReqHelper);
+        $session = $this->getPortfolioSession($this->cidReqHelper, $course);
         if ($course instanceof Course && !$this->canReadPortfolioCourse(
             $this->security,
             $this->userHelper,

--- a/src/CoreBundle/State/Portfolio/PortfolioFormProvider.php
+++ b/src/CoreBundle/State/Portfolio/PortfolioFormProvider.php
@@ -19,6 +19,7 @@ use Chamilo\CoreBundle\Entity\PortfolioRelTag;
 use Chamilo\CoreBundle\Entity\ResourceLink;
 use Chamilo\CoreBundle\Entity\Session;
 use Chamilo\CoreBundle\Entity\User;
+use Chamilo\CoreBundle\Helpers\CidReqHelper;
 use Chamilo\CoreBundle\Helpers\UserHelper;
 use Chamilo\CoreBundle\Repository\ExtraFieldValuesRepository;
 use Chamilo\CoreBundle\Repository\Node\PortfolioRepository;
@@ -51,6 +52,7 @@ final readonly class PortfolioFormProvider implements ProviderInterface
         private UserHelper $userHelper,
         private SettingsManager $settingsManager,
         private CsrfTokenManagerInterface $csrfTokenManager,
+        private CidReqHelper $cidReqHelper,
     ) {}
 
     /**
@@ -65,8 +67,8 @@ final readonly class PortfolioFormProvider implements ProviderInterface
         }
 
         $currentUser = $this->getPortfolioCurrentUser($this->userHelper);
-        $course = $this->getPortfolioCourse($this->entityManager, $request);
-        $session = $this->getPortfolioSession($this->entityManager, $request, $course);
+        $course = $this->getPortfolioCourse($this->cidReqHelper);
+        $session = $this->getPortfolioSession($this->cidReqHelper, $course);
         if ($course instanceof Course && !$this->canReadPortfolioCourse(
             $this->security,
             $this->userHelper,

--- a/src/CoreBundle/State/Portfolio/PortfolioFormProvider.php
+++ b/src/CoreBundle/State/Portfolio/PortfolioFormProvider.php
@@ -67,8 +67,8 @@ final readonly class PortfolioFormProvider implements ProviderInterface
         }
 
         $currentUser = $this->getPortfolioCurrentUser($this->userHelper);
-        $course = $this->getPortfolioCourse($this->cidReqHelper);
-        $session = $this->getPortfolioSession($this->cidReqHelper, $course);
+        $course = $this->cidReqHelper->getDoctrineCourseEntity();
+        $session = $this->cidReqHelper->getDoctrineSessionEntity();
         if ($course instanceof Course && !$this->canReadPortfolioCourse(
             $this->security,
             $this->userHelper,

--- a/src/CoreBundle/State/Portfolio/PortfolioItemProvider.php
+++ b/src/CoreBundle/State/Portfolio/PortfolioItemProvider.php
@@ -20,6 +20,7 @@ use Chamilo\CoreBundle\Entity\Tag;
 use Chamilo\CoreBundle\Entity\User;
 use Chamilo\CoreBundle\Event\Events;
 use Chamilo\CoreBundle\Event\PortfolioItemViewedEvent;
+use Chamilo\CoreBundle\Helpers\CidReqHelper;
 use Chamilo\CoreBundle\Helpers\UserHelper;
 use Chamilo\CoreBundle\Repository\Node\PortfolioCommentRepository;
 use Chamilo\CoreBundle\Repository\Node\PortfolioRepository;
@@ -55,6 +56,7 @@ final readonly class PortfolioItemProvider implements ProviderInterface
         private SettingsManager $settingsManager,
         private CsrfTokenManagerInterface $csrfTokenManager,
         private EventDispatcherInterface $eventDispatcher,
+        private CidReqHelper $cidReqHelper,
     ) {}
 
     /**
@@ -74,8 +76,8 @@ final readonly class PortfolioItemProvider implements ProviderInterface
         }
 
         $currentUser = $this->getPortfolioCurrentUser($this->userHelper);
-        $course = $this->getPortfolioCourse($this->entityManager, $request);
-        $session = $this->getPortfolioSession($this->entityManager, $request, $course);
+        $course = $this->getPortfolioCourse($this->cidReqHelper);
+        $session = $this->getPortfolioSession($this->cidReqHelper, $course);
 
         if ($course instanceof Course
             && !$this->canReadPortfolioCourse(

--- a/src/CoreBundle/State/Portfolio/PortfolioItemProvider.php
+++ b/src/CoreBundle/State/Portfolio/PortfolioItemProvider.php
@@ -76,8 +76,8 @@ final readonly class PortfolioItemProvider implements ProviderInterface
         }
 
         $currentUser = $this->getPortfolioCurrentUser($this->userHelper);
-        $course = $this->getPortfolioCourse($this->cidReqHelper);
-        $session = $this->getPortfolioSession($this->cidReqHelper, $course);
+        $course = $this->cidReqHelper->getDoctrineCourseEntity();
+        $session = $this->cidReqHelper->getDoctrineSessionEntity();
 
         if ($course instanceof Course
             && !$this->canReadPortfolioCourse(

--- a/src/CoreBundle/State/Portfolio/PortfolioListProvider.php
+++ b/src/CoreBundle/State/Portfolio/PortfolioListProvider.php
@@ -18,6 +18,7 @@ use Chamilo\CoreBundle\Entity\PortfolioComment;
 use Chamilo\CoreBundle\Entity\Session;
 use Chamilo\CoreBundle\Entity\Tag;
 use Chamilo\CoreBundle\Entity\User;
+use Chamilo\CoreBundle\Helpers\CidReqHelper;
 use Chamilo\CoreBundle\Helpers\UserHelper;
 use Chamilo\CoreBundle\Repository\Node\PortfolioCommentRepository;
 use Chamilo\CoreBundle\Repository\Node\PortfolioRepository;
@@ -56,6 +57,7 @@ final readonly class PortfolioListProvider implements ProviderInterface
         private UserHelper $userHelper,
         private SettingsManager $settingsManager,
         private CsrfTokenManagerInterface $csrfTokenManager,
+        private CidReqHelper $cidReqHelper,
     ) {}
 
     /**
@@ -70,8 +72,8 @@ final readonly class PortfolioListProvider implements ProviderInterface
         }
 
         $currentUser = $this->getPortfolioCurrentUser($this->userHelper);
-        $course = $this->getPortfolioCourse($this->entityManager, $request);
-        $session = $this->getPortfolioSession($this->entityManager, $request, $course);
+        $course = $this->getPortfolioCourse($this->cidReqHelper);
+        $session = $this->getPortfolioSession($this->cidReqHelper, $course);
 
         if ($course instanceof Course
             && !$this->canReadPortfolioCourse(

--- a/src/CoreBundle/State/Portfolio/PortfolioListProvider.php
+++ b/src/CoreBundle/State/Portfolio/PortfolioListProvider.php
@@ -72,8 +72,8 @@ final readonly class PortfolioListProvider implements ProviderInterface
         }
 
         $currentUser = $this->getPortfolioCurrentUser($this->userHelper);
-        $course = $this->getPortfolioCourse($this->cidReqHelper);
-        $session = $this->getPortfolioSession($this->cidReqHelper, $course);
+        $course = $this->cidReqHelper->getDoctrineCourseEntity();
+        $session = $this->cidReqHelper->getDoctrineSessionEntity();
 
         if ($course instanceof Course
             && !$this->canReadPortfolioCourse(

--- a/src/CoreBundle/State/Portfolio/PortfolioManagementProcessor.php
+++ b/src/CoreBundle/State/Portfolio/PortfolioManagementProcessor.php
@@ -14,6 +14,7 @@ use Chamilo\CoreBundle\Entity\ExtraField;
 use Chamilo\CoreBundle\Entity\PortfolioCategory;
 use Chamilo\CoreBundle\Entity\PortfolioRelTag;
 use Chamilo\CoreBundle\Entity\Tag;
+use Chamilo\CoreBundle\Helpers\CidReqHelper;
 use Chamilo\CoreBundle\Helpers\UserHelper;
 use Chamilo\CoreBundle\Repository\ExtraFieldRepository;
 use Chamilo\CoreBundle\Settings\SettingsManager;
@@ -41,6 +42,7 @@ final readonly class PortfolioManagementProcessor implements ProcessorInterface
         private ExtraFieldRepository $extraFieldRepository,
         private SettingsManager $settingsManager,
         private CsrfTokenManagerInterface $csrfTokenManager,
+        private CidReqHelper $cidReqHelper,
     ) {}
 
     /**
@@ -63,8 +65,8 @@ final readonly class PortfolioManagementProcessor implements ProcessorInterface
         $this->validatePortfolioCsrfToken($this->csrfTokenManager, ['csrfToken' => $data->csrfToken]);
 
         $currentUser = $this->getPortfolioCurrentUser($this->userHelper);
-        $course = $this->getPortfolioCourse($this->entityManager, $request);
-        $session = $this->getPortfolioSession($this->entityManager, $request, $course);
+        $course = $this->getPortfolioCourse($this->cidReqHelper);
+        $session = $this->getPortfolioSession($this->cidReqHelper, $course);
         $canManageTags = $course instanceof Course
             && $this->canManagePortfolioCourse($this->security, $currentUser, $course, $session);
         $result = new PortfolioManagement();

--- a/src/CoreBundle/State/Portfolio/PortfolioManagementProcessor.php
+++ b/src/CoreBundle/State/Portfolio/PortfolioManagementProcessor.php
@@ -65,8 +65,8 @@ final readonly class PortfolioManagementProcessor implements ProcessorInterface
         $this->validatePortfolioCsrfToken($this->csrfTokenManager, ['csrfToken' => $data->csrfToken]);
 
         $currentUser = $this->getPortfolioCurrentUser($this->userHelper);
-        $course = $this->getPortfolioCourse($this->cidReqHelper);
-        $session = $this->getPortfolioSession($this->cidReqHelper, $course);
+        $course = $this->cidReqHelper->getDoctrineCourseEntity();
+        $session = $this->cidReqHelper->getDoctrineSessionEntity();
         $canManageTags = $course instanceof Course
             && $this->canManagePortfolioCourse($this->security, $currentUser, $course, $session);
         $result = new PortfolioManagement();

--- a/src/CoreBundle/State/Portfolio/PortfolioManagementProvider.php
+++ b/src/CoreBundle/State/Portfolio/PortfolioManagementProvider.php
@@ -51,8 +51,8 @@ final readonly class PortfolioManagementProvider implements ProviderInterface
             throw new BadRequestHttpException('The current request is required.');
         }
         $currentUser = $this->getPortfolioCurrentUser($this->userHelper);
-        $course = $this->getPortfolioCourse($this->cidReqHelper);
-        $session = $this->getPortfolioSession($this->cidReqHelper, $course);
+        $course = $this->cidReqHelper->getDoctrineCourseEntity();
+        $session = $this->cidReqHelper->getDoctrineSessionEntity();
         if ($course instanceof Course && !$this->canReadPortfolioCourse(
             $this->security,
             $this->userHelper,

--- a/src/CoreBundle/State/Portfolio/PortfolioManagementProvider.php
+++ b/src/CoreBundle/State/Portfolio/PortfolioManagementProvider.php
@@ -12,6 +12,7 @@ use Chamilo\CoreBundle\ApiResource\Portfolio\PortfolioManagement;
 use Chamilo\CoreBundle\Entity\Course;
 use Chamilo\CoreBundle\Entity\PortfolioCategory;
 use Chamilo\CoreBundle\Entity\PortfolioRelTag;
+use Chamilo\CoreBundle\Helpers\CidReqHelper;
 use Chamilo\CoreBundle\Helpers\UserHelper;
 use Chamilo\CoreBundle\Settings\SettingsManager;
 use Doctrine\ORM\EntityManagerInterface;
@@ -36,6 +37,7 @@ final readonly class PortfolioManagementProvider implements ProviderInterface
         private UserHelper $userHelper,
         private SettingsManager $settingsManager,
         private CsrfTokenManagerInterface $csrfTokenManager,
+        private CidReqHelper $cidReqHelper,
     ) {}
 
     /**
@@ -49,8 +51,8 @@ final readonly class PortfolioManagementProvider implements ProviderInterface
             throw new BadRequestHttpException('The current request is required.');
         }
         $currentUser = $this->getPortfolioCurrentUser($this->userHelper);
-        $course = $this->getPortfolioCourse($this->entityManager, $request);
-        $session = $this->getPortfolioSession($this->entityManager, $request, $course);
+        $course = $this->getPortfolioCourse($this->cidReqHelper);
+        $session = $this->getPortfolioSession($this->cidReqHelper, $course);
         if ($course instanceof Course && !$this->canReadPortfolioCourse(
             $this->security,
             $this->userHelper,

--- a/src/CourseBundle/Entity/CForum.php
+++ b/src/CourseBundle/Entity/CForum.php
@@ -16,6 +16,7 @@ use ApiPlatform\Metadata\Get;
 use ApiPlatform\Metadata\GetCollection;
 use ApiPlatform\Metadata\Patch;
 use ApiPlatform\Metadata\Post;
+use ApiPlatform\Metadata\QueryParameter;
 use ApiPlatform\OpenApi\Model\Operation;
 use ApiPlatform\OpenApi\Model\Parameter;
 use ApiPlatform\OpenApi\Model\RequestBody;
@@ -77,6 +78,21 @@ use Symfony\Component\Validator\Constraints as Assert;
             input: ForumWriteInput::class,
             read: false,
             name: 'create_forum',
+            parameters: [
+                'cid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Course identifier',
+                    required: true,
+                ),
+                'sid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Session identifier',
+                ),
+                'gid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Group identifier',
+                ),
+            ],
             processor: ForumProcessor::class,
         ),
         new Patch(
@@ -84,6 +100,21 @@ use Symfony\Component\Validator\Constraints as Assert;
             security: "is_granted('EDIT', object.resourceNode)",
             deserialize: false,
             name: 'update_forum',
+            parameters: [
+                'cid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Course identifier',
+                    required: true,
+                ),
+                'sid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Session identifier',
+                ),
+                'gid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Group identifier',
+                ),
+            ],
             processor: ForumProcessor::class,
         ),
         new Patch(
@@ -91,6 +122,21 @@ use Symfony\Component\Validator\Constraints as Assert;
             security: "is_granted('EDIT', object.resourceNode)",
             deserialize: false,
             name: 'toggle_forum_lock',
+            parameters: [
+                'cid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Course identifier',
+                    required: true,
+                ),
+                'sid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Session identifier',
+                ),
+                'gid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Group identifier',
+                ),
+            ],
             processor: ForumProcessor::class,
         ),
         new Patch(
@@ -98,6 +144,21 @@ use Symfony\Component\Validator\Constraints as Assert;
             security: "is_granted('EDIT', object.resourceNode)",
             deserialize: false,
             name: 'toggle_forum_visibility',
+            parameters: [
+                'cid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Course identifier',
+                    required: true,
+                ),
+                'sid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Session identifier',
+                ),
+                'gid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Group identifier',
+                ),
+            ],
             processor: ForumProcessor::class,
         ),
         new Patch(
@@ -105,6 +166,21 @@ use Symfony\Component\Validator\Constraints as Assert;
             security: "is_granted('EDIT', object.resourceNode)",
             deserialize: false,
             name: 'move_forum',
+            parameters: [
+                'cid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Course identifier',
+                    required: true,
+                ),
+                'sid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Session identifier',
+                ),
+                'gid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Group identifier',
+                ),
+            ],
             processor: ForumProcessor::class,
         ),
         new Patch(
@@ -112,6 +188,21 @@ use Symfony\Component\Validator\Constraints as Assert;
             security: "is_granted('VIEW', object.resourceNode)",
             deserialize: false,
             name: 'toggle_forum_subscription',
+            parameters: [
+                'cid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Course identifier',
+                    required: true,
+                ),
+                'sid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Session identifier',
+                ),
+                'gid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Group identifier',
+                ),
+            ],
             processor: ForumProcessor::class,
         ),
         new Post(
@@ -152,6 +243,21 @@ use Symfony\Component\Validator\Constraints as Assert;
                 'multipart' => ['multipart/form-data'],
             ],
             name: 'upload_forum_image',
+            parameters: [
+                'cid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Course identifier',
+                    required: true,
+                ),
+                'sid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Session identifier',
+                ),
+                'gid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Group identifier',
+                ),
+            ],
             processor: ForumProcessor::class,
         ),
         new Delete(
@@ -159,6 +265,21 @@ use Symfony\Component\Validator\Constraints as Assert;
             security: "is_granted('EDIT', object.resourceNode)",
             deserialize: false,
             name: 'delete_forum',
+            parameters: [
+                'cid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Course identifier',
+                    required: true,
+                ),
+                'sid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Session identifier',
+                ),
+                'gid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Group identifier',
+                ),
+            ],
             processor: ForumDeleteProcessor::class,
         ),
         new Get(

--- a/src/CourseBundle/Entity/CForumCategory.php
+++ b/src/CourseBundle/Entity/CForumCategory.php
@@ -16,6 +16,7 @@ use ApiPlatform\Metadata\Get;
 use ApiPlatform\Metadata\GetCollection;
 use ApiPlatform\Metadata\Patch;
 use ApiPlatform\Metadata\Post;
+use ApiPlatform\Metadata\QueryParameter;
 use ApiPlatform\OpenApi\Model\Operation;
 use ApiPlatform\OpenApi\Model\Parameter;
 use ApiPlatform\OpenApi\Model\RequestBody;
@@ -66,6 +67,21 @@ use Symfony\Component\Validator\Constraints as Assert;
             input: ForumWriteInput::class,
             read: false,
             name: 'create_forum_category',
+            parameters: [
+                'cid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Course identifier',
+                    required: true,
+                ),
+                'sid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Session identifier',
+                ),
+                'gid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Group identifier',
+                ),
+            ],
             processor: ForumCategoryProcessor::class,
         ),
         new Patch(
@@ -73,6 +89,21 @@ use Symfony\Component\Validator\Constraints as Assert;
             security: "is_granted('EDIT', object.resourceNode)",
             deserialize: false,
             name: 'update_forum_category',
+            parameters: [
+                'cid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Course identifier',
+                    required: true,
+                ),
+                'sid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Session identifier',
+                ),
+                'gid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Group identifier',
+                ),
+            ],
             processor: ForumCategoryProcessor::class,
         ),
         new Patch(
@@ -80,6 +111,21 @@ use Symfony\Component\Validator\Constraints as Assert;
             security: "is_granted('EDIT', object.resourceNode)",
             deserialize: false,
             name: 'toggle_forum_category_lock',
+            parameters: [
+                'cid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Course identifier',
+                    required: true,
+                ),
+                'sid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Session identifier',
+                ),
+                'gid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Group identifier',
+                ),
+            ],
             processor: ForumCategoryProcessor::class,
         ),
         new Patch(
@@ -87,6 +133,21 @@ use Symfony\Component\Validator\Constraints as Assert;
             security: "is_granted('EDIT', object.resourceNode)",
             deserialize: false,
             name: 'toggle_forum_category_visibility',
+            parameters: [
+                'cid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Course identifier',
+                    required: true,
+                ),
+                'sid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Session identifier',
+                ),
+                'gid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Group identifier',
+                ),
+            ],
             processor: ForumCategoryProcessor::class,
         ),
         new Patch(
@@ -94,6 +155,21 @@ use Symfony\Component\Validator\Constraints as Assert;
             security: "is_granted('EDIT', object.resourceNode)",
             deserialize: false,
             name: 'move_forum_category',
+            parameters: [
+                'cid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Course identifier',
+                    required: true,
+                ),
+                'sid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Session identifier',
+                ),
+                'gid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Group identifier',
+                ),
+            ],
             processor: ForumCategoryProcessor::class,
         ),
         new Delete(
@@ -101,6 +177,21 @@ use Symfony\Component\Validator\Constraints as Assert;
             security: "is_granted('EDIT', object.resourceNode)",
             deserialize: false,
             name: 'delete_forum_category',
+            parameters: [
+                'cid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Course identifier',
+                    required: true,
+                ),
+                'sid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Session identifier',
+                ),
+                'gid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Group identifier',
+                ),
+            ],
             processor: ForumDeleteProcessor::class,
         ),
         new Get(security: "is_granted('VIEW', object.resourceNode)"),

--- a/src/CourseBundle/Entity/CForumPost.php
+++ b/src/CourseBundle/Entity/CForumPost.php
@@ -16,6 +16,7 @@ use ApiPlatform\Metadata\Get;
 use ApiPlatform\Metadata\GetCollection;
 use ApiPlatform\Metadata\Patch;
 use ApiPlatform\Metadata\Post;
+use ApiPlatform\Metadata\QueryParameter;
 use ApiPlatform\OpenApi\Model\Operation;
 use ApiPlatform\OpenApi\Model\Parameter;
 use ApiPlatform\OpenApi\Model\RequestBody;
@@ -92,6 +93,21 @@ use Symfony\Component\Validator\Constraints as Assert;
             security: "is_granted('ROLE_CURRENT_COURSE_STUDENT') or is_granted('ROLE_CURRENT_COURSE_SESSION_STUDENT')",
             input: ForumPostWriteInput::class,
             provider: ForumPostCreateStateProvider::class,
+            parameters: [
+                'cid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Course identifier',
+                    required: true,
+                ),
+                'sid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Session identifier',
+                ),
+                'gid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Group identifier',
+                ),
+            ],
             processor: ForumPostProcessor::class,
             deserialize: false,
             read: true,
@@ -103,6 +119,21 @@ use Symfony\Component\Validator\Constraints as Assert;
             deserialize: false,
             name: 'update_forum_post',
             provider: ForumPostActionProvider::class,
+            parameters: [
+                'cid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Course identifier',
+                    required: true,
+                ),
+                'sid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Session identifier',
+                ),
+                'gid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Group identifier',
+                ),
+            ],
             processor: ForumPostProcessor::class,
         ),
         new Patch(
@@ -111,6 +142,21 @@ use Symfony\Component\Validator\Constraints as Assert;
             deserialize: false,
             name: 'toggle_forum_post_visibility',
             provider: ForumPostActionProvider::class,
+            parameters: [
+                'cid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Course identifier',
+                    required: true,
+                ),
+                'sid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Session identifier',
+                ),
+                'gid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Group identifier',
+                ),
+            ],
             processor: ForumPostProcessor::class,
         ),
         new Patch(
@@ -119,6 +165,21 @@ use Symfony\Component\Validator\Constraints as Assert;
             deserialize: false,
             name: 'approve_forum_post',
             provider: ForumPostActionProvider::class,
+            parameters: [
+                'cid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Course identifier',
+                    required: true,
+                ),
+                'sid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Session identifier',
+                ),
+                'gid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Group identifier',
+                ),
+            ],
             processor: ForumPostProcessor::class,
         ),
         new Patch(
@@ -127,6 +188,21 @@ use Symfony\Component\Validator\Constraints as Assert;
             deserialize: false,
             name: 'reject_forum_post',
             provider: ForumPostActionProvider::class,
+            parameters: [
+                'cid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Course identifier',
+                    required: true,
+                ),
+                'sid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Session identifier',
+                ),
+                'gid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Group identifier',
+                ),
+            ],
             processor: ForumPostProcessor::class,
         ),
         new Patch(
@@ -135,6 +211,21 @@ use Symfony\Component\Validator\Constraints as Assert;
             deserialize: false,
             name: 'move_forum_post',
             provider: ForumPostActionProvider::class,
+            parameters: [
+                'cid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Course identifier',
+                    required: true,
+                ),
+                'sid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Session identifier',
+                ),
+                'gid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Group identifier',
+                ),
+            ],
             processor: ForumPostProcessor::class,
         ),
         new Patch(
@@ -143,6 +234,21 @@ use Symfony\Component\Validator\Constraints as Assert;
             deserialize: false,
             name: 'ask_forum_post_revision',
             provider: ForumPostActionProvider::class,
+            parameters: [
+                'cid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Course identifier',
+                    required: true,
+                ),
+                'sid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Session identifier',
+                ),
+                'gid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Group identifier',
+                ),
+            ],
             processor: ForumPostProcessor::class,
         ),
         new Patch(
@@ -151,6 +257,21 @@ use Symfony\Component\Validator\Constraints as Assert;
             deserialize: false,
             name: 'report_forum_post',
             provider: ForumPostActionProvider::class,
+            parameters: [
+                'cid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Course identifier',
+                    required: true,
+                ),
+                'sid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Session identifier',
+                ),
+                'gid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Group identifier',
+                ),
+            ],
             processor: ForumPostProcessor::class,
         ),
         new Delete(
@@ -159,6 +280,21 @@ use Symfony\Component\Validator\Constraints as Assert;
             deserialize: false,
             name: 'delete_forum_post',
             provider: ForumPostActionProvider::class,
+            parameters: [
+                'cid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Course identifier',
+                    required: true,
+                ),
+                'sid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Session identifier',
+                ),
+                'gid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Group identifier',
+                ),
+            ],
             processor: ForumPostProcessor::class,
         ),
         new Get(security: "is_granted('VIEW', object.resourceNode)"),

--- a/src/CourseBundle/Entity/CForumThread.php
+++ b/src/CourseBundle/Entity/CForumThread.php
@@ -16,6 +16,7 @@ use ApiPlatform\Metadata\Get;
 use ApiPlatform\Metadata\GetCollection;
 use ApiPlatform\Metadata\Patch;
 use ApiPlatform\Metadata\Post;
+use ApiPlatform\Metadata\QueryParameter;
 use ApiPlatform\OpenApi\Model\Operation;
 use ApiPlatform\OpenApi\Model\Parameter;
 use ApiPlatform\OpenApi\Model\RequestBody;
@@ -99,6 +100,21 @@ use Symfony\Component\Validator\Constraints as Assert;
         new Patch(
             uriTemplate: '/forum_threads/{iid}/update',
             name: 'update_forum_thread',
+            parameters: [
+                'cid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Course identifier',
+                    required: true,
+                ),
+                'sid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Session identifier',
+                ),
+                'gid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Group identifier',
+                ),
+            ],
             processor: ForumThreadProcessor::class,
             security: "is_granted('EDIT', object.resourceNode)",
             deserialize: false,
@@ -106,6 +122,21 @@ use Symfony\Component\Validator\Constraints as Assert;
         new Patch(
             uriTemplate: '/forum_threads/{iid}/toggle-lock',
             name: 'toggle_forum_thread_lock',
+            parameters: [
+                'cid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Course identifier',
+                    required: true,
+                ),
+                'sid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Session identifier',
+                ),
+                'gid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Group identifier',
+                ),
+            ],
             processor: ForumThreadProcessor::class,
             security: "is_granted('EDIT', object.resourceNode)",
             deserialize: false,
@@ -113,6 +144,21 @@ use Symfony\Component\Validator\Constraints as Assert;
         new Patch(
             uriTemplate: '/forum_threads/{iid}/toggle-sticky',
             name: 'toggle_forum_thread_sticky',
+            parameters: [
+                'cid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Course identifier',
+                    required: true,
+                ),
+                'sid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Session identifier',
+                ),
+                'gid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Group identifier',
+                ),
+            ],
             processor: ForumThreadProcessor::class,
             security: "is_granted('EDIT', object.resourceNode)",
             deserialize: false,
@@ -120,6 +166,21 @@ use Symfony\Component\Validator\Constraints as Assert;
         new Patch(
             uriTemplate: '/forum_threads/{iid}/toggle-visibility',
             name: 'toggle_forum_thread_visibility',
+            parameters: [
+                'cid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Course identifier',
+                    required: true,
+                ),
+                'sid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Session identifier',
+                ),
+                'gid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Group identifier',
+                ),
+            ],
             processor: ForumThreadProcessor::class,
             security: "is_granted('EDIT', object.resourceNode)",
             deserialize: false,
@@ -127,6 +188,21 @@ use Symfony\Component\Validator\Constraints as Assert;
         new Patch(
             uriTemplate: '/forum_threads/{iid}/move',
             name: 'move_forum_thread',
+            parameters: [
+                'cid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Course identifier',
+                    required: true,
+                ),
+                'sid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Session identifier',
+                ),
+                'gid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Group identifier',
+                ),
+            ],
             processor: ForumThreadProcessor::class,
             security: "is_granted('EDIT', object.resourceNode)",
             deserialize: false,
@@ -134,6 +210,21 @@ use Symfony\Component\Validator\Constraints as Assert;
         new Patch(
             uriTemplate: '/forum_threads/{iid}/toggle-subscription',
             name: 'toggle_forum_thread_subscription',
+            parameters: [
+                'cid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Course identifier',
+                    required: true,
+                ),
+                'sid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Session identifier',
+                ),
+                'gid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Group identifier',
+                ),
+            ],
             processor: ForumThreadProcessor::class,
             security: "is_granted('VIEW', object.resourceNode)",
             deserialize: false,
@@ -141,6 +232,21 @@ use Symfony\Component\Validator\Constraints as Assert;
         new Delete(
             uriTemplate: '/forum_threads/{iid}',
             name: 'delete_forum_thread',
+            parameters: [
+                'cid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Course identifier',
+                    required: true,
+                ),
+                'sid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Session identifier',
+                ),
+                'gid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Group identifier',
+                ),
+            ],
             processor: ForumThreadProcessor::class,
             security: "is_granted('EDIT', object.resourceNode)",
             deserialize: false,

--- a/src/CourseBundle/Entity/CLp.php
+++ b/src/CourseBundle/Entity/CLp.php
@@ -13,6 +13,7 @@ use ApiPlatform\Metadata\Get;
 use ApiPlatform\Metadata\GetCollection;
 use ApiPlatform\Metadata\Patch;
 use ApiPlatform\Metadata\Post;
+use ApiPlatform\Metadata\QueryParameter;
 use ApiPlatform\OpenApi\Model\Operation;
 use ApiPlatform\OpenApi\Model\Parameter;
 use ApiPlatform\OpenApi\Model\RequestBody;
@@ -71,6 +72,17 @@ use Symfony\Component\Validator\Constraints as Assert;
                     ),
                 ],
             ),
+            parameters: [
+                'cid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Course identifier',
+                    required: true,
+                ),
+                'gid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Group identifier',
+                ),
+            ],
             paginationClientEnabled: true,
             name: 'get_lp_collection_with_progress',
             provider: LearningPathCollectionProvider::class,
@@ -82,6 +94,21 @@ use Symfony\Component\Validator\Constraints as Assert;
             security: "is_granted('EDIT', object.resourceNode)",
             deserialize: false,
             validate: false,
+            parameters: [
+                'cid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Course identifier',
+                    required: true,
+                ),
+                'sid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Session identifier',
+                ),
+                'gid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Group identifier',
+                ),
+            ],
             name: 'toggle_learning_path_visibility',
             processor: LearningPathVisibilityProcessor::class,
         ),
@@ -143,6 +170,21 @@ use Symfony\Component\Validator\Constraints as Assert;
             security: "is_granted('ROLE_CURRENT_COURSE_TEACHER') or is_granted('ROLE_CURRENT_COURSE_SESSION_TEACHER')",
             read: false,
             deserialize: false,
+            parameters: [
+                'cid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Course identifier',
+                    required: true,
+                ),
+                'sid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Session identifier',
+                ),
+                'gid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Group identifier',
+                ),
+            ],
             name: 'lp_reorder',
             processor: LearningPathReorderProcessor::class,
         ),
@@ -190,6 +232,21 @@ use Symfony\Component\Validator\Constraints as Assert;
             read: false,
             validate: false,
             denormalizationContext: ['groups' => ['lp:layout']],
+            parameters: [
+                'cid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Course identifier',
+                    required: true,
+                ),
+                'sid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Session identifier',
+                ),
+                'gid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Group identifier',
+                ),
+            ],
             name: 'lp_layout_update',
             processor: LearningPathLayoutProcessor::class,
         ),

--- a/src/CourseBundle/Entity/CLpCategory.php
+++ b/src/CourseBundle/Entity/CLpCategory.php
@@ -13,6 +13,7 @@ use ApiPlatform\Metadata\Get;
 use ApiPlatform\Metadata\GetCollection;
 use ApiPlatform\Metadata\Patch;
 use ApiPlatform\Metadata\Post;
+use ApiPlatform\Metadata\QueryParameter;
 use ApiPlatform\OpenApi\Model\Operation;
 use ApiPlatform\OpenApi\Model\RequestBody;
 use ArrayObject;
@@ -42,6 +43,21 @@ use Symfony\Component\Validator\Constraints as Assert;
                 summary: 'List LP categories by course (resourceNode.parent) or sid',
             ),
             security: "is_granted('ROLE_CURRENT_COURSE_STUDENT') or is_granted('ROLE_CURRENT_COURSE_SESSION_STUDENT')",
+            parameters: [
+                'cid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Course identifier',
+                    required: true,
+                ),
+                'sid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Session identifier',
+                ),
+                'gid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Group identifier',
+                ),
+            ],
             provider: LearningPathCategoryCollectionProvider::class,
         ),
         new Get(security: "is_granted('VIEW', object.resourceNode)"),
@@ -50,6 +66,21 @@ use Symfony\Component\Validator\Constraints as Assert;
             security: "is_granted('EDIT', object.resourceNode)",
             deserialize: false,
             validate: false,
+            parameters: [
+                'cid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Course identifier',
+                    required: true,
+                ),
+                'sid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Session identifier',
+                ),
+                'gid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Group identifier',
+                ),
+            ],
             name: 'toggle_learning_path_category_visibility',
             processor: LearningPathVisibilityProcessor::class,
         ),
@@ -83,6 +114,21 @@ use Symfony\Component\Validator\Constraints as Assert;
             deserialize: false,
             validate: false,
             name: 'lp_category_reorder',
+            parameters: [
+                'cid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Course identifier',
+                    required: true,
+                ),
+                'sid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Session identifier',
+                ),
+                'gid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Group identifier',
+                ),
+            ],
             processor: LearningPathCategoryReorderProcessor::class,
         ),
     ],

--- a/tests/CoreBundle/Service/CourseInvitation/CourseInvitationTokenServiceTest.php
+++ b/tests/CoreBundle/Service/CourseInvitation/CourseInvitationTokenServiceTest.php
@@ -26,7 +26,7 @@ final class CourseInvitationTokenServiceTest extends AbstractApiTest
     private CourseInvitationTokenService $service;
     private ValidationTokenRepository $tokenRepository;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
 


### PR DESCRIPTION
Refs #8817 — six blocks of the checklist, one commit each: `LearningPath`, `Portfolio`, `Forum`, `CourseInvitation`, `Ai` and `CalendarEvent`.

API Platform providers and processors should take their input from `$operation`, `$uriVariables`, `$context` and `$data`. Several traits and providers were reading `cid`, `sid` and `gid` straight from the query, so the parameters never reached the OpenAPI schema and were never validated, and the classes could not run outside an HTTP request. The context methods now receive `CidReqHelper` — the canonical source once `CidReqListener` has resolved the context — and the operations wiring those classes declare the parameters with `Metadata\QueryParameter`.

Every block uses `getDoctrineCourseEntity()` / `getDoctrineSessionEntity()` rather than `getCourseEntity()` / `getSessionEntity()`, because the latter return the entity stored in the session, which may be detached, and these objects are persisted downstream. Every validation each trait added on top of the listener is kept, and the existing status codes and messages are preserved verbatim.

Whether `cid` is declared `required` follows the code, not a blanket rule: it is required where the trait already threw a 400 without it (LearningPath, Forum, CourseInvitation), and optional where a course-less context is legitimate — Portfolio's personal portfolio, and the AI translation flow, where an absent `cid` means "translate outside a course" and is gated by `ROLE_ADMIN`.

Per block:

- **LearningPath** (26 classes, 27 resources, 41 operations): `getValidatedGroupFromContext()` merged into `getContextGroup()` — both did the same thing. `sid` omitted on the `CLp` collection, where `SidFilter` already documents it.
- **Portfolio** (10 classes, 8 resources, 12 operations): `PortfolioList`, `PortfolioItem` and `PortfolioForm` already declared `cid`/`sid` through `openapi: new Parameter`, which only documents; those were *moved* to `QueryParameter` rather than added, to avoid duplicate schema entries.
- **Forum** (13 classes, 6 resources, 32 operations): the two gid-reading helpers are duplicated in the trait and redefined locally in two providers; all three copies were switched to `CidReqHelper`, but the duplication itself is pre-existing and left alone. `ForumGradingOptions` had its `cid`/`sid` moved out of `openapi:`, leaving two imports to drop.
- **CourseInvitation** (3 classes + trait, 4 operations): `EntityManagerInterface` became unused in all three classes once the trait stopped needing it, and `RequestStack` in two of them; `CourseInvitationRevokeProcessor` keeps both, since it reads the CSRF token from the raw DELETE body.
- **Ai** (2 classes, 2 operations): `resolveCourseAndAssertAccess()` was duplicated byte-for-byte in the provider and the processor; it is now `WysiwygTranslationAccessHelperTrait`. `sid` there only feeds the AI audit log and gains no new validation.
- **CalendarEvent** (1 class): **no parameters declared** — `GET /api/c_calendar_events` already documents `cid` and `sid` via `CidFilter::getDescription()` and `SidFilter::getDescription()`, so declaring them would duplicate. The point of the change is that the provider and `CCalendarEventExtension` now derive the "personal agenda" context from the same source; they previously disagreed (query string vs session), and the extension's `WHERE` can contradict rows the provider adds. It also drops an unchecked `getMainRequest()` dereference and closes a latent `TypeError` where a possibly-null user reached a non-nullable `User` parameter.

**Behaviour change worth reviewing:** `CidReqListener` returns early on the `_lti_provider_access_restored` path before syncing `sid`/`gid` into the session. Endpoints that used to read those from the query may now pick up the `sid`/`gid` of the previous navigation under LTI. `cid` is unaffected — it is written before that early return. I don't know whether any LTI flow opens a learning path inside a session, so a second opinion there would help.

Checks: ECS clean on all 106 files. PHPStan reports no new errors in any block, verified against a baseline captured before editing (LearningPath 6, Portfolio 21, Forum 69 — all pre-existing; the last four blocks start from 0 and stay at 0). `api:openapi:export` regenerates cleanly, with every touched route exposing its context and no duplicate parameter names anywhere. `tests/CoreBundle/State/LearningPath/` passes 4/4; `CCalendarEventRepositoryTest` is unchanged at 6/7 — `testGetEvents` fails with a 401 both before and after, so it is pre-existing and unrelated.

Coverage is thin: Portfolio, Forum, CourseInvitation and Ai have no tests at all, so those four rest on ECS, PHPStan and the OpenAPI export rather than on behavioural coverage.

Re-running the audit from the issue takes the count from 50 classes to 1. What remains is `CourseGroupOverviewProvider`, deliberately deferred: the actual read lives in `CourseGroupManager::resolveContext(Request)`, which 12 providers/processors and `CourseGroupExportController` depend on — around 22 files and 29 operations, with no test coverage. It belongs in its own PR together with `CourseUserManager` and `CourseClassManager`, which have a structurally identical `resolveContext(Request)` and were never listed in the issue.
