### PR TITLE
CourseClass, CourseUser, CourseGroup: read course context from CidReqHelper in the managers and declare cid/sid/gid in the operations

### DIFF
--- a/src/CoreBundle/ApiResource/CourseClass/CourseClassAction.php
+++ b/src/CoreBundle/ApiResource/CourseClass/CourseClassAction.php
@@ -9,8 +9,8 @@ namespace Chamilo\CoreBundle\ApiResource\CourseClass;
 use ApiPlatform\Metadata\ApiProperty;
 use ApiPlatform\Metadata\ApiResource;
 use ApiPlatform\Metadata\Post;
+use ApiPlatform\Metadata\QueryParameter;
 use ApiPlatform\OpenApi\Model\Operation;
-use ApiPlatform\OpenApi\Model\Parameter;
 use Chamilo\CoreBundle\State\CourseClass\CourseClassActionProcessor;
 use Symfony\Component\Serializer\Attribute\Groups;
 
@@ -21,45 +21,75 @@ use Symfony\Component\Serializer\Attribute\Groups;
             uriTemplate: '/course-classes/actions/add',
             openapi: new Operation(
                 summary: 'Link a class to the current course or session',
-                parameters: [
-                    new Parameter(name: 'cid', in: 'query', required: true, schema: ['type' => 'integer']),
-                    new Parameter(name: 'sid', in: 'query', required: false, schema: ['type' => 'integer']),
-                    new Parameter(name: 'gid', in: 'query', required: false, schema: ['type' => 'integer']),
-                ],
             ),
             security: "is_granted('IS_AUTHENTICATED_FULLY')",
             read: false,
             name: 'post_course_class_add',
+            parameters: [
+                'cid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Course identifier',
+                    required: true,
+                ),
+                'sid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Session identifier',
+                ),
+                'gid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Group identifier',
+                ),
+            ],
             processor: CourseClassActionProcessor::class,
         ),
         new Post(
             uriTemplate: '/course-classes/actions/remove',
             openapi: new Operation(
                 summary: 'Remove a class and apply legacy user unsubscription behavior',
-                parameters: [
-                    new Parameter(name: 'cid', in: 'query', required: true, schema: ['type' => 'integer']),
-                    new Parameter(name: 'sid', in: 'query', required: false, schema: ['type' => 'integer']),
-                    new Parameter(name: 'gid', in: 'query', required: false, schema: ['type' => 'integer']),
-                ],
             ),
             security: "is_granted('IS_AUTHENTICATED_FULLY')",
             read: false,
             name: 'post_course_class_remove',
+            parameters: [
+                'cid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Course identifier',
+                    required: true,
+                ),
+                'sid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Session identifier',
+                ),
+                'gid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Group identifier',
+                ),
+            ],
             processor: CourseClassActionProcessor::class,
         ),
         new Post(
             uriTemplate: '/course-classes/actions/remove-only',
             openapi: new Operation(
                 summary: 'Remove only the class relation and keep users subscribed',
-                parameters: [
-                    new Parameter(name: 'cid', in: 'query', required: true, schema: ['type' => 'integer']),
-                    new Parameter(name: 'sid', in: 'query', required: false, schema: ['type' => 'integer']),
-                    new Parameter(name: 'gid', in: 'query', required: false, schema: ['type' => 'integer']),
-                ],
             ),
             security: "is_granted('IS_AUTHENTICATED_FULLY')",
             read: false,
             name: 'post_course_class_remove_only',
+            parameters: [
+                'cid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Course identifier',
+                    required: true,
+                ),
+                'sid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Session identifier',
+                ),
+                'gid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Group identifier',
+                ),
+            ],
             processor: CourseClassActionProcessor::class,
         ),
     ],

--- a/src/CoreBundle/ApiResource/CourseClass/CourseClassList.php
+++ b/src/CoreBundle/ApiResource/CourseClass/CourseClassList.php
@@ -9,6 +9,7 @@ namespace Chamilo\CoreBundle\ApiResource\CourseClass;
 use ApiPlatform\Metadata\ApiProperty;
 use ApiPlatform\Metadata\ApiResource;
 use ApiPlatform\Metadata\Get;
+use ApiPlatform\Metadata\QueryParameter;
 use ApiPlatform\OpenApi\Model\Operation;
 use ApiPlatform\OpenApi\Model\Parameter;
 use Chamilo\CoreBundle\State\CourseClass\CourseClassListProvider;
@@ -22,9 +23,6 @@ use Symfony\Component\Serializer\Attribute\Groups;
             openapi: new Operation(
                 summary: 'Classes linked or available in the current course context',
                 parameters: [
-                    new Parameter(name: 'cid', in: 'query', required: true, schema: ['type' => 'integer']),
-                    new Parameter(name: 'sid', in: 'query', required: false, schema: ['type' => 'integer']),
-                    new Parameter(name: 'gid', in: 'query', required: false, schema: ['type' => 'integer']),
                     new Parameter(name: 'view', in: 'query', required: false, schema: ['type' => 'string']),
                     new Parameter(name: 'groupFilter', in: 'query', required: false, schema: ['type' => 'integer']),
                     new Parameter(name: 'search', in: 'query', required: false, schema: ['type' => 'string']),
@@ -36,6 +34,21 @@ use Symfony\Component\Serializer\Attribute\Groups;
             ),
             security: "is_granted('IS_AUTHENTICATED_FULLY')",
             name: 'get_course_class_list',
+            parameters: [
+                'cid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Course identifier',
+                    required: true,
+                ),
+                'sid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Session identifier',
+                ),
+                'gid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Group identifier',
+                ),
+            ],
             provider: CourseClassListProvider::class,
         ),
     ],

--- a/src/CoreBundle/ApiResource/CourseGroup/CourseGroupAction.php
+++ b/src/CoreBundle/ApiResource/CourseGroup/CourseGroupAction.php
@@ -9,6 +9,7 @@ namespace Chamilo\CoreBundle\ApiResource\CourseGroup;
 use ApiPlatform\Metadata\ApiProperty;
 use ApiPlatform\Metadata\ApiResource;
 use ApiPlatform\Metadata\Post;
+use ApiPlatform\Metadata\QueryParameter;
 use ApiPlatform\OpenApi\Model\Operation;
 use Chamilo\CoreBundle\State\CourseGroup\CourseGroupActionProcessor;
 use Symfony\Component\Serializer\Attribute\Groups;
@@ -22,6 +23,17 @@ use Symfony\Component\Serializer\Attribute\Groups;
             security: "is_granted('IS_AUTHENTICATED_FULLY')",
             read: false,
             name: 'post_course_group_create_groups',
+            parameters: [
+                'cid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Course identifier',
+                    required: true,
+                ),
+                'sid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Session identifier',
+                ),
+            ],
             processor: CourseGroupActionProcessor::class,
         ),
         new Post(
@@ -30,6 +42,17 @@ use Symfony\Component\Serializer\Attribute\Groups;
             security: "is_granted('IS_AUTHENTICATED_FULLY')",
             read: false,
             name: 'post_course_group_create_subgroups',
+            parameters: [
+                'cid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Course identifier',
+                    required: true,
+                ),
+                'sid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Session identifier',
+                ),
+            ],
             processor: CourseGroupActionProcessor::class,
         ),
         new Post(
@@ -38,6 +61,17 @@ use Symfony\Component\Serializer\Attribute\Groups;
             security: "is_granted('IS_AUTHENTICATED_FULLY')",
             read: false,
             name: 'post_course_group_create_class_groups',
+            parameters: [
+                'cid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Course identifier',
+                    required: true,
+                ),
+                'sid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Session identifier',
+                ),
+            ],
             processor: CourseGroupActionProcessor::class,
         ),
         new Post(
@@ -46,6 +80,17 @@ use Symfony\Component\Serializer\Attribute\Groups;
             security: "is_granted('IS_AUTHENTICATED_FULLY')",
             read: false,
             name: 'post_course_group_delete',
+            parameters: [
+                'cid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Course identifier',
+                    required: true,
+                ),
+                'sid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Session identifier',
+                ),
+            ],
             processor: CourseGroupActionProcessor::class,
         ),
         new Post(
@@ -54,6 +99,17 @@ use Symfony\Component\Serializer\Attribute\Groups;
             security: "is_granted('IS_AUTHENTICATED_FULLY')",
             read: false,
             name: 'post_course_group_empty',
+            parameters: [
+                'cid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Course identifier',
+                    required: true,
+                ),
+                'sid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Session identifier',
+                ),
+            ],
             processor: CourseGroupActionProcessor::class,
         ),
         new Post(
@@ -62,6 +118,17 @@ use Symfony\Component\Serializer\Attribute\Groups;
             security: "is_granted('IS_AUTHENTICATED_FULLY')",
             read: false,
             name: 'post_course_group_fill',
+            parameters: [
+                'cid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Course identifier',
+                    required: true,
+                ),
+                'sid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Session identifier',
+                ),
+            ],
             processor: CourseGroupActionProcessor::class,
         ),
         new Post(
@@ -70,6 +137,17 @@ use Symfony\Component\Serializer\Attribute\Groups;
             security: "is_granted('IS_AUTHENTICATED_FULLY')",
             read: false,
             name: 'post_course_group_toggle_visibility',
+            parameters: [
+                'cid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Course identifier',
+                    required: true,
+                ),
+                'sid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Session identifier',
+                ),
+            ],
             processor: CourseGroupActionProcessor::class,
         ),
         new Post(
@@ -78,6 +156,17 @@ use Symfony\Component\Serializer\Attribute\Groups;
             security: "is_granted('IS_AUTHENTICATED_FULLY')",
             read: false,
             name: 'post_course_group_self_register',
+            parameters: [
+                'cid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Course identifier',
+                    required: true,
+                ),
+                'sid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Session identifier',
+                ),
+            ],
             processor: CourseGroupActionProcessor::class,
         ),
         new Post(
@@ -86,6 +175,17 @@ use Symfony\Component\Serializer\Attribute\Groups;
             security: "is_granted('IS_AUTHENTICATED_FULLY')",
             read: false,
             name: 'post_course_group_self_unregister',
+            parameters: [
+                'cid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Course identifier',
+                    required: true,
+                ),
+                'sid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Session identifier',
+                ),
+            ],
             processor: CourseGroupActionProcessor::class,
         ),
         new Post(
@@ -94,6 +194,17 @@ use Symfony\Component\Serializer\Attribute\Groups;
             security: "is_granted('IS_AUTHENTICATED_FULLY')",
             read: false,
             name: 'post_course_group_delete_category',
+            parameters: [
+                'cid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Course identifier',
+                    required: true,
+                ),
+                'sid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Session identifier',
+                ),
+            ],
             processor: CourseGroupActionProcessor::class,
         ),
         new Post(
@@ -102,6 +213,17 @@ use Symfony\Component\Serializer\Attribute\Groups;
             security: "is_granted('IS_AUTHENTICATED_FULLY')",
             read: false,
             name: 'post_course_group_move_category',
+            parameters: [
+                'cid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Course identifier',
+                    required: true,
+                ),
+                'sid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Session identifier',
+                ),
+            ],
             processor: CourseGroupActionProcessor::class,
         ),
         new Post(
@@ -110,6 +232,17 @@ use Symfony\Component\Serializer\Attribute\Groups;
             security: "is_granted('IS_AUTHENTICATED_FULLY')",
             read: false,
             name: 'post_course_group_remove_class_link',
+            parameters: [
+                'cid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Course identifier',
+                    required: true,
+                ),
+                'sid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Session identifier',
+                ),
+            ],
             processor: CourseGroupActionProcessor::class,
         ),
     ],

--- a/src/CoreBundle/ApiResource/CourseGroup/CourseGroupCategoryForm.php
+++ b/src/CoreBundle/ApiResource/CourseGroup/CourseGroupCategoryForm.php
@@ -11,6 +11,7 @@ use ApiPlatform\Metadata\ApiResource;
 use ApiPlatform\Metadata\Get;
 use ApiPlatform\Metadata\Link;
 use ApiPlatform\Metadata\Post;
+use ApiPlatform\Metadata\QueryParameter;
 use ApiPlatform\OpenApi\Model\Operation;
 use Chamilo\CoreBundle\State\CourseGroup\CourseGroupCategoryFormProcessor;
 use Chamilo\CoreBundle\State\CourseGroup\CourseGroupCategoryFormProvider;
@@ -24,6 +25,17 @@ use Symfony\Component\Serializer\Attribute\Groups;
             openapi: new Operation(summary: 'New group category form data'),
             security: "is_granted('IS_AUTHENTICATED_FULLY')",
             name: 'get_course_group_category_create_form',
+            parameters: [
+                'cid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Course identifier',
+                    required: true,
+                ),
+                'sid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Session identifier',
+                ),
+            ],
             provider: CourseGroupCategoryFormProvider::class,
         ),
         new Get(
@@ -34,6 +46,17 @@ use Symfony\Component\Serializer\Attribute\Groups;
             openapi: new Operation(summary: 'Existing group category form data'),
             security: "is_granted('IS_AUTHENTICATED_FULLY')",
             name: 'get_course_group_category_update_form',
+            parameters: [
+                'cid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Course identifier',
+                    required: true,
+                ),
+                'sid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Session identifier',
+                ),
+            ],
             provider: CourseGroupCategoryFormProvider::class,
         ),
         new Post(
@@ -42,6 +65,17 @@ use Symfony\Component\Serializer\Attribute\Groups;
             security: "is_granted('IS_AUTHENTICATED_FULLY')",
             read: false,
             name: 'post_course_group_category_create_form',
+            parameters: [
+                'cid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Course identifier',
+                    required: true,
+                ),
+                'sid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Session identifier',
+                ),
+            ],
             processor: CourseGroupCategoryFormProcessor::class,
         ),
         new Post(
@@ -53,6 +87,17 @@ use Symfony\Component\Serializer\Attribute\Groups;
             security: "is_granted('IS_AUTHENTICATED_FULLY')",
             read: false,
             name: 'post_course_group_category_update_form',
+            parameters: [
+                'cid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Course identifier',
+                    required: true,
+                ),
+                'sid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Session identifier',
+                ),
+            ],
             processor: CourseGroupCategoryFormProcessor::class,
         ),
     ],

--- a/src/CoreBundle/ApiResource/CourseGroup/CourseGroupDetail.php
+++ b/src/CoreBundle/ApiResource/CourseGroup/CourseGroupDetail.php
@@ -10,6 +10,7 @@ use ApiPlatform\Metadata\ApiProperty;
 use ApiPlatform\Metadata\ApiResource;
 use ApiPlatform\Metadata\Get;
 use ApiPlatform\Metadata\Link;
+use ApiPlatform\Metadata\QueryParameter;
 use ApiPlatform\OpenApi\Model\Operation;
 use Chamilo\CoreBundle\State\CourseGroup\CourseGroupDetailProvider;
 use Symfony\Component\Serializer\Attribute\Groups;
@@ -25,6 +26,17 @@ use Symfony\Component\Serializer\Attribute\Groups;
             openapi: new Operation(summary: 'Course group area data'),
             security: "is_granted('IS_AUTHENTICATED_FULLY')",
             name: 'get_course_group_detail',
+            parameters: [
+                'cid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Course identifier',
+                    required: true,
+                ),
+                'sid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Session identifier',
+                ),
+            ],
             provider: CourseGroupDetailProvider::class,
         ),
     ],

--- a/src/CoreBundle/ApiResource/CourseGroup/CourseGroupForm.php
+++ b/src/CoreBundle/ApiResource/CourseGroup/CourseGroupForm.php
@@ -11,6 +11,7 @@ use ApiPlatform\Metadata\ApiResource;
 use ApiPlatform\Metadata\Get;
 use ApiPlatform\Metadata\Link;
 use ApiPlatform\Metadata\Post;
+use ApiPlatform\Metadata\QueryParameter;
 use ApiPlatform\OpenApi\Model\Operation;
 use Chamilo\CoreBundle\State\CourseGroup\CourseGroupFormProcessor;
 use Chamilo\CoreBundle\State\CourseGroup\CourseGroupFormProvider;
@@ -24,6 +25,17 @@ use Symfony\Component\Serializer\Attribute\Groups;
             openapi: new Operation(summary: 'New course group form data'),
             security: "is_granted('IS_AUTHENTICATED_FULLY')",
             name: 'get_course_group_create_form',
+            parameters: [
+                'cid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Course identifier',
+                    required: true,
+                ),
+                'sid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Session identifier',
+                ),
+            ],
             provider: CourseGroupFormProvider::class,
         ),
         new Get(
@@ -34,6 +46,17 @@ use Symfony\Component\Serializer\Attribute\Groups;
             openapi: new Operation(summary: 'Existing course group form data'),
             security: "is_granted('IS_AUTHENTICATED_FULLY')",
             name: 'get_course_group_update_form',
+            parameters: [
+                'cid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Course identifier',
+                    required: true,
+                ),
+                'sid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Session identifier',
+                ),
+            ],
             provider: CourseGroupFormProvider::class,
         ),
         new Post(
@@ -42,6 +65,17 @@ use Symfony\Component\Serializer\Attribute\Groups;
             security: "is_granted('IS_AUTHENTICATED_FULLY')",
             read: false,
             name: 'post_course_group_create_form',
+            parameters: [
+                'cid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Course identifier',
+                    required: true,
+                ),
+                'sid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Session identifier',
+                ),
+            ],
             processor: CourseGroupFormProcessor::class,
         ),
         new Post(
@@ -53,6 +87,17 @@ use Symfony\Component\Serializer\Attribute\Groups;
             security: "is_granted('IS_AUTHENTICATED_FULLY')",
             read: false,
             name: 'post_course_group_update_form',
+            parameters: [
+                'cid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Course identifier',
+                    required: true,
+                ),
+                'sid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Session identifier',
+                ),
+            ],
             processor: CourseGroupFormProcessor::class,
         ),
     ],

--- a/src/CoreBundle/ApiResource/CourseGroup/CourseGroupImport.php
+++ b/src/CoreBundle/ApiResource/CourseGroup/CourseGroupImport.php
@@ -10,6 +10,7 @@ use ApiPlatform\Metadata\ApiProperty;
 use ApiPlatform\Metadata\ApiResource;
 use ApiPlatform\Metadata\Get;
 use ApiPlatform\Metadata\Post;
+use ApiPlatform\Metadata\QueryParameter;
 use ApiPlatform\OpenApi\Model\Operation;
 use ApiPlatform\OpenApi\Model\RequestBody;
 use ArrayObject;
@@ -25,6 +26,17 @@ use Symfony\Component\Serializer\Attribute\Groups;
             openapi: new Operation(summary: 'Course group CSV import form data'),
             security: "is_granted('IS_AUTHENTICATED_FULLY')",
             name: 'get_course_group_import',
+            parameters: [
+                'cid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Course identifier',
+                    required: true,
+                ),
+                'sid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Session identifier',
+                ),
+            ],
             provider: CourseGroupImportProvider::class,
         ),
         new Post(
@@ -49,6 +61,17 @@ use Symfony\Component\Serializer\Attribute\Groups;
             security: "is_granted('IS_AUTHENTICATED_FULLY')",
             deserialize: false,
             name: 'post_course_group_import',
+            parameters: [
+                'cid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Course identifier',
+                    required: true,
+                ),
+                'sid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Session identifier',
+                ),
+            ],
             processor: CourseGroupImportProcessor::class,
         ),
     ],

--- a/src/CoreBundle/ApiResource/CourseGroup/CourseGroupList.php
+++ b/src/CoreBundle/ApiResource/CourseGroup/CourseGroupList.php
@@ -9,6 +9,7 @@ namespace Chamilo\CoreBundle\ApiResource\CourseGroup;
 use ApiPlatform\Metadata\ApiProperty;
 use ApiPlatform\Metadata\ApiResource;
 use ApiPlatform\Metadata\Get;
+use ApiPlatform\Metadata\QueryParameter;
 use ApiPlatform\OpenApi\Model\Operation;
 use ApiPlatform\OpenApi\Model\Parameter;
 use Chamilo\CoreBundle\State\CourseGroup\CourseGroupListProvider;
@@ -22,14 +23,23 @@ use Symfony\Component\Serializer\Attribute\Groups;
             openapi: new Operation(
                 summary: 'Course groups and categories in the current course context',
                 parameters: [
-                    new Parameter(name: 'cid', in: 'query', required: true, schema: ['type' => 'integer']),
-                    new Parameter(name: 'sid', in: 'query', required: false, schema: ['type' => 'integer']),
                     new Parameter(name: 'gid', in: 'query', required: false, schema: ['type' => 'integer']),
                     new Parameter(name: 'search', in: 'query', required: false, schema: ['type' => 'string']),
                 ],
             ),
             security: "is_granted('IS_AUTHENTICATED_FULLY')",
             name: 'get_course_group_list',
+            parameters: [
+                'cid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Course identifier',
+                    required: true,
+                ),
+                'sid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Session identifier',
+                ),
+            ],
             provider: CourseGroupListProvider::class,
         ),
     ],

--- a/src/CoreBundle/ApiResource/CourseGroup/CourseGroupMembers.php
+++ b/src/CoreBundle/ApiResource/CourseGroup/CourseGroupMembers.php
@@ -11,6 +11,7 @@ use ApiPlatform\Metadata\ApiResource;
 use ApiPlatform\Metadata\Get;
 use ApiPlatform\Metadata\Link;
 use ApiPlatform\Metadata\Post;
+use ApiPlatform\Metadata\QueryParameter;
 use ApiPlatform\OpenApi\Model\Operation;
 use Chamilo\CoreBundle\State\CourseGroup\CourseGroupMembersProcessor;
 use Chamilo\CoreBundle\State\CourseGroup\CourseGroupMembersProvider;
@@ -27,6 +28,17 @@ use Symfony\Component\Serializer\Attribute\Groups;
             openapi: new Operation(summary: 'Course group member selection data'),
             security: "is_granted('IS_AUTHENTICATED_FULLY')",
             name: 'get_course_group_members',
+            parameters: [
+                'cid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Course identifier',
+                    required: true,
+                ),
+                'sid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Session identifier',
+                ),
+            ],
             provider: CourseGroupMembersProvider::class,
         ),
         new Post(
@@ -38,6 +50,17 @@ use Symfony\Component\Serializer\Attribute\Groups;
             security: "is_granted('IS_AUTHENTICATED_FULLY')",
             read: false,
             name: 'post_course_group_members',
+            parameters: [
+                'cid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Course identifier',
+                    required: true,
+                ),
+                'sid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Session identifier',
+                ),
+            ],
             processor: CourseGroupMembersProcessor::class,
         ),
         new Get(
@@ -48,6 +71,17 @@ use Symfony\Component\Serializer\Attribute\Groups;
             openapi: new Operation(summary: 'Course group tutor selection data'),
             security: "is_granted('IS_AUTHENTICATED_FULLY')",
             name: 'get_course_group_tutors',
+            parameters: [
+                'cid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Course identifier',
+                    required: true,
+                ),
+                'sid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Session identifier',
+                ),
+            ],
             provider: CourseGroupMembersProvider::class,
         ),
         new Post(
@@ -59,6 +93,17 @@ use Symfony\Component\Serializer\Attribute\Groups;
             security: "is_granted('IS_AUTHENTICATED_FULLY')",
             read: false,
             name: 'post_course_group_tutors',
+            parameters: [
+                'cid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Course identifier',
+                    required: true,
+                ),
+                'sid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Session identifier',
+                ),
+            ],
             processor: CourseGroupMembersProcessor::class,
         ),
     ],

--- a/src/CoreBundle/ApiResource/CourseGroup/CourseGroupOverview.php
+++ b/src/CoreBundle/ApiResource/CourseGroup/CourseGroupOverview.php
@@ -9,6 +9,7 @@ namespace Chamilo\CoreBundle\ApiResource\CourseGroup;
 use ApiPlatform\Metadata\ApiProperty;
 use ApiPlatform\Metadata\ApiResource;
 use ApiPlatform\Metadata\Get;
+use ApiPlatform\Metadata\QueryParameter;
 use ApiPlatform\OpenApi\Model\Operation;
 use Chamilo\CoreBundle\State\CourseGroup\CourseGroupOverviewProvider;
 use Symfony\Component\Serializer\Attribute\Groups;
@@ -21,6 +22,17 @@ use Symfony\Component\Serializer\Attribute\Groups;
             openapi: new Operation(summary: 'Overview of course groups, tutors and members'),
             security: "is_granted('IS_AUTHENTICATED_FULLY')",
             name: 'get_course_group_overview',
+            parameters: [
+                'cid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Course identifier',
+                    required: true,
+                ),
+                'sid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Session identifier',
+                ),
+            ],
             provider: CourseGroupOverviewProvider::class,
         ),
     ],

--- a/src/CoreBundle/ApiResource/CourseUser/CourseUserAction.php
+++ b/src/CoreBundle/ApiResource/CourseUser/CourseUserAction.php
@@ -9,6 +9,7 @@ namespace Chamilo\CoreBundle\ApiResource\CourseUser;
 use ApiPlatform\Metadata\ApiProperty;
 use ApiPlatform\Metadata\ApiResource;
 use ApiPlatform\Metadata\Post;
+use ApiPlatform\Metadata\QueryParameter;
 use ApiPlatform\OpenApi\Model\Operation;
 use ApiPlatform\OpenApi\Model\Parameter;
 use Chamilo\CoreBundle\State\CourseUser\CourseUserActionProcessor;
@@ -22,15 +23,27 @@ use Symfony\Component\Serializer\Attribute\Groups;
             openapi: new Operation(
                 summary: 'Subscribe users to the current course or session-course context',
                 parameters: [
-                    new Parameter(name: 'cid', in: 'query', required: true, schema: ['type' => 'integer']),
-                    new Parameter(name: 'sid', in: 'query', required: false, schema: ['type' => 'integer']),
-                    new Parameter(name: 'gid', in: 'query', required: false, schema: ['type' => 'integer']),
                     new Parameter(name: 'type', in: 'query', required: false, schema: ['type' => 'integer']),
                 ],
             ),
             security: "is_granted('IS_AUTHENTICATED_FULLY')",
             read: false,
             name: 'post_course_user_subscribe',
+            parameters: [
+                'cid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Course identifier',
+                    required: true,
+                ),
+                'sid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Session identifier',
+                ),
+                'gid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Group identifier',
+                ),
+            ],
             processor: CourseUserActionProcessor::class,
         ),
         new Post(
@@ -38,15 +51,27 @@ use Symfony\Component\Serializer\Attribute\Groups;
             openapi: new Operation(
                 summary: 'Unsubscribe users from the current course or session-course context',
                 parameters: [
-                    new Parameter(name: 'cid', in: 'query', required: true, schema: ['type' => 'integer']),
-                    new Parameter(name: 'sid', in: 'query', required: false, schema: ['type' => 'integer']),
-                    new Parameter(name: 'gid', in: 'query', required: false, schema: ['type' => 'integer']),
                     new Parameter(name: 'type', in: 'query', required: false, schema: ['type' => 'integer']),
                 ],
             ),
             security: "is_granted('IS_AUTHENTICATED_FULLY')",
             read: false,
             name: 'post_course_user_unsubscribe',
+            parameters: [
+                'cid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Course identifier',
+                    required: true,
+                ),
+                'sid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Session identifier',
+                ),
+                'gid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Group identifier',
+                ),
+            ],
             processor: CourseUserActionProcessor::class,
         ),
         new Post(
@@ -54,15 +79,27 @@ use Symfony\Component\Serializer\Attribute\Groups;
             openapi: new Operation(
                 summary: 'Enable or disable the course tutor role for a student',
                 parameters: [
-                    new Parameter(name: 'cid', in: 'query', required: true, schema: ['type' => 'integer']),
-                    new Parameter(name: 'sid', in: 'query', required: false, schema: ['type' => 'integer']),
-                    new Parameter(name: 'gid', in: 'query', required: false, schema: ['type' => 'integer']),
                     new Parameter(name: 'type', in: 'query', required: false, schema: ['type' => 'integer']),
                 ],
             ),
             security: "is_granted('IS_AUTHENTICATED_FULLY')",
             read: false,
             name: 'post_course_user_tutor',
+            parameters: [
+                'cid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Course identifier',
+                    required: true,
+                ),
+                'sid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Session identifier',
+                ),
+                'gid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Group identifier',
+                ),
+            ],
             processor: CourseUserActionProcessor::class,
         ),
     ],

--- a/src/CoreBundle/ApiResource/CourseUser/CourseUserAvailable.php
+++ b/src/CoreBundle/ApiResource/CourseUser/CourseUserAvailable.php
@@ -9,6 +9,7 @@ namespace Chamilo\CoreBundle\ApiResource\CourseUser;
 use ApiPlatform\Metadata\ApiProperty;
 use ApiPlatform\Metadata\ApiResource;
 use ApiPlatform\Metadata\Get;
+use ApiPlatform\Metadata\QueryParameter;
 use ApiPlatform\OpenApi\Model\Operation;
 use ApiPlatform\OpenApi\Model\Parameter;
 use Chamilo\CoreBundle\State\CourseUser\CourseUserAvailableProvider;
@@ -22,9 +23,6 @@ use Symfony\Component\Serializer\Attribute\Groups;
             openapi: new Operation(
                 summary: 'Users available for subscription in the current course context',
                 parameters: [
-                    new Parameter(name: 'cid', in: 'query', required: true, schema: ['type' => 'integer']),
-                    new Parameter(name: 'sid', in: 'query', required: false, schema: ['type' => 'integer']),
-                    new Parameter(name: 'gid', in: 'query', required: false, schema: ['type' => 'integer']),
                     new Parameter(name: 'type', in: 'query', required: false, schema: ['type' => 'integer']),
                     new Parameter(name: 'search', in: 'query', required: false, schema: ['type' => 'string']),
                     new Parameter(name: 'extraFieldId', in: 'query', required: false, schema: ['type' => 'integer']),
@@ -37,6 +35,21 @@ use Symfony\Component\Serializer\Attribute\Groups;
             ),
             security: "is_granted('IS_AUTHENTICATED_FULLY')",
             name: 'get_course_user_available',
+            parameters: [
+                'cid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Course identifier',
+                    required: true,
+                ),
+                'sid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Session identifier',
+                ),
+                'gid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Group identifier',
+                ),
+            ],
             provider: CourseUserAvailableProvider::class,
         ),
     ],

--- a/src/CoreBundle/ApiResource/CourseUser/CourseUserImport.php
+++ b/src/CoreBundle/ApiResource/CourseUser/CourseUserImport.php
@@ -10,6 +10,7 @@ use ApiPlatform\Metadata\ApiProperty;
 use ApiPlatform\Metadata\ApiResource;
 use ApiPlatform\Metadata\Get;
 use ApiPlatform\Metadata\Post;
+use ApiPlatform\Metadata\QueryParameter;
 use ApiPlatform\OpenApi\Model\Operation;
 use ApiPlatform\OpenApi\Model\Parameter;
 use ApiPlatform\OpenApi\Model\RequestBody;
@@ -26,14 +27,26 @@ use Symfony\Component\Serializer\Attribute\Groups;
             openapi: new Operation(
                 summary: 'Course user CSV import form data',
                 parameters: [
-                    new Parameter(name: 'cid', in: 'query', required: true, schema: ['type' => 'integer']),
-                    new Parameter(name: 'sid', in: 'query', required: false, schema: ['type' => 'integer']),
-                    new Parameter(name: 'gid', in: 'query', required: false, schema: ['type' => 'integer']),
                     new Parameter(name: 'type', in: 'query', required: false, schema: ['type' => 'integer']),
                 ],
             ),
             security: "is_granted('IS_AUTHENTICATED_FULLY')",
             name: 'get_course_user_import',
+            parameters: [
+                'cid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Course identifier',
+                    required: true,
+                ),
+                'sid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Session identifier',
+                ),
+                'gid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Group identifier',
+                ),
+            ],
             provider: CourseUserImportProvider::class,
         ),
         new Post(
@@ -41,9 +54,6 @@ use Symfony\Component\Serializer\Attribute\Groups;
             openapi: new Operation(
                 summary: 'Import course users from CSV',
                 parameters: [
-                    new Parameter(name: 'cid', in: 'query', required: true, schema: ['type' => 'integer']),
-                    new Parameter(name: 'sid', in: 'query', required: false, schema: ['type' => 'integer']),
-                    new Parameter(name: 'gid', in: 'query', required: false, schema: ['type' => 'integer']),
                     new Parameter(name: 'type', in: 'query', required: false, schema: ['type' => 'integer']),
                 ],
                 requestBody: new RequestBody(
@@ -64,6 +74,21 @@ use Symfony\Component\Serializer\Attribute\Groups;
             security: "is_granted('IS_AUTHENTICATED_FULLY')",
             deserialize: false,
             name: 'post_course_user_import',
+            parameters: [
+                'cid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Course identifier',
+                    required: true,
+                ),
+                'sid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Session identifier',
+                ),
+                'gid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Group identifier',
+                ),
+            ],
             processor: CourseUserImportProcessor::class,
         ),
     ],

--- a/src/CoreBundle/ApiResource/CourseUser/CourseUserList.php
+++ b/src/CoreBundle/ApiResource/CourseUser/CourseUserList.php
@@ -9,6 +9,7 @@ namespace Chamilo\CoreBundle\ApiResource\CourseUser;
 use ApiPlatform\Metadata\ApiProperty;
 use ApiPlatform\Metadata\ApiResource;
 use ApiPlatform\Metadata\Get;
+use ApiPlatform\Metadata\QueryParameter;
 use ApiPlatform\OpenApi\Model\Operation;
 use ApiPlatform\OpenApi\Model\Parameter;
 use Chamilo\CoreBundle\State\CourseUser\CourseUserListProvider;
@@ -22,9 +23,6 @@ use Symfony\Component\Serializer\Attribute\Groups;
             openapi: new Operation(
                 summary: 'Course users list in the current course and session context',
                 parameters: [
-                    new Parameter(name: 'cid', in: 'query', required: true, schema: ['type' => 'integer']),
-                    new Parameter(name: 'sid', in: 'query', required: false, schema: ['type' => 'integer']),
-                    new Parameter(name: 'gid', in: 'query', required: false, schema: ['type' => 'integer']),
                     new Parameter(name: 'type', in: 'query', required: false, schema: ['type' => 'integer']),
                     new Parameter(name: 'search', in: 'query', required: false, schema: ['type' => 'string']),
                     new Parameter(name: 'active', in: 'query', required: false, schema: ['type' => 'boolean']),
@@ -36,6 +34,21 @@ use Symfony\Component\Serializer\Attribute\Groups;
             ),
             security: "is_granted('IS_AUTHENTICATED_FULLY')",
             name: 'get_course_user_list',
+            parameters: [
+                'cid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Course identifier',
+                    required: true,
+                ),
+                'sid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Session identifier',
+                ),
+                'gid' => new QueryParameter(
+                    schema: ['type' => 'integer'],
+                    description: 'Group identifier',
+                ),
+            ],
             provider: CourseUserListProvider::class,
         ),
     ],

--- a/src/CoreBundle/Controller/Api/CourseGroupExportController.php
+++ b/src/CoreBundle/Controller/Api/CourseGroupExportController.php
@@ -41,7 +41,7 @@ final class CourseGroupExportController extends AbstractController
     public function __invoke(Request $request, string $format): Response
     {
         $groupId = $request->query->getInt('groupId');
-        $rows = $this->manager->getExportData($request, $groupId > 0 ? $groupId : null, true);
+        $rows = $this->manager->getExportData($groupId > 0 ? $groupId : null, true);
         $filename = $groupId > 0 ? 'course-group-'.$groupId : 'course-groups';
 
         return match ($format) {

--- a/src/CoreBundle/Controller/Api/CourseUserExportController.php
+++ b/src/CoreBundle/Controller/Api/CourseUserExportController.php
@@ -61,7 +61,7 @@ final class CourseUserExportController extends AbstractController
      */
     private function loadAllData(Request $request): array
     {
-        [$course, $session] = $this->courseUserManager->resolveContext($request);
+        [$course, $session] = $this->courseUserManager->resolveContext();
         if (!$this->courseUserManager->canManage($course, $session)) {
             throw $this->createAccessDeniedException('You are not allowed to export users in this context.');
         }

--- a/src/CoreBundle/Controller/Api/LearningPathChamiloBackupExportAction.php
+++ b/src/CoreBundle/Controller/Api/LearningPathChamiloBackupExportAction.php
@@ -7,6 +7,7 @@ declare(strict_types=1);
 namespace Chamilo\CoreBundle\Controller\Api;
 
 use Chamilo\CoreBundle\Entity\ResourceLink;
+use Chamilo\CoreBundle\Helpers\CidReqHelper;
 use Chamilo\CoreBundle\Service\LearningPath\LearningPathBackupEmptyException;
 use Chamilo\CoreBundle\Service\LearningPath\LearningPathBackupResourceException;
 use Chamilo\CoreBundle\Service\LearningPath\LearningPathChamiloBackupExportService;
@@ -42,6 +43,7 @@ final class LearningPathChamiloBackupExportAction extends AbstractController
         private readonly SettingsManager $settingsManager,
         private readonly CLpRepository $learningPathRepository,
         private readonly LearningPathChamiloBackupExportService $exportService,
+        private readonly CidReqHelper $cidReqHelper,
     ) {}
 
     #[Route(
@@ -56,9 +58,9 @@ final class LearningPathChamiloBackupExportAction extends AbstractController
             throw new AccessDeniedHttpException('Chamilo learning path export is disabled.');
         }
 
-        $course = $this->getContextCourse($this->entityManager, $request);
-        $session = $this->getContextSession($this->entityManager, $request, $course);
-        $group = $this->getContextGroup($this->entityManager, $request, $course);
+        $course = $this->getContextCourse($this->cidReqHelper);
+        $session = $this->cidReqHelper->getDoctrineSessionEntity();
+        $group = $this->getContextGroup($this->entityManager, $this->cidReqHelper, $course);
         if (null !== $group) {
             throw new BadRequestHttpException('Chamilo learning path export is not available in a group context.');
         }

--- a/src/CoreBundle/Controller/Api/LearningPathContentPdfAction.php
+++ b/src/CoreBundle/Controller/Api/LearningPathContentPdfAction.php
@@ -11,6 +11,7 @@ use Chamilo\CoreBundle\Entity\Course;
 use Chamilo\CoreBundle\Entity\ResourceLink;
 use Chamilo\CoreBundle\Entity\Session;
 use Chamilo\CoreBundle\Entity\User;
+use Chamilo\CoreBundle\Helpers\CidReqHelper;
 use Chamilo\CoreBundle\Helpers\LpAdvancedAccessHelper;
 use Chamilo\CoreBundle\Service\LearningPath\LearningPathContentPdfService;
 use Chamilo\CoreBundle\Settings\SettingsManager;
@@ -56,6 +57,7 @@ final class LearningPathContentPdfAction extends AbstractController
         private readonly LearningPathContentPdfService $contentPdfService,
         #[Autowire('%kernel.cache_dir%')]
         private readonly string $cacheDir,
+        private readonly CidReqHelper $cidReqHelper,
     ) {}
 
     #[Route(
@@ -139,9 +141,9 @@ final class LearningPathContentPdfAction extends AbstractController
             throw new AccessDeniedHttpException('Learning path PDF export is disabled.');
         }
 
-        $course = $this->getContextCourse($this->entityManager, $request);
-        $session = $this->getContextSession($this->entityManager, $request, $course);
-        $group = $this->getContextGroup($this->entityManager, $request, $course);
+        $course = $this->getContextCourse($this->cidReqHelper);
+        $session = $this->cidReqHelper->getDoctrineSessionEntity();
+        $group = $this->getContextGroup($this->entityManager, $this->cidReqHelper, $course);
         $lp = $this->lpRepository->find($lpId);
         if (!$lp instanceof CLp) {
             throw new NotFoundHttpException('Learning path not found.');

--- a/src/CoreBundle/Controller/Api/LearningPathScormPackageAction.php
+++ b/src/CoreBundle/Controller/Api/LearningPathScormPackageAction.php
@@ -10,6 +10,7 @@ use Chamilo\CoreBundle\Entity\Asset;
 use Chamilo\CoreBundle\Entity\Course;
 use Chamilo\CoreBundle\Entity\ResourceFile;
 use Chamilo\CoreBundle\Entity\ResourceLink;
+use Chamilo\CoreBundle\Helpers\CidReqHelper;
 use Chamilo\CoreBundle\Repository\AssetRepository;
 use Chamilo\CoreBundle\Repository\ResourceNodeRepository;
 use Chamilo\CoreBundle\Settings\SettingsManager;
@@ -45,6 +46,7 @@ final readonly class LearningPathScormPackageAction
         private ResourceNodeRepository $resourceNodeRepository,
         private CDocumentRepository $documentRepository,
         private CLpRepository $learningPathRepository,
+        private CidReqHelper $cidReqHelper,
     ) {}
 
     public function __invoke(int $lpId, Request $request): Response
@@ -53,15 +55,15 @@ final readonly class LearningPathScormPackageAction
             throw new AccessDeniedHttpException('SCORM package download is disabled.');
         }
 
-        $course = $this->getContextCourse($this->entityManager, $request);
+        $course = $this->getContextCourse($this->cidReqHelper);
         $requestedNodeId = $request->query->getInt('node');
         $courseNodeId = (int) ($course->getResourceNode()?->getId() ?? 0);
         if ($requestedNodeId > 0 && $requestedNodeId !== $courseNodeId) {
             throw new AccessDeniedHttpException('The requested resource node does not belong to this course.');
         }
 
-        $session = $this->getContextSession($this->entityManager, $request, $course);
-        $group = $this->getContextGroup($this->entityManager, $request, $course);
+        $session = $this->cidReqHelper->getDoctrineSessionEntity();
+        $group = $this->getContextGroup($this->entityManager, $this->cidReqHelper, $course);
 
         $learningPath = $this->learningPathRepository->find($lpId);
         if (!$learningPath instanceof CLp || CLp::SCORM_TYPE !== $learningPath->getLpType()) {

--- a/src/CoreBundle/Controller/Api/LearningPathScormRuntimePackageAction.php
+++ b/src/CoreBundle/Controller/Api/LearningPathScormRuntimePackageAction.php
@@ -11,6 +11,7 @@ use Chamilo\CoreBundle\Entity\Asset;
 use Chamilo\CoreBundle\Entity\Course;
 use Chamilo\CoreBundle\Entity\ResourceFile;
 use Chamilo\CoreBundle\Entity\ResourceLink;
+use Chamilo\CoreBundle\Helpers\CidReqHelper;
 use Chamilo\CoreBundle\Repository\AssetRepository;
 use Chamilo\CoreBundle\Repository\ResourceNodeRepository;
 use Chamilo\CoreBundle\Service\LearningPath\ScormRuntimeManager;
@@ -52,6 +53,7 @@ final readonly class LearningPathScormRuntimePackageAction
         private CLpItemRepository $learningPathItemRepository,
         private LearningPathRuntimeProvider $runtimeProvider,
         private ScormRuntimeManager $runtimeManager,
+        private CidReqHelper $cidReqHelper,
     ) {}
 
     public function __invoke(int $lpId, Request $request): Response
@@ -72,9 +74,9 @@ final readonly class LearningPathScormRuntimePackageAction
             throw new NotFoundHttpException('SCORM runtime package not found.');
         }
 
-        $course = $this->getContextCourse($this->entityManager, $request);
-        $session = $this->getContextSession($this->entityManager, $request, $course);
-        $group = $this->getContextGroup($this->entityManager, $request, $course);
+        $course = $this->getContextCourse($this->cidReqHelper);
+        $session = $this->cidReqHelper->getDoctrineSessionEntity();
+        $group = $this->getContextGroup($this->entityManager, $this->cidReqHelper, $course);
         $resourceNode = $learningPath->getResourceNode();
         if (null === $resourceNode || !$this->security->isGranted('VIEW', $resourceNode)) {
             throw new AccessDeniedHttpException('The SCORM learning path is not available.');

--- a/src/CoreBundle/Controller/Api/PortfolioExportController.php
+++ b/src/CoreBundle/Controller/Api/PortfolioExportController.php
@@ -14,6 +14,7 @@ use Chamilo\CoreBundle\Entity\Session;
 use Chamilo\CoreBundle\Entity\User;
 use Chamilo\CoreBundle\Event\Events;
 use Chamilo\CoreBundle\Event\PortfolioItemDownloadedEvent;
+use Chamilo\CoreBundle\Helpers\CidReqHelper;
 use Chamilo\CoreBundle\Helpers\UserHelper;
 use Chamilo\CoreBundle\Repository\Node\PortfolioCommentRepository;
 use Chamilo\CoreBundle\Repository\Node\PortfolioRepository;
@@ -55,6 +56,7 @@ final class PortfolioExportController extends AbstractController
         private readonly UserHelper $userHelper,
         private readonly SettingsManager $settingsManager,
         private readonly EventDispatcherInterface $eventDispatcher,
+        private readonly CidReqHelper $cidReqHelper,
     ) {}
 
     #[Route('/api/portfolio/export.pdf', name: 'api_portfolio_export_pdf', methods: ['GET'])]
@@ -138,8 +140,8 @@ final class PortfolioExportController extends AbstractController
     private function resolveExport(Request $request): array
     {
         $currentUser = $this->getPortfolioCurrentUser($this->userHelper);
-        $course = $this->getPortfolioCourse($this->entityManager, $request);
-        $session = $this->getPortfolioSession($this->entityManager, $request, $course);
+        $course = $this->cidReqHelper->getDoctrineCourseEntity();
+        $session = $this->cidReqHelper->getDoctrineSessionEntity();
         if ($course instanceof Course && !$this->canReadPortfolioCourse(
             $this->security,
             $this->userHelper,

--- a/src/CoreBundle/Controller/Api/WikiPageExportController.php
+++ b/src/CoreBundle/Controller/Api/WikiPageExportController.php
@@ -9,6 +9,8 @@ namespace Chamilo\CoreBundle\Controller\Api;
 use Chamilo\CoreBundle\Component\Mpdf\SafeMpdfHttpClient;
 use Chamilo\CoreBundle\Entity\Course;
 use Chamilo\CoreBundle\Entity\Session;
+use Chamilo\CoreBundle\Helpers\CidReqHelper;
+use Chamilo\CoreBundle\Helpers\StudentViewHelper;
 use Chamilo\CoreBundle\Settings\SettingsManager;
 use Chamilo\CoreBundle\State\Wiki\WikiAccessHelperTrait;
 use Chamilo\CoreBundle\State\Wiki\WikiPageExportService;
@@ -48,6 +50,8 @@ final class WikiPageExportController extends AbstractController
         private readonly WikiPageExportService $exportService,
         #[Autowire('%kernel.cache_dir%')]
         private readonly string $cacheDir,
+        private readonly CidReqHelper $cidReqHelper,
+        private readonly StudentViewHelper $studentViewHelper,
     ) {}
 
     #[Route(
@@ -120,19 +124,19 @@ final class WikiPageExportController extends AbstractController
             throw new BadRequestHttpException('A valid Wiki page id is required.');
         }
 
-        $course = $this->getWikiCourse($this->entityManager, $request);
+        $course = $this->getWikiCourse($this->cidReqHelper);
         $this->assertWikiToolEnabled($this->entityManager, $course);
         $nodeId = $this->assertWikiRouteNode($course, $request);
-        $session = $this->getWikiSession($this->entityManager, $request);
+        $session = $this->getWikiSession($this->cidReqHelper);
         $this->assertWikiSessionBelongsToCourse($session, $course);
-        $group = $this->getWikiGroup($this->entityManager, $request);
+        $group = $this->getWikiGroup($this->entityManager, $this->cidReqHelper);
         $this->assertWikiGroupBelongsToContext($group, $course, $session);
 
         if (!$this->canReadWikiContext($this->security, $this->settingsManager, $course, $session, $group)) {
             throw new AccessDeniedHttpException('You are not allowed to view Wiki pages in this context.');
         }
 
-        $studentView = $this->isWikiStudentView($request);
+        $studentView = $this->studentViewHelper->isStudentView();
         $canManage = !$studentView && $this->canManageWikiContext(
             $this->entityManager,
             $this->security,

--- a/src/CoreBundle/Controller/LearningPathScormContentController.php
+++ b/src/CoreBundle/Controller/LearningPathScormContentController.php
@@ -8,6 +8,7 @@ namespace Chamilo\CoreBundle\Controller;
 
 use ApiPlatform\Metadata\Get;
 use Chamilo\CoreBundle\Entity\ResourceLink;
+use Chamilo\CoreBundle\Helpers\CidReqHelper;
 use Chamilo\CoreBundle\Repository\AssetRepository;
 use Chamilo\CoreBundle\Service\LearningPath\ScormRuntimeManager;
 use Chamilo\CoreBundle\State\LearningPath\LearningPathRuntimeProvider;
@@ -57,6 +58,7 @@ final class LearningPathScormContentController extends AbstractController
         string $path,
         Request $request,
         EntityManagerInterface $entityManager,
+        CidReqHelper $cidReqHelper,
         Security $security,
         LearningPathRuntimeProvider $runtimeProvider,
         ScormRuntimeManager $runtimeManager,
@@ -80,9 +82,9 @@ final class LearningPathScormContentController extends AbstractController
             throw new NotFoundHttpException('SCORM content not found.');
         }
 
-        $course = $this->getContextCourse($entityManager, $request);
-        $session = $this->getContextSession($entityManager, $request, $course);
-        $group = $this->getContextGroup($entityManager, $request, $course);
+        $course = $this->getContextCourse($cidReqHelper);
+        $session = $cidReqHelper->getDoctrineSessionEntity();
+        $group = $this->getContextGroup($entityManager, $cidReqHelper, $course);
         $resourceNode = $lp->getResourceNode();
         if (null === $resourceNode || !$security->isGranted('VIEW', $resourceNode)) {
             throw new AccessDeniedHttpException('The SCORM learning path is not available.');

--- a/src/CoreBundle/Helpers/StudentViewHelper.php
+++ b/src/CoreBundle/Helpers/StudentViewHelper.php
@@ -1,0 +1,74 @@
+<?php
+
+/* For licensing terms, see /license.txt */
+
+declare(strict_types=1);
+
+namespace Chamilo\CoreBundle\Helpers;
+
+use Chamilo\CoreBundle\EventListener\LegacyListener;
+use Symfony\Component\HttpFoundation\Exception\SessionNotFoundException;
+use Symfony\Component\HttpFoundation\RequestStack;
+
+/**
+ * Reads the "student view" toggle, which teachers use to preview a course as a learner would see it.
+ *
+ * The session is the normalized source: LegacyListener (kernel.request, priority 7) turns the
+ * incoming isStudentView query parameter into the session value, and only does so when the
+ * course.student_view_enabled setting is on. Reading the query parameter here instead would
+ * bypass that setting, so consumers must always go through this helper.
+ *
+ * @see LegacyListener::onKernelRequest()
+ */
+readonly class StudentViewHelper
+{
+    private const string SESSION_KEY = 'studentview';
+    private const string ACTIVE = 'studentview';
+
+    public function __construct(
+        private RequestStack $requestStack,
+    ) {}
+
+    public function isStudentView(): bool
+    {
+        return self::ACTIVE === $this->getRawValue();
+    }
+
+    /**
+     * Same as isStudentView(), but honouring the per-course override that the legacy course
+     * progress page writes (public/main/course_progress/index.php). When that key is absent the
+     * platform-wide toggle applies.
+     */
+    public function isStudentViewForCourse(int $courseId): bool
+    {
+        try {
+            $session = $this->requestStack->getSession();
+        } catch (SessionNotFoundException) {
+            return false;
+        }
+
+        $perCourse = $session->get('student_view_course_'.$courseId);
+
+        return null !== $perCourse ? (bool) $perCourse : $this->isStudentView();
+    }
+
+    /**
+     * Whether the current user may act as a teacher right now: the capability must be granted
+     * and the student view preview must be off.
+     */
+    public function canManageInCurrentView(bool $isAllowedToEdit): bool
+    {
+        return $isAllowedToEdit && !$this->isStudentView();
+    }
+
+    private function getRawValue(): ?string
+    {
+        try {
+            $value = $this->requestStack->getSession()->get(self::SESSION_KEY);
+        } catch (SessionNotFoundException) {
+            return null;
+        }
+
+        return \is_string($value) ? $value : null;
+    }
+}

--- a/src/CoreBundle/State/Announcement/AnnouncementAccessHelperTrait.php
+++ b/src/CoreBundle/State/Announcement/AnnouncementAccessHelperTrait.php
@@ -573,17 +573,4 @@ trait AnnouncementAccessHelperTrait
             // Tracking must never break announcement actions.
         }
     }
-
-    private function isStudentView(Request $request): bool
-    {
-        if ($request->query->has('isStudentView')) {
-            return $request->query->getBoolean('isStudentView');
-        }
-
-        if (!$request->hasSession()) {
-            return false;
-        }
-
-        return 'studentview' === $request->getSession()->get('studentview');
-    }
 }

--- a/src/CoreBundle/State/Announcement/AnnouncementActionProcessor.php
+++ b/src/CoreBundle/State/Announcement/AnnouncementActionProcessor.php
@@ -12,6 +12,7 @@ use Chamilo\CoreBundle\ApiResource\Announcement\AnnouncementAction;
 use Chamilo\CoreBundle\Entity\Course;
 use Chamilo\CoreBundle\Entity\ResourceLink;
 use Chamilo\CoreBundle\Entity\Session;
+use Chamilo\CoreBundle\Helpers\StudentViewHelper;
 use Chamilo\CoreBundle\Settings\SettingsManager;
 use Chamilo\CourseBundle\Entity\CAnnouncement;
 use Chamilo\CourseBundle\Entity\CGroup;
@@ -45,6 +46,7 @@ final readonly class AnnouncementActionProcessor implements ProcessorInterface
         private Security $security,
         private SettingsManager $settingsManager,
         private CsrfTokenManagerInterface $csrfTokenManager,
+        private StudentViewHelper $studentViewHelper,
     ) {}
 
     /**
@@ -71,7 +73,7 @@ final readonly class AnnouncementActionProcessor implements ProcessorInterface
         $group = $this->getGroup($request);
         $this->assertGroupBelongsToContext($group, $course, $session);
 
-        if ($this->isStudentView($request) || !$this->canManageAnnouncements(
+        if ($this->studentViewHelper->isStudentView() || !$this->canManageAnnouncements(
             $this->entityManager,
             $this->security,
             $this->settingsManager,

--- a/src/CoreBundle/State/Announcement/AnnouncementEmailProcessor.php
+++ b/src/CoreBundle/State/Announcement/AnnouncementEmailProcessor.php
@@ -12,6 +12,7 @@ use Chamilo\CoreBundle\ApiResource\Announcement\AnnouncementEmailAction;
 use Chamilo\CoreBundle\Entity\Course;
 use Chamilo\CoreBundle\Entity\Session;
 use Chamilo\CoreBundle\Entity\User;
+use Chamilo\CoreBundle\Helpers\StudentViewHelper;
 use Chamilo\CoreBundle\Settings\SettingsManager;
 use Chamilo\CourseBundle\Entity\CAnnouncement;
 use Chamilo\CourseBundle\Entity\CGroup;
@@ -47,6 +48,7 @@ final readonly class AnnouncementEmailProcessor implements ProcessorInterface
         private Security $security,
         private SettingsManager $settingsManager,
         private CsrfTokenManagerInterface $csrfTokenManager,
+        private StudentViewHelper $studentViewHelper,
     ) {}
 
     /**
@@ -73,7 +75,7 @@ final readonly class AnnouncementEmailProcessor implements ProcessorInterface
         $group = $this->getGroup($request);
         $this->assertGroupBelongsToContext($group, $course, $session);
 
-        if ($this->isStudentView($request) || !$this->canManageAnnouncements(
+        if ($this->studentViewHelper->isStudentView() || !$this->canManageAnnouncements(
             $this->entityManager,
             $this->security,
             $this->settingsManager,

--- a/src/CoreBundle/State/Announcement/AnnouncementFormProcessor.php
+++ b/src/CoreBundle/State/Announcement/AnnouncementFormProcessor.php
@@ -14,6 +14,7 @@ use Chamilo\CoreBundle\Entity\Course;
 use Chamilo\CoreBundle\Entity\Language;
 use Chamilo\CoreBundle\Entity\Session;
 use Chamilo\CoreBundle\Entity\User;
+use Chamilo\CoreBundle\Helpers\StudentViewHelper;
 use Chamilo\CoreBundle\Settings\SettingsManager;
 use Chamilo\CourseBundle\Entity\CAnnouncement;
 use Chamilo\CourseBundle\Entity\CGroup;
@@ -54,6 +55,7 @@ final readonly class AnnouncementFormProcessor implements ProcessorInterface
         private Security $security,
         private SettingsManager $settingsManager,
         private CsrfTokenManagerInterface $csrfTokenManager,
+        private StudentViewHelper $studentViewHelper,
     ) {}
 
     /**
@@ -80,7 +82,7 @@ final readonly class AnnouncementFormProcessor implements ProcessorInterface
         $group = $this->getGroup($request);
         $this->assertGroupBelongsToContext($group, $course, $session);
 
-        if ($this->isStudentView($request) || !$this->canManageAnnouncements(
+        if ($this->studentViewHelper->isStudentView() || !$this->canManageAnnouncements(
             $this->entityManager,
             $this->security,
             $this->settingsManager,

--- a/src/CoreBundle/State/Announcement/AnnouncementFormProvider.php
+++ b/src/CoreBundle/State/Announcement/AnnouncementFormProvider.php
@@ -14,6 +14,7 @@ use Chamilo\CoreBundle\Controller\AnnouncementAttachmentController;
 use Chamilo\CoreBundle\Entity\Course;
 use Chamilo\CoreBundle\Entity\Language;
 use Chamilo\CoreBundle\Entity\Session;
+use Chamilo\CoreBundle\Helpers\StudentViewHelper;
 use Chamilo\CoreBundle\Settings\SettingsManager;
 use Chamilo\CourseBundle\Entity\CAnnouncement;
 use Chamilo\CourseBundle\Entity\CAnnouncementAttachment;
@@ -49,6 +50,7 @@ final readonly class AnnouncementFormProvider implements ProviderInterface
         private Security $security,
         private SettingsManager $settingsManager,
         private CsrfTokenManagerInterface $csrfTokenManager,
+        private StudentViewHelper $studentViewHelper,
     ) {}
 
     /**
@@ -71,7 +73,7 @@ final readonly class AnnouncementFormProvider implements ProviderInterface
         $group = $this->getGroup($request);
         $this->assertGroupBelongsToContext($group, $course, $session);
 
-        if ($this->isStudentView($request) || !$this->canManageAnnouncements(
+        if ($this->studentViewHelper->isStudentView() || !$this->canManageAnnouncements(
             $this->entityManager,
             $this->security,
             $this->settingsManager,

--- a/src/CoreBundle/State/Announcement/AnnouncementItemProvider.php
+++ b/src/CoreBundle/State/Announcement/AnnouncementItemProvider.php
@@ -15,6 +15,7 @@ use Chamilo\CoreBundle\Entity\Course;
 use Chamilo\CoreBundle\Entity\ResourceLink;
 use Chamilo\CoreBundle\Entity\Session;
 use Chamilo\CoreBundle\Entity\User;
+use Chamilo\CoreBundle\Helpers\StudentViewHelper;
 use Chamilo\CoreBundle\Settings\SettingsManager;
 use Chamilo\CourseBundle\Entity\CAnnouncement;
 use Chamilo\CourseBundle\Entity\CAnnouncementAttachment;
@@ -47,6 +48,7 @@ final readonly class AnnouncementItemProvider implements ProviderInterface
         private Security $security,
         private SettingsManager $settingsManager,
         private CsrfTokenManagerInterface $csrfTokenManager,
+        private StudentViewHelper $studentViewHelper,
     ) {}
 
     /**
@@ -89,7 +91,7 @@ final readonly class AnnouncementItemProvider implements ProviderInterface
             throw new NotFoundHttpException('The requested announcement was not found.');
         }
 
-        $studentView = $this->isStudentView($request);
+        $studentView = $this->studentViewHelper->isStudentView();
         $canManage = !$studentView && $this->canManageAnnouncements(
             $this->entityManager,
             $this->security,

--- a/src/CoreBundle/State/Announcement/AnnouncementListProvider.php
+++ b/src/CoreBundle/State/Announcement/AnnouncementListProvider.php
@@ -13,6 +13,7 @@ use Chamilo\CoreBundle\Entity\Course;
 use Chamilo\CoreBundle\Entity\ResourceLink;
 use Chamilo\CoreBundle\Entity\Session;
 use Chamilo\CoreBundle\Entity\User;
+use Chamilo\CoreBundle\Helpers\StudentViewHelper;
 use Chamilo\CoreBundle\Settings\SettingsManager;
 use Chamilo\CourseBundle\Entity\CAnnouncement;
 use Chamilo\CourseBundle\Entity\CGroup;
@@ -44,6 +45,7 @@ final readonly class AnnouncementListProvider implements ProviderInterface
         private Security $security,
         private SettingsManager $settingsManager,
         private CsrfTokenManagerInterface $csrfTokenManager,
+        private StudentViewHelper $studentViewHelper,
     ) {}
 
     /**
@@ -76,7 +78,7 @@ final readonly class AnnouncementListProvider implements ProviderInterface
             throw new AccessDeniedHttpException('You are not allowed to view announcements in this context.');
         }
 
-        $studentView = $this->isStudentView($request);
+        $studentView = $this->studentViewHelper->isStudentView();
         $canManage = !$studentView && $this->canManageAnnouncements(
             $this->entityManager,
             $this->security,

--- a/src/CoreBundle/State/CToolStateProvider.php
+++ b/src/CoreBundle/State/CToolStateProvider.php
@@ -15,6 +15,7 @@ use Chamilo\CoreBundle\Entity\Course;
 use Chamilo\CoreBundle\Entity\ResourceLink;
 use Chamilo\CoreBundle\Entity\User;
 use Chamilo\CoreBundle\Helpers\PluginHelper;
+use Chamilo\CoreBundle\Helpers\StudentViewHelper;
 use Chamilo\CoreBundle\Settings\SettingsManager;
 use Chamilo\CoreBundle\Tool\AbstractPlugin;
 use Chamilo\CoreBundle\Tool\AbstractTool;
@@ -49,6 +50,7 @@ final class CToolStateProvider implements ProviderInterface
         private readonly ToolChain $toolChain,
         protected RequestStack $requestStack,
         private readonly PluginHelper $pluginHelper,
+        private readonly StudentViewHelper $studentViewHelper,
     ) {
         $this->transformer = new CourseToolDataTranformer(
             $this->requestStack,
@@ -62,8 +64,7 @@ final class CToolStateProvider implements ProviderInterface
         /** @var PartialPaginatorInterface $result */
         $result = $this->provider->provide($operation, $uriVariables, $context);
 
-        $request = $this->requestStack->getMainRequest();
-        $studentView = $request ? $request->getSession()->get('studentview') : 'studentview';
+        $studentView = $this->studentViewHelper->isStudentView() ? 'studentview' : 'teacherview';
 
         /** @var User|null $user */
         $user = $this->security->getUser();

--- a/src/CoreBundle/State/CourseClass/CourseClassActionProcessor.php
+++ b/src/CoreBundle/State/CourseClass/CourseClassActionProcessor.php
@@ -9,7 +9,6 @@ namespace Chamilo\CoreBundle\State\CourseClass;
 use ApiPlatform\Metadata\Operation;
 use ApiPlatform\State\ProcessorInterface;
 use Chamilo\CoreBundle\ApiResource\CourseClass\CourseClassAction;
-use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 use Symfony\Component\HttpKernel\Exception\UnprocessableEntityHttpException;
 use Symfony\Component\Security\Csrf\CsrfToken;
@@ -21,7 +20,6 @@ use Symfony\Component\Security\Csrf\CsrfTokenManagerInterface;
 final readonly class CourseClassActionProcessor implements ProcessorInterface
 {
     public function __construct(
-        private RequestStack $requestStack,
         private CourseClassManager $manager,
         private CsrfTokenManagerInterface $csrfTokenManager,
     ) {}
@@ -42,12 +40,7 @@ final readonly class CourseClassActionProcessor implements ProcessorInterface
             throw new BadRequestHttpException('Invalid CSRF token.');
         }
 
-        $request = $this->requestStack->getCurrentRequest();
-        if (null === $request) {
-            throw new BadRequestHttpException('The current request is not available.');
-        }
-
-        [$course, $session] = $this->manager->resolveContext($request);
+        [$course, $session] = $this->manager->resolveContext();
         $this->manager->assertCanManage($course, $session);
         $usergroup = $this->manager->findAccessibleGroup($data->usergroupId);
 

--- a/src/CoreBundle/State/CourseClass/CourseClassManager.php
+++ b/src/CoreBundle/State/CourseClass/CourseClassManager.php
@@ -13,6 +13,7 @@ use Chamilo\CoreBundle\Entity\Usergroup;
 use Chamilo\CoreBundle\Entity\UsergroupRelCourse;
 use Chamilo\CoreBundle\Entity\UsergroupRelSession;
 use Chamilo\CoreBundle\Helpers\AccessUrlHelper;
+use Chamilo\CoreBundle\Helpers\CidReqHelper;
 use Chamilo\CoreBundle\Repository\Node\UsergroupRepository;
 use Chamilo\CoreBundle\Settings\SettingsManager;
 use Doctrine\DBAL\ArrayParameterType;
@@ -35,34 +36,22 @@ final readonly class CourseClassManager
         private SettingsManager $settingsManager,
         private UsergroupRepository $usergroupRepository,
         private AccessUrlHelper $accessUrlHelper,
+        private CidReqHelper $cidReqHelper,
     ) {}
 
     /**
      * @return array{0: Course, 1: Session|null}
      */
-    public function resolveContext(Request $request): array
+    public function resolveContext(): array
     {
-        $courseId = $request->query->getInt('cid');
-        if ($courseId <= 0) {
-            throw new BadRequestHttpException('A valid course id is required.');
-        }
+        $course = $this->cidReqHelper->getDoctrineCourseEntity()
+            ?? throw new BadRequestHttpException('A valid course id is required.');
 
-        $course = $this->entityManager->getRepository(Course::class)->find($courseId);
-        if (!$course instanceof Course) {
-            throw new BadRequestHttpException('The requested course was not found.');
-        }
-
-        $sessionId = $request->query->getInt('sid');
-        $session = null;
-        if ($sessionId > 0) {
-            $session = $this->entityManager->getRepository(Session::class)->find($sessionId);
-            if (!$session instanceof Session) {
-                throw new BadRequestHttpException('The requested session was not found.');
-            }
-
-            if (!$session->hasCourse($course)) {
-                throw new AccessDeniedHttpException('The requested session does not contain the current course.');
-            }
+        // SessionVoter only proves the course/session pairing for students and course coaches,
+        // so assert it here for general coaches and admins too.
+        $session = $this->cidReqHelper->getDoctrineSessionEntity();
+        if ($session instanceof Session && !$session->hasCourse($course)) {
+            throw new AccessDeniedHttpException('The requested session does not contain the current course.');
         }
 
         return [$course, $session];
@@ -118,7 +107,7 @@ final readonly class CourseClassManager
      */
     public function getListData(Request $request): array
     {
-        [$course, $session] = $this->resolveContext($request);
+        [$course, $session] = $this->resolveContext();
         $this->assertCanManage($course, $session);
 
         $view = self::VIEW_AVAILABLE === (string) $request->query->get('view')
@@ -168,7 +157,7 @@ final readonly class CourseClassManager
             'groupFilter' => $groupFilter,
             'canManage' => true,
             'groupsUrl' => $this->buildLegacyUrl('/main/group/group.php', $course, $session, [
-                'gid' => $request->query->getInt('gid'),
+                'gid' => (int) ($this->cidReqHelper->getGroupId() ?? 0),
             ]),
             'information' => self::VIEW_REGISTERED === $view
                 ? 'Information: This list shows the classes already linked to this course. '

--- a/src/CoreBundle/State/CourseDescription/CourseDescriptionDeleteProcessor.php
+++ b/src/CoreBundle/State/CourseDescription/CourseDescriptionDeleteProcessor.php
@@ -12,6 +12,7 @@ use Chamilo\CoreBundle\ApiResource\CourseDescription\CourseDescriptionItem;
 use Chamilo\CoreBundle\Entity\Course;
 use Chamilo\CoreBundle\Entity\ResourceLink;
 use Chamilo\CoreBundle\Entity\Session;
+use Chamilo\CoreBundle\Helpers\StudentViewHelper;
 use Chamilo\CoreBundle\Settings\SettingsManager;
 use Chamilo\CourseBundle\Entity\CCourseDescription;
 use Chamilo\CourseBundle\Repository\CCourseDescriptionRepository;
@@ -42,6 +43,7 @@ final readonly class CourseDescriptionDeleteProcessor implements ProcessorInterf
         private Security $security,
         private SettingsManager $settingsManager,
         private CsrfTokenManagerInterface $csrfTokenManager,
+        private StudentViewHelper $studentViewHelper,
     ) {}
 
     /**
@@ -60,7 +62,7 @@ final readonly class CourseDescriptionDeleteProcessor implements ProcessorInterf
         $session = $this->getSession($request);
         $this->assertSessionBelongsToCourse($session, $course);
 
-        if ($this->isStudentView($request) || !$this->canManageCourseDescriptions(
+        if ($this->studentViewHelper->isStudentView() || !$this->canManageCourseDescriptions(
             $this->entityManager,
             $this->security,
             $this->settingsManager,
@@ -178,18 +180,5 @@ final readonly class CourseDescriptionDeleteProcessor implements ProcessorInterf
         if (!$this->csrfTokenManager->isTokenValid(new CsrfToken(CourseDescriptionItemProvider::CSRF_TOKEN_ID, $token))) {
             throw new AccessDeniedHttpException('The security token is invalid.');
         }
-    }
-
-    private function isStudentView(Request $request): bool
-    {
-        if ($request->query->has('isStudentView')) {
-            return $request->query->getBoolean('isStudentView');
-        }
-
-        if (!$request->hasSession()) {
-            return false;
-        }
-
-        return 'studentview' === $request->getSession()->get('studentview');
     }
 }

--- a/src/CoreBundle/State/CourseDescription/CourseDescriptionItemProcessor.php
+++ b/src/CoreBundle/State/CourseDescription/CourseDescriptionItemProcessor.php
@@ -14,6 +14,7 @@ use Chamilo\CoreBundle\Entity\Course;
 use Chamilo\CoreBundle\Entity\Language;
 use Chamilo\CoreBundle\Entity\ResourceLink;
 use Chamilo\CoreBundle\Entity\Session;
+use Chamilo\CoreBundle\Helpers\StudentViewHelper;
 use Chamilo\CoreBundle\Settings\SettingsManager;
 use Chamilo\CourseBundle\Entity\CCourseDescription;
 use Chamilo\CourseBundle\Repository\CCourseDescriptionRepository;
@@ -43,6 +44,7 @@ final readonly class CourseDescriptionItemProcessor implements ProcessorInterfac
         private Security $security,
         private SettingsManager $settingsManager,
         private CsrfTokenManagerInterface $csrfTokenManager,
+        private StudentViewHelper $studentViewHelper,
     ) {}
 
     /**
@@ -65,7 +67,7 @@ final readonly class CourseDescriptionItemProcessor implements ProcessorInterfac
         $session = $this->getSession($request);
         $this->assertSessionBelongsToCourse($session, $course);
 
-        if ($this->isStudentView($request) || !$this->canManageCourseDescriptions(
+        if ($this->studentViewHelper->isStudentView() || !$this->canManageCourseDescriptions(
             $this->entityManager,
             $this->security,
             $this->settingsManager,
@@ -289,19 +291,6 @@ final readonly class CourseDescriptionItemProcessor implements ProcessorInterfac
         $value = $this->settingsManager->getSetting($name, true);
 
         return true === $value || 'true' === strtolower((string) $value) || '1' === (string) $value;
-    }
-
-    private function isStudentView(Request $request): bool
-    {
-        if ($request->query->has('isStudentView')) {
-            return $request->query->getBoolean('isStudentView');
-        }
-
-        if (!$request->hasSession()) {
-            return false;
-        }
-
-        return 'studentview' === $request->getSession()->get('studentview');
     }
 
     private function buildResponse(CCourseDescription $description): CourseDescriptionItem

--- a/src/CoreBundle/State/CourseDescription/CourseDescriptionItemProvider.php
+++ b/src/CoreBundle/State/CourseDescription/CourseDescriptionItemProvider.php
@@ -13,6 +13,7 @@ use Chamilo\CoreBundle\Entity\Course;
 use Chamilo\CoreBundle\Entity\Language;
 use Chamilo\CoreBundle\Entity\ResourceLink;
 use Chamilo\CoreBundle\Entity\Session;
+use Chamilo\CoreBundle\Helpers\StudentViewHelper;
 use Chamilo\CoreBundle\Settings\SettingsManager;
 use Chamilo\CourseBundle\Entity\CCourseDescription;
 use Chamilo\CourseBundle\Repository\CCourseDescriptionRepository;
@@ -95,6 +96,7 @@ final readonly class CourseDescriptionItemProvider implements ProviderInterface
         private Security $security,
         private SettingsManager $settingsManager,
         private CsrfTokenManagerInterface $csrfTokenManager,
+        private StudentViewHelper $studentViewHelper,
     ) {}
 
     /**
@@ -113,7 +115,7 @@ final readonly class CourseDescriptionItemProvider implements ProviderInterface
         $session = $this->getSession($request);
         $this->assertSessionBelongsToCourse($session, $course);
 
-        if ($this->isStudentView($request) || !$this->canManageCourseDescriptions(
+        if ($this->studentViewHelper->isStudentView() || !$this->canManageCourseDescriptions(
             $this->entityManager,
             $this->security,
             $this->settingsManager,
@@ -320,19 +322,6 @@ final readonly class CourseDescriptionItemProvider implements ProviderInterface
         $value = $this->settingsManager->getSetting($name, true);
 
         return true === $value || 'true' === strtolower((string) $value) || '1' === (string) $value;
-    }
-
-    private function isStudentView(Request $request): bool
-    {
-        if ($request->query->has('isStudentView')) {
-            return $request->query->getBoolean('isStudentView');
-        }
-
-        if (!$request->hasSession()) {
-            return false;
-        }
-
-        return 'studentview' === $request->getSession()->get('studentview');
     }
 
     private function getResourceLanguage(CCourseDescription $description): string

--- a/src/CoreBundle/State/CourseDescription/CourseDescriptionListProvider.php
+++ b/src/CoreBundle/State/CourseDescription/CourseDescriptionListProvider.php
@@ -12,6 +12,7 @@ use Chamilo\CoreBundle\ApiResource\CourseDescription\CourseDescriptionList;
 use Chamilo\CoreBundle\Entity\Course;
 use Chamilo\CoreBundle\Entity\ResourceLink;
 use Chamilo\CoreBundle\Entity\Session;
+use Chamilo\CoreBundle\Helpers\StudentViewHelper;
 use Chamilo\CoreBundle\Settings\SettingsManager;
 use Chamilo\CourseBundle\Entity\CCourseDescription;
 use Chamilo\CourseBundle\Repository\CCourseDescriptionRepository;
@@ -41,6 +42,7 @@ final readonly class CourseDescriptionListProvider implements ProviderInterface
         private Security $security,
         private SettingsManager $settingsManager,
         private CsrfTokenManagerInterface $csrfTokenManager,
+        private StudentViewHelper $studentViewHelper,
     ) {}
 
     /**
@@ -63,7 +65,7 @@ final readonly class CourseDescriptionListProvider implements ProviderInterface
             throw new AccessDeniedHttpException('You are not allowed to view course descriptions in this context.');
         }
 
-        $studentView = $this->isStudentView($request);
+        $studentView = $this->studentViewHelper->isStudentView();
         $canManage = !$studentView && $this->canManageCourseDescriptions(
             $this->entityManager,
             $this->security,
@@ -264,18 +266,5 @@ final readonly class CourseDescriptionListProvider implements ProviderInterface
         $value = $this->settingsManager->getSetting($name, true);
 
         return true === $value || 'true' === strtolower((string) $value) || '1' === (string) $value;
-    }
-
-    private function isStudentView(Request $request): bool
-    {
-        if ($request->query->has('isStudentView')) {
-            return $request->query->getBoolean('isStudentView');
-        }
-
-        if (!$request->hasSession()) {
-            return false;
-        }
-
-        return 'studentview' === $request->getSession()->get('studentview');
     }
 }

--- a/src/CoreBundle/State/CourseGroup/CourseGroupActionProcessor.php
+++ b/src/CoreBundle/State/CourseGroup/CourseGroupActionProcessor.php
@@ -40,17 +40,16 @@ final readonly class CourseGroupActionProcessor implements ProcessorInterface
         }
 
         $data->affectedIds = match ($operation->getName()) {
-            'post_course_group_create_groups' => $this->manager->createGroups($request, $data->groups),
+            'post_course_group_create_groups' => $this->manager->createGroups($data->groups),
             'post_course_group_create_subgroups' => $this->createSubgroups($request, $data),
             'post_course_group_create_class_groups' => $this->manager->createClassGroups(
-                $request,
                 $data->categoryId,
                 $data->classIds,
                 $data->consistentLink,
             ),
-            'post_course_group_delete' => $this->manager->deleteGroups($request, $data->groupIds),
-            'post_course_group_empty' => $this->manager->emptyGroups($request, $data->groupIds),
-            'post_course_group_fill' => $this->manager->fillGroups($request, $data->groupIds),
+            'post_course_group_delete' => $this->manager->deleteGroups($data->groupIds),
+            'post_course_group_empty' => $this->manager->emptyGroups($data->groupIds),
+            'post_course_group_fill' => $this->manager->fillGroups($data->groupIds),
             'post_course_group_toggle_visibility' => $this->toggleVisibility($request, $data),
             'post_course_group_self_register' => $this->selfRegister($request, $data),
             'post_course_group_self_unregister' => $this->selfUnregister($request, $data),
@@ -81,49 +80,49 @@ final readonly class CourseGroupActionProcessor implements ProcessorInterface
 
     private function createSubgroups(Request $request, CourseGroupAction $data): array
     {
-        $this->manager->createSubgroups($request, $data->baseGroupId, $data->numberOfGroups);
+        $this->manager->createSubgroups($data->baseGroupId, $data->numberOfGroups);
 
         return [];
     }
 
     private function toggleVisibility(Request $request, CourseGroupAction $data): array
     {
-        $this->manager->toggleVisibility($request, $data->groupId, $data->visible);
+        $this->manager->toggleVisibility($data->groupId, $data->visible);
 
         return [$data->groupId];
     }
 
     private function selfRegister(Request $request, CourseGroupAction $data): array
     {
-        $this->manager->selfRegister($request, $data->groupId);
+        $this->manager->selfRegister($data->groupId);
 
         return [$data->groupId];
     }
 
     private function selfUnregister(Request $request, CourseGroupAction $data): array
     {
-        $this->manager->selfUnregister($request, $data->groupId);
+        $this->manager->selfUnregister($data->groupId);
 
         return [$data->groupId];
     }
 
     private function deleteCategory(Request $request, CourseGroupAction $data): array
     {
-        $this->manager->deleteCategory($request, $data->categoryId);
+        $this->manager->deleteCategory($data->categoryId);
 
         return [$data->categoryId];
     }
 
     private function moveCategory(Request $request, CourseGroupAction $data): array
     {
-        $this->manager->moveCategory($request, $data->categoryId, $data->otherCategoryId);
+        $this->manager->moveCategory($data->categoryId, $data->otherCategoryId);
 
         return [$data->categoryId, $data->otherCategoryId];
     }
 
     private function removeClassLink(Request $request, CourseGroupAction $data): array
     {
-        $this->manager->removeClassLink($request, $data->groupId);
+        $this->manager->removeClassLink($data->groupId);
 
         return [$data->groupId];
     }

--- a/src/CoreBundle/State/CourseGroup/CourseGroupCategoryFormProcessor.php
+++ b/src/CoreBundle/State/CourseGroup/CourseGroupCategoryFormProcessor.php
@@ -38,7 +38,7 @@ final readonly class CourseGroupCategoryFormProcessor implements ProcessorInterf
             throw new BadRequestHttpException('The current request is not available.');
         }
         $categoryId = (int) ($uriVariables['categoryId'] ?? $request->attributes->get('categoryId', 0));
-        $data->categoryId = $this->manager->saveCategory($data, $request, $categoryId);
+        $data->categoryId = $this->manager->saveCategory($data, $categoryId);
         $data->success = true;
         $data->message = 'Saved';
 

--- a/src/CoreBundle/State/CourseGroup/CourseGroupCategoryFormProvider.php
+++ b/src/CoreBundle/State/CourseGroup/CourseGroupCategoryFormProvider.php
@@ -31,7 +31,7 @@ final readonly class CourseGroupCategoryFormProvider implements ProviderInterfac
             throw new BadRequestHttpException('The current request is not available.');
         }
         $categoryId = (int) ($uriVariables['categoryId'] ?? $request->attributes->get('categoryId', 0));
-        $data = $this->manager->getCategoryFormData($request, $categoryId);
+        $data = $this->manager->getCategoryFormData($categoryId);
         $resource = new CourseGroupCategoryForm();
         foreach ($data as $property => $value) {
             $resource->{$property} = $value;

--- a/src/CoreBundle/State/CourseGroup/CourseGroupDetailProvider.php
+++ b/src/CoreBundle/State/CourseGroup/CourseGroupDetailProvider.php
@@ -31,7 +31,7 @@ final readonly class CourseGroupDetailProvider implements ProviderInterface
             throw new BadRequestHttpException('The current request is not available.');
         }
         $groupId = (int) ($uriVariables['groupId'] ?? $request->attributes->get('groupId', 0));
-        $data = $this->manager->getDetailData($request, $groupId);
+        $data = $this->manager->getDetailData($groupId);
         $resource = new CourseGroupDetail();
         foreach ($data as $property => $value) {
             $resource->{$property} = $value;

--- a/src/CoreBundle/State/CourseGroup/CourseGroupFormProcessor.php
+++ b/src/CoreBundle/State/CourseGroup/CourseGroupFormProcessor.php
@@ -38,7 +38,7 @@ final readonly class CourseGroupFormProcessor implements ProcessorInterface
             throw new BadRequestHttpException('The current request is not available.');
         }
         $groupId = (int) ($uriVariables['groupId'] ?? $request->attributes->get('groupId', 0));
-        $data->groupId = $this->manager->saveGroup($data, $request, $groupId);
+        $data->groupId = $this->manager->saveGroup($data, $groupId);
         $data->success = true;
         $data->message = 'Saved';
 

--- a/src/CoreBundle/State/CourseGroup/CourseGroupImportProcessor.php
+++ b/src/CoreBundle/State/CourseGroup/CourseGroupImportProcessor.php
@@ -44,7 +44,7 @@ final readonly class CourseGroupImportProcessor implements ProcessorInterface
         if (!\is_array($rows)) {
             throw new BadRequestHttpException('The CSV file is invalid.');
         }
-        $result = $this->manager->import($request, $rows, $request->request->getBoolean('deleteMissing'));
+        $result = $this->manager->import($rows, $request->request->getBoolean('deleteMissing'));
         $resource = new CourseGroupImport();
         $resource->success = true;
         $resource->message = 'Import completed';

--- a/src/CoreBundle/State/CourseGroup/CourseGroupImportProvider.php
+++ b/src/CoreBundle/State/CourseGroup/CourseGroupImportProvider.php
@@ -9,8 +9,6 @@ namespace Chamilo\CoreBundle\State\CourseGroup;
 use ApiPlatform\Metadata\Operation;
 use ApiPlatform\State\ProviderInterface;
 use Chamilo\CoreBundle\ApiResource\CourseGroup\CourseGroupImport;
-use Symfony\Component\HttpFoundation\RequestStack;
-use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 use Symfony\Component\Security\Csrf\CsrfTokenManagerInterface;
 
 /**
@@ -19,18 +17,13 @@ use Symfony\Component\Security\Csrf\CsrfTokenManagerInterface;
 final readonly class CourseGroupImportProvider implements ProviderInterface
 {
     public function __construct(
-        private RequestStack $requestStack,
         private CourseGroupManager $manager,
         private CsrfTokenManagerInterface $csrfTokenManager,
     ) {}
 
     public function provide(Operation $operation, array $uriVariables = [], array $context = []): CourseGroupImport
     {
-        $request = $this->requestStack->getCurrentRequest();
-        if (null === $request) {
-            throw new BadRequestHttpException('The current request is not available.');
-        }
-        [$course, $session] = $this->manager->resolveContext($request);
+        [$course, $session] = $this->manager->resolveContext();
         $this->manager->assertCanManage($course, $session);
         $resource = new CourseGroupImport();
         $resource->canImport = true;

--- a/src/CoreBundle/State/CourseGroup/CourseGroupManager.php
+++ b/src/CoreBundle/State/CourseGroup/CourseGroupManager.php
@@ -9,6 +9,7 @@ namespace Chamilo\CoreBundle\State\CourseGroup;
 use Chamilo\CoreBundle\Entity\Course;
 use Chamilo\CoreBundle\Entity\Session;
 use Chamilo\CoreBundle\Entity\User;
+use Chamilo\CoreBundle\Helpers\CidReqHelper;
 use Chamilo\CoreBundle\Settings\SettingsManager;
 use Chamilo\CourseBundle\Entity\CGroup;
 use Chamilo\CourseBundle\Entity\CGroupCategory;
@@ -41,6 +42,7 @@ final readonly class CourseGroupManager
         private CGroupRepository $groupRepository,
         private CGroupCategoryRepository $categoryRepository,
         private UrlGeneratorInterface $router,
+        private CidReqHelper $cidReqHelper,
     ) {}
 
     public function getCsrfIntention(): string
@@ -51,29 +53,16 @@ final readonly class CourseGroupManager
     /**
      * @return array{0: Course, 1: Session|null}
      */
-    public function resolveContext(Request $request): array
+    public function resolveContext(): array
     {
-        $courseId = $request->query->getInt('cid');
-        if ($courseId <= 0) {
-            throw new BadRequestHttpException('A valid course id is required.');
-        }
+        $course = $this->cidReqHelper->getDoctrineCourseEntity()
+            ?? throw new BadRequestHttpException('A valid course id is required.');
 
-        $course = $this->entityManager->getRepository(Course::class)->find($courseId);
-        if (!$course instanceof Course) {
-            throw new NotFoundHttpException('The requested course was not found.');
-        }
-
-        $sessionId = $request->query->getInt('sid');
-        $session = null;
-        if ($sessionId > 0) {
-            $session = $this->entityManager->getRepository(Session::class)->find($sessionId);
-            if (!$session instanceof Session) {
-                throw new NotFoundHttpException('The requested session was not found.');
-            }
-
-            if (!$session->hasCourse($course)) {
-                throw new AccessDeniedHttpException('The requested session does not contain the current course.');
-            }
+        // SessionVoter only proves the course/session pairing for students and course coaches,
+        // so assert it here for general coaches and admins too.
+        $session = $this->cidReqHelper->getDoctrineSessionEntity();
+        if ($session instanceof Session && !$session->hasCourse($course)) {
+            throw new AccessDeniedHttpException('The requested session does not contain the current course.');
         }
 
         return [$course, $session];
@@ -178,7 +167,7 @@ final readonly class CourseGroupManager
      */
     public function getListData(Request $request): array
     {
-        [$course, $session] = $this->resolveContext($request);
+        [$course, $session] = $this->resolveContext();
         $this->assertCanRead($course, $session);
 
         $canManage = $this->canManage($course, $session);
@@ -333,7 +322,7 @@ final readonly class CourseGroupManager
      */
     public function getOverviewData(Request $request): array
     {
-        [$course, $session] = $this->resolveContext($request);
+        [$course, $session] = $this->resolveContext();
         $this->assertCanManage($course, $session);
         $keyword = trim((string) $request->query->get('search', ''));
         $groups = $this->groupRepository->getResourcesByCourse($course, $session)->getQuery()->getResult();
@@ -378,7 +367,7 @@ final readonly class CourseGroupManager
      */
     public function getGroupFormData(Request $request, int $groupId = 0): array
     {
-        [$course, $session] = $this->resolveContext($request);
+        [$course, $session] = $this->resolveContext();
         $group = $groupId > 0 ? $this->findGroup($groupId, $course, $session) : null;
         if ($group instanceof CGroup) {
             $this->assertCanManageGroup($group, $course, $session);
@@ -468,9 +457,9 @@ final readonly class CourseGroupManager
         ];
     }
 
-    public function saveGroup(object $data, Request $request, int $groupId = 0): int
+    public function saveGroup(object $data, int $groupId = 0): int
     {
-        [$course, $session] = $this->resolveContext($request);
+        [$course, $session] = $this->resolveContext();
         $group = $groupId > 0 ? $this->findGroup($groupId, $course, $session) : null;
         if ($group instanceof CGroup) {
             $this->assertCanManageGroup($group, $course, $session);
@@ -525,9 +514,9 @@ final readonly class CourseGroupManager
     /**
      * @return array<string, mixed>
      */
-    public function getCategoryFormData(Request $request, int $categoryId = 0): array
+    public function getCategoryFormData(int $categoryId = 0): array
     {
-        [$course, $session] = $this->resolveContext($request);
+        [$course, $session] = $this->resolveContext();
         $this->assertCanManage($course, $session);
         if ($session instanceof Session) {
             throw new AccessDeniedHttpException('Group categories cannot be managed inside a session.');
@@ -566,9 +555,9 @@ final readonly class CourseGroupManager
         ];
     }
 
-    public function saveCategory(object $data, Request $request, int $categoryId = 0): int
+    public function saveCategory(object $data, int $categoryId = 0): int
     {
-        [$course, $session] = $this->resolveContext($request);
+        [$course, $session] = $this->resolveContext();
         $this->assertCanManage($course, $session);
         if ($session instanceof Session) {
             throw new AccessDeniedHttpException('Group categories cannot be managed inside a session.');
@@ -629,9 +618,9 @@ final readonly class CourseGroupManager
     /**
      * @return array<string, mixed>
      */
-    public function getMembersData(Request $request, int $groupId, string $mode): array
+    public function getMembersData(int $groupId, string $mode): array
     {
-        [$course, $session] = $this->resolveContext($request);
+        [$course, $session] = $this->resolveContext();
         $group = $this->findGroup($groupId, $course, $session);
         $this->assertCanManageGroup($group, $course, $session);
 
@@ -718,12 +707,12 @@ final readonly class CourseGroupManager
 
     public function saveMembers(Request $request, int $groupId, string $mode, array $selectedIds): void
     {
-        [$course, $session] = $this->resolveContext($request);
+        [$course, $session] = $this->resolveContext();
         $group = $this->findGroup($groupId, $course, $session);
         $this->assertCanManageGroup($group, $course, $session);
 
         $selectedIds = array_values(array_unique(array_filter(array_map('intval', $selectedIds))));
-        $selectionData = $this->getMembersData($request, $groupId, $mode);
+        $selectionData = $this->getMembersData($groupId, $mode);
         $allowedIds = array_map(
             static fn (array $item): int => (int) $item['id'],
             (array) $selectionData['options'],
@@ -783,9 +772,9 @@ final readonly class CourseGroupManager
     /**
      * @return array<string, mixed>
      */
-    public function getDetailData(Request $request, int $groupId): array
+    public function getDetailData(int $groupId): array
     {
-        [$course, $session] = $this->resolveContext($request);
+        [$course, $session] = $this->resolveContext();
         $this->assertCanRead($course, $session);
         $group = $this->findGroup($groupId, $course, $session);
         $user = $this->security->getUser();
@@ -869,9 +858,9 @@ final readonly class CourseGroupManager
         ];
     }
 
-    public function createGroups(Request $request, array $groups): array
+    public function createGroups(array $groups): array
     {
-        [$course, $session] = $this->resolveContext($request);
+        [$course, $session] = $this->resolveContext();
         $this->assertCanManage($course, $session);
         $ids = [];
         foreach ($groups as $groupData) {
@@ -897,9 +886,9 @@ final readonly class CourseGroupManager
         return $ids;
     }
 
-    public function createSubgroups(Request $request, int $baseGroupId, int $numberOfGroups): void
+    public function createSubgroups(int $baseGroupId, int $numberOfGroups): void
     {
-        [$course, $session] = $this->resolveContext($request);
+        [$course, $session] = $this->resolveContext();
         $this->assertCanManage($course, $session);
         $this->findGroup($baseGroupId, $course, $session);
         if ($numberOfGroups <= 0) {
@@ -908,9 +897,9 @@ final readonly class CourseGroupManager
         GroupManager::create_subgroups($baseGroupId, $numberOfGroups);
     }
 
-    public function createClassGroups(Request $request, int $categoryId, array $classIds, bool $consistentLink): array
+    public function createClassGroups(int $categoryId, array $classIds, bool $consistentLink): array
     {
-        [$course, $session] = $this->resolveContext($request);
+        [$course, $session] = $this->resolveContext();
         $this->assertCanManage($course, $session);
         if ($categoryId > 0) {
             $this->findCategory($categoryId, $course, $session);
@@ -933,9 +922,9 @@ final readonly class CourseGroupManager
             : array_values(array_map('intval', GroupManager::create_class_groups($categoryId, $classIds)));
     }
 
-    public function deleteGroups(Request $request, array $groupIds): array
+    public function deleteGroups(array $groupIds): array
     {
-        [$course, $session] = $this->resolveContext($request);
+        [$course, $session] = $this->resolveContext();
         $this->assertCanManage($course, $session);
         $affected = [];
         foreach ($this->normalizeIds($groupIds) as $groupId) {
@@ -947,9 +936,9 @@ final readonly class CourseGroupManager
         return $affected;
     }
 
-    public function emptyGroups(Request $request, array $groupIds): array
+    public function emptyGroups(array $groupIds): array
     {
-        [$course, $session] = $this->resolveContext($request);
+        [$course, $session] = $this->resolveContext();
         $this->assertCanManage($course, $session);
         $affected = [];
         foreach ($this->normalizeIds($groupIds) as $groupId) {
@@ -961,9 +950,9 @@ final readonly class CourseGroupManager
         return $affected;
     }
 
-    public function fillGroups(Request $request, array $groupIds): array
+    public function fillGroups(array $groupIds): array
     {
-        [$course, $session] = $this->resolveContext($request);
+        [$course, $session] = $this->resolveContext();
         $this->assertCanManage($course, $session);
         $affected = [];
         foreach ($this->normalizeIds($groupIds) as $groupId) {
@@ -975,17 +964,17 @@ final readonly class CourseGroupManager
         return $affected;
     }
 
-    public function toggleVisibility(Request $request, int $groupId, bool $visible): void
+    public function toggleVisibility(int $groupId, bool $visible): void
     {
-        [$course, $session] = $this->resolveContext($request);
+        [$course, $session] = $this->resolveContext();
         $this->assertCanManage($course, $session);
         $group = $this->findGroup($groupId, $course, $session);
         $visible ? GroupManager::setVisible($group) : GroupManager::setInvisible($group);
     }
 
-    public function selfRegister(Request $request, int $groupId): void
+    public function selfRegister(int $groupId): void
     {
-        [$course, $session] = $this->resolveContext($request);
+        [$course, $session] = $this->resolveContext();
         $this->assertCanRead($course, $session);
         $group = $this->findGroup($groupId, $course, $session);
         $user = $this->security->getUser();
@@ -995,9 +984,9 @@ final readonly class CourseGroupManager
         GroupManager::subscribeUsers((int) $user->getId(), $group, (int) $course->getId());
     }
 
-    public function selfUnregister(Request $request, int $groupId): void
+    public function selfUnregister(int $groupId): void
     {
-        [$course, $session] = $this->resolveContext($request);
+        [$course, $session] = $this->resolveContext();
         $this->assertCanRead($course, $session);
         $group = $this->findGroup($groupId, $course, $session);
         $user = $this->security->getUser();
@@ -1007,9 +996,9 @@ final readonly class CourseGroupManager
         GroupManager::unsubscribeUsers((int) $user->getId(), $group, (int) $course->getId());
     }
 
-    public function deleteCategory(Request $request, int $categoryId): void
+    public function deleteCategory(int $categoryId): void
     {
-        [$course, $session] = $this->resolveContext($request);
+        [$course, $session] = $this->resolveContext();
         $this->assertCanManage($course, $session);
         if ($session instanceof Session) {
             throw new AccessDeniedHttpException('Categories cannot be deleted inside a session.');
@@ -1024,9 +1013,9 @@ final readonly class CourseGroupManager
         GroupManager::delete_category($categoryId, $course->getCode());
     }
 
-    public function moveCategory(Request $request, int $categoryId, int $otherCategoryId): void
+    public function moveCategory(int $categoryId, int $otherCategoryId): void
     {
-        [$course, $session] = $this->resolveContext($request);
+        [$course, $session] = $this->resolveContext();
         $this->assertCanManage($course, $session);
         if ($session instanceof Session) {
             throw new AccessDeniedHttpException('Categories cannot be reordered inside a session.');
@@ -1039,9 +1028,9 @@ final readonly class CourseGroupManager
         GroupManager::swap_category_order($categoryId, $otherCategoryId);
     }
 
-    public function removeClassLink(Request $request, int $groupId): void
+    public function removeClassLink(int $groupId): void
     {
-        [$course, $session] = $this->resolveContext($request);
+        [$course, $session] = $this->resolveContext();
         $this->assertCanManage($course, $session);
         $group = $this->findGroup($groupId, $course, $session);
         if (!GroupManager::remove_group_consistent_link($group)) {
@@ -1052,9 +1041,9 @@ final readonly class CourseGroupManager
     /**
      * @return array<string, mixed>
      */
-    public function import(Request $request, array $rows, bool $deleteMissing): array
+    public function import(array $rows, bool $deleteMissing): array
     {
-        [$course, $session] = $this->resolveContext($request);
+        [$course, $session] = $this->resolveContext();
         $this->assertCanManage($course, $session);
         if ([] === $rows) {
             throw new BadRequestHttpException('The CSV file is empty or invalid.');
@@ -1066,9 +1055,9 @@ final readonly class CourseGroupManager
     /**
      * @return array<int, array<int, mixed>>
      */
-    public function getExportData(Request $request, ?int $groupId = null, bool $loadUsers = false): array
+    public function getExportData(?int $groupId = null, bool $loadUsers = false): array
     {
-        [$course, $session] = $this->resolveContext($request);
+        [$course, $session] = $this->resolveContext();
         $this->assertCanManage($course, $session);
         if (null !== $groupId && $groupId > 0) {
             $this->findGroup($groupId, $course, $session);

--- a/src/CoreBundle/State/CourseGroup/CourseGroupMembersProvider.php
+++ b/src/CoreBundle/State/CourseGroup/CourseGroupMembersProvider.php
@@ -32,7 +32,7 @@ final readonly class CourseGroupMembersProvider implements ProviderInterface
         }
         $mode = str_contains((string) $operation->getName(), 'tutors') ? 'tutors' : 'members';
         $groupId = (int) ($uriVariables['groupId'] ?? $request->attributes->get('groupId', 0));
-        $data = $this->manager->getMembersData($request, $groupId, $mode);
+        $data = $this->manager->getMembersData($groupId, $mode);
         $resource = new CourseGroupMembers();
         foreach ($data as $property => $value) {
             $resource->{$property} = $value;

--- a/src/CoreBundle/State/CourseGroup/CourseGroupOverviewProvider.php
+++ b/src/CoreBundle/State/CourseGroup/CourseGroupOverviewProvider.php
@@ -9,6 +9,7 @@ namespace Chamilo\CoreBundle\State\CourseGroup;
 use ApiPlatform\Metadata\Operation;
 use ApiPlatform\State\ProviderInterface;
 use Chamilo\CoreBundle\ApiResource\CourseGroup\CourseGroupOverview;
+use Chamilo\CoreBundle\Helpers\CidReqHelper;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 
@@ -20,6 +21,7 @@ final readonly class CourseGroupOverviewProvider implements ProviderInterface
     public function __construct(
         private RequestStack $requestStack,
         private CourseGroupManager $manager,
+        private CidReqHelper $cidReqHelper,
     ) {}
 
     public function provide(Operation $operation, array $uriVariables = [], array $context = []): CourseGroupOverview
@@ -31,9 +33,11 @@ final readonly class CourseGroupOverviewProvider implements ProviderInterface
 
         $resource = new CourseGroupOverview();
         $resource->groups = $this->manager->getOverviewData($request);
+        // The export endpoints are plain Symfony routes that resolve the context from their own
+        // query string, so these values must keep being emitted — only their source changes.
         $query = http_build_query(array_filter([
-            'cid' => $request->query->getInt('cid'),
-            'sid' => $request->query->getInt('sid'),
+            'cid' => (int) ($this->cidReqHelper->getCourseId() ?? 0),
+            'sid' => (int) ($this->cidReqHelper->getSessionId() ?? 0),
         ], static fn (int $value): bool => $value > 0));
         $resource->csvExportUrl = '/api/course-groups/export.csv?'.$query;
         $resource->xlsxExportUrl = '/api/course-groups/export.xlsx?'.$query;

--- a/src/CoreBundle/State/CourseProgress/CourseProgressAccessHelperTrait.php
+++ b/src/CoreBundle/State/CourseProgress/CourseProgressAccessHelperTrait.php
@@ -14,6 +14,7 @@ use Chamilo\CoreBundle\Entity\ResourceLink;
 use Chamilo\CoreBundle\Entity\Session;
 use Chamilo\CoreBundle\Entity\SessionRelCourseRelUser;
 use Chamilo\CoreBundle\Entity\User;
+use Chamilo\CoreBundle\Helpers\CidReqHelper;
 use Chamilo\CoreBundle\Helpers\StudentViewHelper;
 use Chamilo\CoreBundle\Repository\ExtraFieldValuesRepository;
 use Chamilo\CoreBundle\Security\Authorization\Voter\CourseVoter;
@@ -22,40 +23,30 @@ use Chamilo\CourseBundle\Entity\CCourseSetting;
 use Chamilo\CourseBundle\Entity\CThematic;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\SecurityBundle\Security;
-use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 
 trait CourseProgressAccessHelperTrait
 {
-    private function getCourseProgressCourse(Request $request, EntityManagerInterface $entityManager): Course
+    /**
+     * CidReqListener already resolved and validated the course, so a missing entity here
+     * can only mean the request carried no course context at all.
+     */
+    private function getCourseProgressCourse(CidReqHelper $cidReqHelper): Course
     {
-        $courseId = $request->query->getInt('cid');
-        if ($courseId <= 0) {
-            throw new BadRequestHttpException('A valid course id is required.');
-        }
-
-        $course = $entityManager->getRepository(Course::class)->find($courseId);
-        if (!$course instanceof Course) {
-            throw new BadRequestHttpException('The requested course was not found.');
-        }
-
-        return $course;
+        return $cidReqHelper->getDoctrineCourseEntity()
+            ?? throw new BadRequestHttpException('A valid course id is required.');
     }
 
-    private function getCourseProgressSession(Request $request, EntityManagerInterface $entityManager): ?Session
+    private function getCourseProgressSession(CidReqHelper $cidReqHelper): ?Session
     {
-        $sessionId = $request->query->getInt('sid');
+        $sessionId = (int) ($cidReqHelper->getSessionId() ?? 0);
         if ($sessionId <= 0) {
             return null;
         }
 
-        $session = $entityManager->getRepository(Session::class)->find($sessionId);
-        if (!$session instanceof Session) {
-            throw new BadRequestHttpException('The requested session was not found.');
-        }
-
-        return $session;
+        return $cidReqHelper->getDoctrineSessionEntity()
+            ?? throw new BadRequestHttpException('The requested session was not found.');
     }
 
     private function assertCourseProgressToolEnabled(EntityManagerInterface $entityManager, Course $course): void

--- a/src/CoreBundle/State/CourseProgress/CourseProgressAccessHelperTrait.php
+++ b/src/CoreBundle/State/CourseProgress/CourseProgressAccessHelperTrait.php
@@ -14,6 +14,7 @@ use Chamilo\CoreBundle\Entity\ResourceLink;
 use Chamilo\CoreBundle\Entity\Session;
 use Chamilo\CoreBundle\Entity\SessionRelCourseRelUser;
 use Chamilo\CoreBundle\Entity\User;
+use Chamilo\CoreBundle\Helpers\StudentViewHelper;
 use Chamilo\CoreBundle\Repository\ExtraFieldValuesRepository;
 use Chamilo\CoreBundle\Security\Authorization\Voter\CourseVoter;
 use Chamilo\CoreBundle\Settings\SettingsManager;
@@ -189,24 +190,9 @@ trait CourseProgressAccessHelperTrait
         return $session instanceof Session && $this->isSessionAdminReadingAllowed($user, $settingsManager);
     }
 
-    private function isCourseProgressStudentView(Request $request, int $courseId): bool
+    private function isCourseProgressStudentView(StudentViewHelper $studentViewHelper, int $courseId): bool
     {
-        if ($request->query->has('isStudentView') && $request->query->getBoolean('isStudentView')) {
-            return true;
-        }
-
-        if (!$request->hasSession()) {
-            return false;
-        }
-
-        $session = $request->getSession();
-        $legacyCourseStudentView = $session->get('student_view_course_'.$courseId);
-
-        if (null !== $legacyCourseStudentView) {
-            return (bool) $legacyCourseStudentView;
-        }
-
-        return 'studentview' === $session->get('studentview');
+        return $studentViewHelper->isStudentViewForCourse($courseId);
     }
 
     private function thematicBelongsToExactContext(

--- a/src/CoreBundle/State/CourseProgress/CourseProgressCompletionProcessor.php
+++ b/src/CoreBundle/State/CourseProgress/CourseProgressCompletionProcessor.php
@@ -11,6 +11,7 @@ use ApiPlatform\State\ProcessorInterface;
 use Chamilo\CoreBundle\ApiResource\CourseProgress\CourseProgressCompletion;
 use Chamilo\CoreBundle\Entity\Course;
 use Chamilo\CoreBundle\Entity\Session;
+use Chamilo\CoreBundle\Helpers\CidReqHelper;
 use Chamilo\CoreBundle\Helpers\StudentViewHelper;
 use Chamilo\CoreBundle\Settings\SettingsManager;
 use Chamilo\CourseBundle\Entity\CThematic;
@@ -19,8 +20,6 @@ use Chamilo\CourseBundle\Repository\CThematicAdvanceRepository;
 use Chamilo\CourseBundle\Repository\CThematicRepository;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\SecurityBundle\Security;
-use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
@@ -37,13 +36,13 @@ final readonly class CourseProgressCompletionProcessor implements ProcessorInter
     public const string CSRF_TOKEN_ID = 'course_progress_completion';
 
     public function __construct(
-        private RequestStack $requestStack,
         private EntityManagerInterface $entityManager,
         private CThematicRepository $thematicRepository,
         private CThematicAdvanceRepository $thematicAdvanceRepository,
         private Security $security,
         private SettingsManager $settingsManager,
         private CsrfTokenManagerInterface $csrfTokenManager,
+        private CidReqHelper $cidReqHelper,
         private StudentViewHelper $studentViewHelper,
     ) {}
 
@@ -61,16 +60,11 @@ final readonly class CourseProgressCompletionProcessor implements ProcessorInter
             throw new BadRequestHttpException('The request payload is invalid.');
         }
 
-        $request = $this->requestStack->getCurrentRequest();
-        if (!$request instanceof Request) {
-            throw new BadRequestHttpException('The current request is required.');
-        }
-
-        $course = $this->getCourseProgressCourse($request, $this->entityManager);
+        $course = $this->getCourseProgressCourse($this->cidReqHelper);
         $this->assertCourseProgressToolEnabled($this->entityManager, $course);
-        $session = $this->getCourseProgressSession($request, $this->entityManager);
+        $session = $this->getCourseProgressSession($this->cidReqHelper);
         $this->assertSessionBelongsToCourse($session, $course);
-        $this->assertCanManage($request, $course, $session);
+        $this->assertCanManage($course, $session);
         $this->validateCsrfToken($data->csrfToken);
 
         $advance = $this->getTargetAdvance($data->advanceId, $course, $session);
@@ -111,7 +105,7 @@ final readonly class CourseProgressCompletionProcessor implements ProcessorInter
         return $result;
     }
 
-    private function assertCanManage(Request $request, Course $course, ?Session $session): void
+    private function assertCanManage(Course $course, ?Session $session): void
     {
         if (!$this->isCourseProgressStudentView($this->studentViewHelper, (int) $course->getId())
             && $this->canManageCourseProgress(

--- a/src/CoreBundle/State/CourseProgress/CourseProgressCompletionProcessor.php
+++ b/src/CoreBundle/State/CourseProgress/CourseProgressCompletionProcessor.php
@@ -11,6 +11,7 @@ use ApiPlatform\State\ProcessorInterface;
 use Chamilo\CoreBundle\ApiResource\CourseProgress\CourseProgressCompletion;
 use Chamilo\CoreBundle\Entity\Course;
 use Chamilo\CoreBundle\Entity\Session;
+use Chamilo\CoreBundle\Helpers\StudentViewHelper;
 use Chamilo\CoreBundle\Settings\SettingsManager;
 use Chamilo\CourseBundle\Entity\CThematic;
 use Chamilo\CourseBundle\Entity\CThematicAdvance;
@@ -43,6 +44,7 @@ final readonly class CourseProgressCompletionProcessor implements ProcessorInter
         private Security $security,
         private SettingsManager $settingsManager,
         private CsrfTokenManagerInterface $csrfTokenManager,
+        private StudentViewHelper $studentViewHelper,
     ) {}
 
     /**
@@ -111,7 +113,7 @@ final readonly class CourseProgressCompletionProcessor implements ProcessorInter
 
     private function assertCanManage(Request $request, Course $course, ?Session $session): void
     {
-        if (!$this->isCourseProgressStudentView($request, (int) $course->getId())
+        if (!$this->isCourseProgressStudentView($this->studentViewHelper, (int) $course->getId())
             && $this->canManageCourseProgress(
                 $this->entityManager,
                 $this->security,

--- a/src/CoreBundle/State/CourseProgress/CourseProgressCsvManager.php
+++ b/src/CoreBundle/State/CourseProgress/CourseProgressCsvManager.php
@@ -9,6 +9,7 @@ namespace Chamilo\CoreBundle\State\CourseProgress;
 use Chamilo\CoreBundle\Entity\Course;
 use Chamilo\CoreBundle\Entity\Session;
 use Chamilo\CoreBundle\Entity\User;
+use Chamilo\CoreBundle\Helpers\CidReqHelper;
 use Chamilo\CoreBundle\Helpers\StudentViewHelper;
 use Chamilo\CoreBundle\Repository\ResourceLinkRepository;
 use Chamilo\CoreBundle\Settings\SettingsManager;
@@ -51,12 +52,13 @@ final readonly class CourseProgressCsvManager
         private Security $security,
         private SettingsManager $settingsManager,
         private CsrfTokenManagerInterface $csrfTokenManager,
+        private CidReqHelper $cidReqHelper,
         private StudentViewHelper $studentViewHelper,
     ) {}
 
     public function export(Request $request): StreamedResponse
     {
-        [$course, $session] = $this->resolveWritableContext($request);
+        [$course, $session] = $this->resolveWritableContext();
         $rows = $this->buildExportRows($course, $session);
         $filename = 'course_progress_'.$course->getId().'.csv';
 
@@ -92,7 +94,7 @@ final readonly class CourseProgressCsvManager
      */
     public function import(Request $request): array
     {
-        [$course, $session] = $this->resolveWritableContext($request);
+        [$course, $session] = $this->resolveWritableContext();
         $this->validateCsrfToken((string) $request->request->get('csrfToken', ''));
 
         $file = $request->files->get('file');
@@ -176,11 +178,11 @@ final readonly class CourseProgressCsvManager
     /**
      * @return array{0: Course, 1: ?Session}
      */
-    private function resolveWritableContext(Request $request): array
+    private function resolveWritableContext(): array
     {
-        $course = $this->getCourseProgressCourse($request, $this->entityManager);
+        $course = $this->getCourseProgressCourse($this->cidReqHelper);
         $this->assertCourseProgressToolEnabled($this->entityManager, $course);
-        $session = $this->getCourseProgressSession($request, $this->entityManager);
+        $session = $this->getCourseProgressSession($this->cidReqHelper);
         $this->assertSessionBelongsToCourse($session, $course);
 
         if ($this->isCourseProgressStudentView($this->studentViewHelper, (int) $course->getId())

--- a/src/CoreBundle/State/CourseProgress/CourseProgressCsvManager.php
+++ b/src/CoreBundle/State/CourseProgress/CourseProgressCsvManager.php
@@ -9,6 +9,7 @@ namespace Chamilo\CoreBundle\State\CourseProgress;
 use Chamilo\CoreBundle\Entity\Course;
 use Chamilo\CoreBundle\Entity\Session;
 use Chamilo\CoreBundle\Entity\User;
+use Chamilo\CoreBundle\Helpers\StudentViewHelper;
 use Chamilo\CoreBundle\Repository\ResourceLinkRepository;
 use Chamilo\CoreBundle\Settings\SettingsManager;
 use Chamilo\CourseBundle\Entity\CThematic;
@@ -50,6 +51,7 @@ final readonly class CourseProgressCsvManager
         private Security $security,
         private SettingsManager $settingsManager,
         private CsrfTokenManagerInterface $csrfTokenManager,
+        private StudentViewHelper $studentViewHelper,
     ) {}
 
     public function export(Request $request): StreamedResponse
@@ -181,7 +183,7 @@ final readonly class CourseProgressCsvManager
         $session = $this->getCourseProgressSession($request, $this->entityManager);
         $this->assertSessionBelongsToCourse($session, $course);
 
-        if ($this->isCourseProgressStudentView($request, (int) $course->getId())
+        if ($this->isCourseProgressStudentView($this->studentViewHelper, (int) $course->getId())
             || !$this->canManageCourseProgress(
                 $this->entityManager,
                 $this->security,

--- a/src/CoreBundle/State/CourseProgress/CourseProgressListProvider.php
+++ b/src/CoreBundle/State/CourseProgress/CourseProgressListProvider.php
@@ -13,6 +13,7 @@ use Chamilo\CoreBundle\Entity\Course;
 use Chamilo\CoreBundle\Entity\ResourceLink;
 use Chamilo\CoreBundle\Entity\Session;
 use Chamilo\CoreBundle\Entity\User;
+use Chamilo\CoreBundle\Helpers\CidReqHelper;
 use Chamilo\CoreBundle\Helpers\StudentViewHelper;
 use Chamilo\CoreBundle\Settings\SettingsManager;
 use Chamilo\CourseBundle\Entity\CThematic;
@@ -47,6 +48,7 @@ final readonly class CourseProgressListProvider implements ProviderInterface
         private Security $security,
         private SettingsManager $settingsManager,
         private CsrfTokenManagerInterface $csrfTokenManager,
+        private CidReqHelper $cidReqHelper,
         private StudentViewHelper $studentViewHelper,
     ) {}
 
@@ -61,9 +63,9 @@ final readonly class CourseProgressListProvider implements ProviderInterface
             throw new BadRequestHttpException('The current request is required.');
         }
 
-        $course = $this->getCourseProgressCourse($request, $this->entityManager);
+        $course = $this->getCourseProgressCourse($this->cidReqHelper);
         $this->assertCourseProgressToolEnabled($this->entityManager, $course);
-        $session = $this->getCourseProgressSession($request, $this->entityManager);
+        $session = $this->getCourseProgressSession($this->cidReqHelper);
         $this->assertSessionBelongsToCourse($session, $course);
 
         if (!$this->canReadCourseProgress($this->security, $this->settingsManager, $course, $session)) {

--- a/src/CoreBundle/State/CourseProgress/CourseProgressListProvider.php
+++ b/src/CoreBundle/State/CourseProgress/CourseProgressListProvider.php
@@ -13,6 +13,7 @@ use Chamilo\CoreBundle\Entity\Course;
 use Chamilo\CoreBundle\Entity\ResourceLink;
 use Chamilo\CoreBundle\Entity\Session;
 use Chamilo\CoreBundle\Entity\User;
+use Chamilo\CoreBundle\Helpers\StudentViewHelper;
 use Chamilo\CoreBundle\Settings\SettingsManager;
 use Chamilo\CourseBundle\Entity\CThematic;
 use Chamilo\CourseBundle\Entity\CThematicAdvance;
@@ -46,6 +47,7 @@ final readonly class CourseProgressListProvider implements ProviderInterface
         private Security $security,
         private SettingsManager $settingsManager,
         private CsrfTokenManagerInterface $csrfTokenManager,
+        private StudentViewHelper $studentViewHelper,
     ) {}
 
     /**
@@ -68,7 +70,7 @@ final readonly class CourseProgressListProvider implements ProviderInterface
             throw new AccessDeniedHttpException('You are not allowed to view course progress in this context.');
         }
 
-        $studentView = $this->isCourseProgressStudentView($request, (int) $course->getId());
+        $studentView = $this->isCourseProgressStudentView($this->studentViewHelper, (int) $course->getId());
         $canManage = !$studentView && $this->canManageCourseProgress(
             $this->entityManager,
             $this->security,

--- a/src/CoreBundle/State/CourseProgress/CourseProgressPdfManager.php
+++ b/src/CoreBundle/State/CourseProgress/CourseProgressPdfManager.php
@@ -10,6 +10,7 @@ use Chamilo\CoreBundle\Component\Mpdf\SafeMpdfHttpClient;
 use Chamilo\CoreBundle\Entity\Course;
 use Chamilo\CoreBundle\Entity\Session;
 use Chamilo\CoreBundle\Entity\User;
+use Chamilo\CoreBundle\Helpers\CidReqHelper;
 use Chamilo\CoreBundle\Helpers\StudentViewHelper;
 use Chamilo\CoreBundle\Settings\SettingsManager;
 use Chamilo\CourseBundle\Entity\CThematic;
@@ -48,12 +49,13 @@ final readonly class CourseProgressPdfManager
         private Security $security,
         private SettingsManager $settingsManager,
         private TranslatorInterface $translator,
+        private CidReqHelper $cidReqHelper,
         private StudentViewHelper $studentViewHelper,
     ) {}
 
     public function export(Request $request, ?int $thematicId = null): Response
     {
-        [$course, $session] = $this->resolveWritableContext($request);
+        [$course, $session] = $this->resolveWritableContext();
         $thematics = $this->resolveThematics($course, $session, $thematicId);
         $dateFormatter = $this->createDateFormatter($request);
         $data = [];
@@ -97,11 +99,11 @@ final readonly class CourseProgressPdfManager
     /**
      * @return array{0: Course, 1: ?Session}
      */
-    private function resolveWritableContext(Request $request): array
+    private function resolveWritableContext(): array
     {
-        $course = $this->getCourseProgressCourse($request, $this->entityManager);
+        $course = $this->getCourseProgressCourse($this->cidReqHelper);
         $this->assertCourseProgressToolEnabled($this->entityManager, $course);
-        $session = $this->getCourseProgressSession($request, $this->entityManager);
+        $session = $this->getCourseProgressSession($this->cidReqHelper);
         $this->assertSessionBelongsToCourse($session, $course);
 
         if ($this->isCourseProgressStudentView($this->studentViewHelper, (int) $course->getId())

--- a/src/CoreBundle/State/CourseProgress/CourseProgressPdfManager.php
+++ b/src/CoreBundle/State/CourseProgress/CourseProgressPdfManager.php
@@ -10,6 +10,7 @@ use Chamilo\CoreBundle\Component\Mpdf\SafeMpdfHttpClient;
 use Chamilo\CoreBundle\Entity\Course;
 use Chamilo\CoreBundle\Entity\Session;
 use Chamilo\CoreBundle\Entity\User;
+use Chamilo\CoreBundle\Helpers\StudentViewHelper;
 use Chamilo\CoreBundle\Settings\SettingsManager;
 use Chamilo\CourseBundle\Entity\CThematic;
 use Chamilo\CourseBundle\Entity\CThematicAdvance;
@@ -47,6 +48,7 @@ final readonly class CourseProgressPdfManager
         private Security $security,
         private SettingsManager $settingsManager,
         private TranslatorInterface $translator,
+        private StudentViewHelper $studentViewHelper,
     ) {}
 
     public function export(Request $request, ?int $thematicId = null): Response
@@ -102,7 +104,7 @@ final readonly class CourseProgressPdfManager
         $session = $this->getCourseProgressSession($request, $this->entityManager);
         $this->assertSessionBelongsToCourse($session, $course);
 
-        if ($this->isCourseProgressStudentView($request, (int) $course->getId())
+        if ($this->isCourseProgressStudentView($this->studentViewHelper, (int) $course->getId())
             || !$this->canManageCourseProgress(
                 $this->entityManager,
                 $this->security,

--- a/src/CoreBundle/State/CourseProgress/CourseProgressThematicActionProcessor.php
+++ b/src/CoreBundle/State/CourseProgress/CourseProgressThematicActionProcessor.php
@@ -11,6 +11,7 @@ use ApiPlatform\State\ProcessorInterface;
 use Chamilo\CoreBundle\ApiResource\CourseProgress\CourseProgressThematicAction;
 use Chamilo\CoreBundle\Entity\Course;
 use Chamilo\CoreBundle\Entity\Session;
+use Chamilo\CoreBundle\Helpers\StudentViewHelper;
 use Chamilo\CoreBundle\Repository\ResourceLinkRepository;
 use Chamilo\CoreBundle\Settings\SettingsManager;
 use Chamilo\CourseBundle\Entity\CAttendance;
@@ -46,6 +47,7 @@ final readonly class CourseProgressThematicActionProcessor implements ProcessorI
         private Security $security,
         private SettingsManager $settingsManager,
         private CsrfTokenManagerInterface $csrfTokenManager,
+        private StudentViewHelper $studentViewHelper,
     ) {}
 
     /**
@@ -101,7 +103,7 @@ final readonly class CourseProgressThematicActionProcessor implements ProcessorI
 
     private function assertCanManage(Request $request, Course $course, ?Session $session): void
     {
-        if (!$this->isCourseProgressStudentView($request, (int) $course->getId())
+        if (!$this->isCourseProgressStudentView($this->studentViewHelper, (int) $course->getId())
             && $this->canManageCourseProgress(
                 $this->entityManager,
                 $this->security,

--- a/src/CoreBundle/State/CourseProgress/CourseProgressThematicActionProcessor.php
+++ b/src/CoreBundle/State/CourseProgress/CourseProgressThematicActionProcessor.php
@@ -11,6 +11,7 @@ use ApiPlatform\State\ProcessorInterface;
 use Chamilo\CoreBundle\ApiResource\CourseProgress\CourseProgressThematicAction;
 use Chamilo\CoreBundle\Entity\Course;
 use Chamilo\CoreBundle\Entity\Session;
+use Chamilo\CoreBundle\Helpers\CidReqHelper;
 use Chamilo\CoreBundle\Helpers\StudentViewHelper;
 use Chamilo\CoreBundle\Repository\ResourceLinkRepository;
 use Chamilo\CoreBundle\Settings\SettingsManager;
@@ -22,8 +23,6 @@ use Chamilo\CourseBundle\Repository\CAttendanceRepository;
 use Chamilo\CourseBundle\Repository\CThematicRepository;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\SecurityBundle\Security;
-use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
@@ -39,7 +38,6 @@ final readonly class CourseProgressThematicActionProcessor implements ProcessorI
     use CourseProgressAccessHelperTrait;
 
     public function __construct(
-        private RequestStack $requestStack,
         private EntityManagerInterface $entityManager,
         private CThematicRepository $thematicRepository,
         private CAttendanceRepository $attendanceRepository,
@@ -47,6 +45,7 @@ final readonly class CourseProgressThematicActionProcessor implements ProcessorI
         private Security $security,
         private SettingsManager $settingsManager,
         private CsrfTokenManagerInterface $csrfTokenManager,
+        private CidReqHelper $cidReqHelper,
         private StudentViewHelper $studentViewHelper,
     ) {}
 
@@ -64,16 +63,11 @@ final readonly class CourseProgressThematicActionProcessor implements ProcessorI
             throw new BadRequestHttpException('The request payload is invalid.');
         }
 
-        $request = $this->requestStack->getCurrentRequest();
-        if (!$request instanceof Request) {
-            throw new BadRequestHttpException('The current request is required.');
-        }
-
-        $course = $this->getCourseProgressCourse($request, $this->entityManager);
+        $course = $this->getCourseProgressCourse($this->cidReqHelper);
         $this->assertCourseProgressToolEnabled($this->entityManager, $course);
-        $session = $this->getCourseProgressSession($request, $this->entityManager);
+        $session = $this->getCourseProgressSession($this->cidReqHelper);
         $this->assertSessionBelongsToCourse($session, $course);
-        $this->assertCanManage($request, $course, $session);
+        $this->assertCanManage($course, $session);
         $this->validateCsrfToken($data->csrfToken);
 
         switch ($operation->getName()) {
@@ -101,7 +95,7 @@ final readonly class CourseProgressThematicActionProcessor implements ProcessorI
         return $data;
     }
 
-    private function assertCanManage(Request $request, Course $course, ?Session $session): void
+    private function assertCanManage(Course $course, ?Session $session): void
     {
         if (!$this->isCourseProgressStudentView($this->studentViewHelper, (int) $course->getId())
             && $this->canManageCourseProgress(

--- a/src/CoreBundle/State/CourseProgress/CourseProgressThematicAdvanceDeleteProcessor.php
+++ b/src/CoreBundle/State/CourseProgress/CourseProgressThematicAdvanceDeleteProcessor.php
@@ -11,6 +11,7 @@ use ApiPlatform\State\ProcessorInterface;
 use Chamilo\CoreBundle\ApiResource\CourseProgress\CourseProgressThematicAdvance;
 use Chamilo\CoreBundle\Entity\Course;
 use Chamilo\CoreBundle\Entity\Session;
+use Chamilo\CoreBundle\Helpers\CidReqHelper;
 use Chamilo\CoreBundle\Helpers\StudentViewHelper;
 use Chamilo\CoreBundle\Settings\SettingsManager;
 use Chamilo\CourseBundle\Entity\CThematic;
@@ -45,6 +46,7 @@ final readonly class CourseProgressThematicAdvanceDeleteProcessor implements Pro
         private Security $security,
         private SettingsManager $settingsManager,
         private CsrfTokenManagerInterface $csrfTokenManager,
+        private CidReqHelper $cidReqHelper,
         private StudentViewHelper $studentViewHelper,
     ) {}
 
@@ -59,11 +61,11 @@ final readonly class CourseProgressThematicAdvanceDeleteProcessor implements Pro
             throw new BadRequestHttpException('The current request is required.');
         }
 
-        $course = $this->getCourseProgressCourse($request, $this->entityManager);
+        $course = $this->getCourseProgressCourse($this->cidReqHelper);
         $this->assertCourseProgressToolEnabled($this->entityManager, $course);
-        $session = $this->getCourseProgressSession($request, $this->entityManager);
+        $session = $this->getCourseProgressSession($this->cidReqHelper);
         $this->assertSessionBelongsToCourse($session, $course);
-        $this->assertCanManage($request, $course, $session);
+        $this->assertCanManage($course, $session);
         $this->validateCsrfToken($this->getSubmittedCsrfToken($request));
 
         $thematicId = isset($uriVariables['thematicId'])
@@ -76,7 +78,7 @@ final readonly class CourseProgressThematicAdvanceDeleteProcessor implements Pro
         $this->thematicAdvanceRepository->delete($advance);
     }
 
-    private function assertCanManage(Request $request, Course $course, ?Session $session): void
+    private function assertCanManage(Course $course, ?Session $session): void
     {
         if (!$this->isCourseProgressStudentView($this->studentViewHelper, (int) $course->getId())
             && $this->canManageCourseProgress(

--- a/src/CoreBundle/State/CourseProgress/CourseProgressThematicAdvanceDeleteProcessor.php
+++ b/src/CoreBundle/State/CourseProgress/CourseProgressThematicAdvanceDeleteProcessor.php
@@ -11,6 +11,7 @@ use ApiPlatform\State\ProcessorInterface;
 use Chamilo\CoreBundle\ApiResource\CourseProgress\CourseProgressThematicAdvance;
 use Chamilo\CoreBundle\Entity\Course;
 use Chamilo\CoreBundle\Entity\Session;
+use Chamilo\CoreBundle\Helpers\StudentViewHelper;
 use Chamilo\CoreBundle\Settings\SettingsManager;
 use Chamilo\CourseBundle\Entity\CThematic;
 use Chamilo\CourseBundle\Entity\CThematicAdvance;
@@ -44,6 +45,7 @@ final readonly class CourseProgressThematicAdvanceDeleteProcessor implements Pro
         private Security $security,
         private SettingsManager $settingsManager,
         private CsrfTokenManagerInterface $csrfTokenManager,
+        private StudentViewHelper $studentViewHelper,
     ) {}
 
     /**
@@ -76,7 +78,7 @@ final readonly class CourseProgressThematicAdvanceDeleteProcessor implements Pro
 
     private function assertCanManage(Request $request, Course $course, ?Session $session): void
     {
-        if (!$this->isCourseProgressStudentView($request, (int) $course->getId())
+        if (!$this->isCourseProgressStudentView($this->studentViewHelper, (int) $course->getId())
             && $this->canManageCourseProgress(
                 $this->entityManager,
                 $this->security,

--- a/src/CoreBundle/State/CourseProgress/CourseProgressThematicAdvanceListProvider.php
+++ b/src/CoreBundle/State/CourseProgress/CourseProgressThematicAdvanceListProvider.php
@@ -12,6 +12,7 @@ use Chamilo\CoreBundle\ApiResource\CourseProgress\CourseProgressThematicAdvanceL
 use Chamilo\CoreBundle\Entity\Course;
 use Chamilo\CoreBundle\Entity\Session;
 use Chamilo\CoreBundle\Entity\User;
+use Chamilo\CoreBundle\Helpers\StudentViewHelper;
 use Chamilo\CoreBundle\Settings\SettingsManager;
 use Chamilo\CourseBundle\Entity\CThematic;
 use Chamilo\CourseBundle\Entity\CThematicAdvance;
@@ -48,6 +49,7 @@ final readonly class CourseProgressThematicAdvanceListProvider implements Provid
         private Security $security,
         private SettingsManager $settingsManager,
         private CsrfTokenManagerInterface $csrfTokenManager,
+        private StudentViewHelper $studentViewHelper,
     ) {}
 
     /**
@@ -111,7 +113,7 @@ final readonly class CourseProgressThematicAdvanceListProvider implements Provid
 
     private function assertCanManage(Request $request, Course $course, ?Session $session): void
     {
-        if (!$this->isCourseProgressStudentView($request, (int) $course->getId())
+        if (!$this->isCourseProgressStudentView($this->studentViewHelper, (int) $course->getId())
             && $this->canManageCourseProgress(
                 $this->entityManager,
                 $this->security,

--- a/src/CoreBundle/State/CourseProgress/CourseProgressThematicAdvanceListProvider.php
+++ b/src/CoreBundle/State/CourseProgress/CourseProgressThematicAdvanceListProvider.php
@@ -12,6 +12,7 @@ use Chamilo\CoreBundle\ApiResource\CourseProgress\CourseProgressThematicAdvanceL
 use Chamilo\CoreBundle\Entity\Course;
 use Chamilo\CoreBundle\Entity\Session;
 use Chamilo\CoreBundle\Entity\User;
+use Chamilo\CoreBundle\Helpers\CidReqHelper;
 use Chamilo\CoreBundle\Helpers\StudentViewHelper;
 use Chamilo\CoreBundle\Settings\SettingsManager;
 use Chamilo\CourseBundle\Entity\CThematic;
@@ -49,6 +50,7 @@ final readonly class CourseProgressThematicAdvanceListProvider implements Provid
         private Security $security,
         private SettingsManager $settingsManager,
         private CsrfTokenManagerInterface $csrfTokenManager,
+        private CidReqHelper $cidReqHelper,
         private StudentViewHelper $studentViewHelper,
     ) {}
 
@@ -63,11 +65,11 @@ final readonly class CourseProgressThematicAdvanceListProvider implements Provid
             throw new BadRequestHttpException('The current request is required.');
         }
 
-        $course = $this->getCourseProgressCourse($request, $this->entityManager);
+        $course = $this->getCourseProgressCourse($this->cidReqHelper);
         $this->assertCourseProgressToolEnabled($this->entityManager, $course);
-        $session = $this->getCourseProgressSession($request, $this->entityManager);
+        $session = $this->getCourseProgressSession($this->cidReqHelper);
         $this->assertSessionBelongsToCourse($session, $course);
-        $this->assertCanManage($request, $course, $session);
+        $this->assertCanManage($course, $session);
 
         $thematicId = isset($uriVariables['thematicId']) ? (int) $uriVariables['thematicId'] : 0;
         $thematic = $this->getEditableThematic($thematicId, $course, $session);
@@ -111,7 +113,7 @@ final readonly class CourseProgressThematicAdvanceListProvider implements Provid
         return $result;
     }
 
-    private function assertCanManage(Request $request, Course $course, ?Session $session): void
+    private function assertCanManage(Course $course, ?Session $session): void
     {
         if (!$this->isCourseProgressStudentView($this->studentViewHelper, (int) $course->getId())
             && $this->canManageCourseProgress(

--- a/src/CoreBundle/State/CourseProgress/CourseProgressThematicAdvanceProcessor.php
+++ b/src/CoreBundle/State/CourseProgress/CourseProgressThematicAdvanceProcessor.php
@@ -11,6 +11,7 @@ use ApiPlatform\State\ProcessorInterface;
 use Chamilo\CoreBundle\ApiResource\CourseProgress\CourseProgressThematicAdvance;
 use Chamilo\CoreBundle\Entity\Course;
 use Chamilo\CoreBundle\Entity\Session;
+use Chamilo\CoreBundle\Helpers\CidReqHelper;
 use Chamilo\CoreBundle\Helpers\StudentViewHelper;
 use Chamilo\CoreBundle\Settings\SettingsManager;
 use Chamilo\CourseBundle\Entity\CAttendance;
@@ -55,6 +56,7 @@ final readonly class CourseProgressThematicAdvanceProcessor implements Processor
         private Security $security,
         private SettingsManager $settingsManager,
         private CsrfTokenManagerInterface $csrfTokenManager,
+        private CidReqHelper $cidReqHelper,
         private StudentViewHelper $studentViewHelper,
     ) {}
 
@@ -77,11 +79,11 @@ final readonly class CourseProgressThematicAdvanceProcessor implements Processor
             throw new BadRequestHttpException('The current request is required.');
         }
 
-        $course = $this->getCourseProgressCourse($request, $this->entityManager);
+        $course = $this->getCourseProgressCourse($this->cidReqHelper);
         $this->assertCourseProgressToolEnabled($this->entityManager, $course);
-        $session = $this->getCourseProgressSession($request, $this->entityManager);
+        $session = $this->getCourseProgressSession($this->cidReqHelper);
         $this->assertSessionBelongsToCourse($session, $course);
-        $this->assertCanManage($request, $course, $session);
+        $this->assertCanManage($course, $session);
         $this->validateCsrfToken($data->csrfToken);
 
         $thematicId = isset($uriVariables['thematicId'])
@@ -178,7 +180,7 @@ final readonly class CourseProgressThematicAdvanceProcessor implements Processor
         $this->entityManager->flush();
     }
 
-    private function assertCanManage(Request $request, Course $course, ?Session $session): void
+    private function assertCanManage(Course $course, ?Session $session): void
     {
         if (!$this->isCourseProgressStudentView($this->studentViewHelper, (int) $course->getId())
             && $this->canManageCourseProgress(

--- a/src/CoreBundle/State/CourseProgress/CourseProgressThematicAdvanceProcessor.php
+++ b/src/CoreBundle/State/CourseProgress/CourseProgressThematicAdvanceProcessor.php
@@ -11,6 +11,7 @@ use ApiPlatform\State\ProcessorInterface;
 use Chamilo\CoreBundle\ApiResource\CourseProgress\CourseProgressThematicAdvance;
 use Chamilo\CoreBundle\Entity\Course;
 use Chamilo\CoreBundle\Entity\Session;
+use Chamilo\CoreBundle\Helpers\StudentViewHelper;
 use Chamilo\CoreBundle\Settings\SettingsManager;
 use Chamilo\CourseBundle\Entity\CAttendance;
 use Chamilo\CourseBundle\Entity\CAttendanceCalendar;
@@ -54,6 +55,7 @@ final readonly class CourseProgressThematicAdvanceProcessor implements Processor
         private Security $security,
         private SettingsManager $settingsManager,
         private CsrfTokenManagerInterface $csrfTokenManager,
+        private StudentViewHelper $studentViewHelper,
     ) {}
 
     /**
@@ -178,7 +180,7 @@ final readonly class CourseProgressThematicAdvanceProcessor implements Processor
 
     private function assertCanManage(Request $request, Course $course, ?Session $session): void
     {
-        if (!$this->isCourseProgressStudentView($request, (int) $course->getId())
+        if (!$this->isCourseProgressStudentView($this->studentViewHelper, (int) $course->getId())
             && $this->canManageCourseProgress(
                 $this->entityManager,
                 $this->security,

--- a/src/CoreBundle/State/CourseProgress/CourseProgressThematicAdvanceProvider.php
+++ b/src/CoreBundle/State/CourseProgress/CourseProgressThematicAdvanceProvider.php
@@ -12,6 +12,7 @@ use Chamilo\CoreBundle\ApiResource\CourseProgress\CourseProgressThematicAdvance;
 use Chamilo\CoreBundle\Entity\Course;
 use Chamilo\CoreBundle\Entity\Session;
 use Chamilo\CoreBundle\Entity\User;
+use Chamilo\CoreBundle\Helpers\StudentViewHelper;
 use Chamilo\CoreBundle\Settings\SettingsManager;
 use Chamilo\CourseBundle\Entity\CAttendance;
 use Chamilo\CourseBundle\Entity\CAttendanceCalendar;
@@ -56,6 +57,7 @@ final readonly class CourseProgressThematicAdvanceProvider implements ProviderIn
         private Security $security,
         private SettingsManager $settingsManager,
         private CsrfTokenManagerInterface $csrfTokenManager,
+        private StudentViewHelper $studentViewHelper,
     ) {}
 
     /**
@@ -93,7 +95,7 @@ final readonly class CourseProgressThematicAdvanceProvider implements ProviderIn
 
     private function assertCanManage(Request $request, Course $course, ?Session $session): void
     {
-        if (!$this->isCourseProgressStudentView($request, (int) $course->getId())
+        if (!$this->isCourseProgressStudentView($this->studentViewHelper, (int) $course->getId())
             && $this->canManageCourseProgress(
                 $this->entityManager,
                 $this->security,

--- a/src/CoreBundle/State/CourseProgress/CourseProgressThematicAdvanceProvider.php
+++ b/src/CoreBundle/State/CourseProgress/CourseProgressThematicAdvanceProvider.php
@@ -12,6 +12,7 @@ use Chamilo\CoreBundle\ApiResource\CourseProgress\CourseProgressThematicAdvance;
 use Chamilo\CoreBundle\Entity\Course;
 use Chamilo\CoreBundle\Entity\Session;
 use Chamilo\CoreBundle\Entity\User;
+use Chamilo\CoreBundle\Helpers\CidReqHelper;
 use Chamilo\CoreBundle\Helpers\StudentViewHelper;
 use Chamilo\CoreBundle\Settings\SettingsManager;
 use Chamilo\CourseBundle\Entity\CAttendance;
@@ -57,6 +58,7 @@ final readonly class CourseProgressThematicAdvanceProvider implements ProviderIn
         private Security $security,
         private SettingsManager $settingsManager,
         private CsrfTokenManagerInterface $csrfTokenManager,
+        private CidReqHelper $cidReqHelper,
         private StudentViewHelper $studentViewHelper,
     ) {}
 
@@ -71,11 +73,11 @@ final readonly class CourseProgressThematicAdvanceProvider implements ProviderIn
             throw new BadRequestHttpException('The current request is required.');
         }
 
-        $course = $this->getCourseProgressCourse($request, $this->entityManager);
+        $course = $this->getCourseProgressCourse($this->cidReqHelper);
         $this->assertCourseProgressToolEnabled($this->entityManager, $course);
-        $session = $this->getCourseProgressSession($request, $this->entityManager);
+        $session = $this->getCourseProgressSession($this->cidReqHelper);
         $this->assertSessionBelongsToCourse($session, $course);
-        $this->assertCanManage($request, $course, $session);
+        $this->assertCanManage($course, $session);
 
         $thematicId = isset($uriVariables['thematicId'])
             ? (int) $uriVariables['thematicId']
@@ -93,7 +95,7 @@ final readonly class CourseProgressThematicAdvanceProvider implements ProviderIn
         return $this->buildResponse($request, $course, $session, $thematic, $advance);
     }
 
-    private function assertCanManage(Request $request, Course $course, ?Session $session): void
+    private function assertCanManage(Course $course, ?Session $session): void
     {
         if (!$this->isCourseProgressStudentView($this->studentViewHelper, (int) $course->getId())
             && $this->canManageCourseProgress(

--- a/src/CoreBundle/State/CourseProgress/CourseProgressThematicDeleteProcessor.php
+++ b/src/CoreBundle/State/CourseProgress/CourseProgressThematicDeleteProcessor.php
@@ -11,6 +11,7 @@ use ApiPlatform\State\ProcessorInterface;
 use Chamilo\CoreBundle\ApiResource\CourseProgress\CourseProgressThematic;
 use Chamilo\CoreBundle\Entity\Course;
 use Chamilo\CoreBundle\Entity\Session;
+use Chamilo\CoreBundle\Helpers\StudentViewHelper;
 use Chamilo\CoreBundle\Repository\ResourceLinkRepository;
 use Chamilo\CoreBundle\Settings\SettingsManager;
 use Chamilo\CourseBundle\Entity\CThematic;
@@ -43,6 +44,7 @@ final readonly class CourseProgressThematicDeleteProcessor implements ProcessorI
         private Security $security,
         private SettingsManager $settingsManager,
         private CsrfTokenManagerInterface $csrfTokenManager,
+        private StudentViewHelper $studentViewHelper,
     ) {}
 
     /**
@@ -61,7 +63,7 @@ final readonly class CourseProgressThematicDeleteProcessor implements ProcessorI
         $session = $this->getCourseProgressSession($request, $this->entityManager);
         $this->assertSessionBelongsToCourse($session, $course);
 
-        if ($this->isCourseProgressStudentView($request, (int) $course->getId())
+        if ($this->isCourseProgressStudentView($this->studentViewHelper, (int) $course->getId())
             || !$this->canManageCourseProgress(
                 $this->entityManager,
                 $this->security,

--- a/src/CoreBundle/State/CourseProgress/CourseProgressThematicDeleteProcessor.php
+++ b/src/CoreBundle/State/CourseProgress/CourseProgressThematicDeleteProcessor.php
@@ -11,6 +11,7 @@ use ApiPlatform\State\ProcessorInterface;
 use Chamilo\CoreBundle\ApiResource\CourseProgress\CourseProgressThematic;
 use Chamilo\CoreBundle\Entity\Course;
 use Chamilo\CoreBundle\Entity\Session;
+use Chamilo\CoreBundle\Helpers\CidReqHelper;
 use Chamilo\CoreBundle\Helpers\StudentViewHelper;
 use Chamilo\CoreBundle\Repository\ResourceLinkRepository;
 use Chamilo\CoreBundle\Settings\SettingsManager;
@@ -44,6 +45,7 @@ final readonly class CourseProgressThematicDeleteProcessor implements ProcessorI
         private Security $security,
         private SettingsManager $settingsManager,
         private CsrfTokenManagerInterface $csrfTokenManager,
+        private CidReqHelper $cidReqHelper,
         private StudentViewHelper $studentViewHelper,
     ) {}
 
@@ -58,9 +60,9 @@ final readonly class CourseProgressThematicDeleteProcessor implements ProcessorI
             throw new BadRequestHttpException('The current request is required.');
         }
 
-        $course = $this->getCourseProgressCourse($request, $this->entityManager);
+        $course = $this->getCourseProgressCourse($this->cidReqHelper);
         $this->assertCourseProgressToolEnabled($this->entityManager, $course);
-        $session = $this->getCourseProgressSession($request, $this->entityManager);
+        $session = $this->getCourseProgressSession($this->cidReqHelper);
         $this->assertSessionBelongsToCourse($session, $course);
 
         if ($this->isCourseProgressStudentView($this->studentViewHelper, (int) $course->getId())

--- a/src/CoreBundle/State/CourseProgress/CourseProgressThematicPlanProcessor.php
+++ b/src/CoreBundle/State/CourseProgress/CourseProgressThematicPlanProcessor.php
@@ -11,6 +11,7 @@ use ApiPlatform\State\ProcessorInterface;
 use Chamilo\CoreBundle\ApiResource\CourseProgress\CourseProgressThematicPlan;
 use Chamilo\CoreBundle\Entity\Course;
 use Chamilo\CoreBundle\Entity\Session;
+use Chamilo\CoreBundle\Helpers\CidReqHelper;
 use Chamilo\CoreBundle\Helpers\StudentViewHelper;
 use Chamilo\CoreBundle\Settings\SettingsManager;
 use Chamilo\CourseBundle\Entity\CThematic;
@@ -18,8 +19,6 @@ use Chamilo\CourseBundle\Entity\CThematicPlan;
 use Chamilo\CourseBundle\Repository\CThematicRepository;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\SecurityBundle\Security;
-use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
@@ -64,12 +63,12 @@ final readonly class CourseProgressThematicPlanProcessor implements ProcessorInt
     ];
 
     public function __construct(
-        private RequestStack $requestStack,
         private EntityManagerInterface $entityManager,
         private CThematicRepository $thematicRepository,
         private Security $security,
         private SettingsManager $settingsManager,
         private CsrfTokenManagerInterface $csrfTokenManager,
+        private CidReqHelper $cidReqHelper,
         private StudentViewHelper $studentViewHelper,
     ) {}
 
@@ -87,16 +86,11 @@ final readonly class CourseProgressThematicPlanProcessor implements ProcessorInt
             throw new BadRequestHttpException('The request payload is invalid.');
         }
 
-        $request = $this->requestStack->getCurrentRequest();
-        if (!$request instanceof Request) {
-            throw new BadRequestHttpException('The current request is required.');
-        }
-
-        $course = $this->getCourseProgressCourse($request, $this->entityManager);
+        $course = $this->getCourseProgressCourse($this->cidReqHelper);
         $this->assertCourseProgressToolEnabled($this->entityManager, $course);
-        $session = $this->getCourseProgressSession($request, $this->entityManager);
+        $session = $this->getCourseProgressSession($this->cidReqHelper);
         $this->assertSessionBelongsToCourse($session, $course);
-        $this->assertCanManage($request, $course, $session);
+        $this->assertCanManage($course, $session);
         $this->validateCsrfToken($data->csrfToken);
 
         $thematicId = isset($uriVariables['thematicId']) ? (int) $uriVariables['thematicId'] : 0;
@@ -125,7 +119,7 @@ final readonly class CourseProgressThematicPlanProcessor implements ProcessorInt
         return $this->buildResponse($thematic);
     }
 
-    private function assertCanManage(Request $request, Course $course, ?Session $session): void
+    private function assertCanManage(Course $course, ?Session $session): void
     {
         if (!$this->isCourseProgressStudentView($this->studentViewHelper, (int) $course->getId())
             && $this->canManageCourseProgress(

--- a/src/CoreBundle/State/CourseProgress/CourseProgressThematicPlanProcessor.php
+++ b/src/CoreBundle/State/CourseProgress/CourseProgressThematicPlanProcessor.php
@@ -11,6 +11,7 @@ use ApiPlatform\State\ProcessorInterface;
 use Chamilo\CoreBundle\ApiResource\CourseProgress\CourseProgressThematicPlan;
 use Chamilo\CoreBundle\Entity\Course;
 use Chamilo\CoreBundle\Entity\Session;
+use Chamilo\CoreBundle\Helpers\StudentViewHelper;
 use Chamilo\CoreBundle\Settings\SettingsManager;
 use Chamilo\CourseBundle\Entity\CThematic;
 use Chamilo\CourseBundle\Entity\CThematicPlan;
@@ -69,6 +70,7 @@ final readonly class CourseProgressThematicPlanProcessor implements ProcessorInt
         private Security $security,
         private SettingsManager $settingsManager,
         private CsrfTokenManagerInterface $csrfTokenManager,
+        private StudentViewHelper $studentViewHelper,
     ) {}
 
     /**
@@ -125,7 +127,7 @@ final readonly class CourseProgressThematicPlanProcessor implements ProcessorInt
 
     private function assertCanManage(Request $request, Course $course, ?Session $session): void
     {
-        if (!$this->isCourseProgressStudentView($request, (int) $course->getId())
+        if (!$this->isCourseProgressStudentView($this->studentViewHelper, (int) $course->getId())
             && $this->canManageCourseProgress(
                 $this->entityManager,
                 $this->security,

--- a/src/CoreBundle/State/CourseProgress/CourseProgressThematicPlanProvider.php
+++ b/src/CoreBundle/State/CourseProgress/CourseProgressThematicPlanProvider.php
@@ -11,6 +11,7 @@ use ApiPlatform\State\ProviderInterface;
 use Chamilo\CoreBundle\ApiResource\CourseProgress\CourseProgressThematicPlan;
 use Chamilo\CoreBundle\Entity\Course;
 use Chamilo\CoreBundle\Entity\Session;
+use Chamilo\CoreBundle\Helpers\StudentViewHelper;
 use Chamilo\CoreBundle\Settings\SettingsManager;
 use Chamilo\CourseBundle\Entity\CThematic;
 use Chamilo\CourseBundle\Entity\CThematicPlan;
@@ -67,6 +68,7 @@ final readonly class CourseProgressThematicPlanProvider implements ProviderInter
         private Security $security,
         private SettingsManager $settingsManager,
         private CsrfTokenManagerInterface $csrfTokenManager,
+        private StudentViewHelper $studentViewHelper,
     ) {}
 
     /**
@@ -94,7 +96,7 @@ final readonly class CourseProgressThematicPlanProvider implements ProviderInter
 
     private function assertCanManage(Request $request, Course $course, ?Session $session): void
     {
-        if (!$this->isCourseProgressStudentView($request, (int) $course->getId())
+        if (!$this->isCourseProgressStudentView($this->studentViewHelper, (int) $course->getId())
             && $this->canManageCourseProgress(
                 $this->entityManager,
                 $this->security,

--- a/src/CoreBundle/State/CourseProgress/CourseProgressThematicPlanProvider.php
+++ b/src/CoreBundle/State/CourseProgress/CourseProgressThematicPlanProvider.php
@@ -11,6 +11,7 @@ use ApiPlatform\State\ProviderInterface;
 use Chamilo\CoreBundle\ApiResource\CourseProgress\CourseProgressThematicPlan;
 use Chamilo\CoreBundle\Entity\Course;
 use Chamilo\CoreBundle\Entity\Session;
+use Chamilo\CoreBundle\Helpers\CidReqHelper;
 use Chamilo\CoreBundle\Helpers\StudentViewHelper;
 use Chamilo\CoreBundle\Settings\SettingsManager;
 use Chamilo\CourseBundle\Entity\CThematic;
@@ -18,8 +19,6 @@ use Chamilo\CourseBundle\Entity\CThematicPlan;
 use Chamilo\CourseBundle\Repository\CThematicRepository;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\SecurityBundle\Security;
-use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
@@ -62,12 +61,12 @@ final readonly class CourseProgressThematicPlanProvider implements ProviderInter
     ];
 
     public function __construct(
-        private RequestStack $requestStack,
         private EntityManagerInterface $entityManager,
         private CThematicRepository $thematicRepository,
         private Security $security,
         private SettingsManager $settingsManager,
         private CsrfTokenManagerInterface $csrfTokenManager,
+        private CidReqHelper $cidReqHelper,
         private StudentViewHelper $studentViewHelper,
     ) {}
 
@@ -77,16 +76,11 @@ final readonly class CourseProgressThematicPlanProvider implements ProviderInter
      */
     public function provide(Operation $operation, array $uriVariables = [], array $context = []): CourseProgressThematicPlan
     {
-        $request = $this->requestStack->getCurrentRequest();
-        if (!$request instanceof Request) {
-            throw new BadRequestHttpException('The current request is required.');
-        }
-
-        $course = $this->getCourseProgressCourse($request, $this->entityManager);
+        $course = $this->getCourseProgressCourse($this->cidReqHelper);
         $this->assertCourseProgressToolEnabled($this->entityManager, $course);
-        $session = $this->getCourseProgressSession($request, $this->entityManager);
+        $session = $this->getCourseProgressSession($this->cidReqHelper);
         $this->assertSessionBelongsToCourse($session, $course);
-        $this->assertCanManage($request, $course, $session);
+        $this->assertCanManage($course, $session);
 
         $thematicId = isset($uriVariables['thematicId']) ? (int) $uriVariables['thematicId'] : 0;
         $thematic = $this->getEditableThematic($thematicId, $course, $session);
@@ -94,7 +88,7 @@ final readonly class CourseProgressThematicPlanProvider implements ProviderInter
         return $this->buildResponse($thematic);
     }
 
-    private function assertCanManage(Request $request, Course $course, ?Session $session): void
+    private function assertCanManage(Course $course, ?Session $session): void
     {
         if (!$this->isCourseProgressStudentView($this->studentViewHelper, (int) $course->getId())
             && $this->canManageCourseProgress(

--- a/src/CoreBundle/State/CourseProgress/CourseProgressThematicProcessor.php
+++ b/src/CoreBundle/State/CourseProgress/CourseProgressThematicProcessor.php
@@ -13,14 +13,13 @@ use Chamilo\CoreBundle\ApiResource\CourseProgress\CourseProgressThematic;
 use Chamilo\CoreBundle\Entity\Course;
 use Chamilo\CoreBundle\Entity\Language;
 use Chamilo\CoreBundle\Entity\Session;
+use Chamilo\CoreBundle\Helpers\CidReqHelper;
 use Chamilo\CoreBundle\Helpers\StudentViewHelper;
 use Chamilo\CoreBundle\Settings\SettingsManager;
 use Chamilo\CourseBundle\Entity\CThematic;
 use Chamilo\CourseBundle\Repository\CThematicRepository;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\SecurityBundle\Security;
-use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
@@ -39,12 +38,12 @@ final readonly class CourseProgressThematicProcessor implements ProcessorInterfa
     use CourseProgressAccessHelperTrait;
 
     public function __construct(
-        private RequestStack $requestStack,
         private EntityManagerInterface $entityManager,
         private CThematicRepository $thematicRepository,
         private Security $security,
         private SettingsManager $settingsManager,
         private CsrfTokenManagerInterface $csrfTokenManager,
+        private CidReqHelper $cidReqHelper,
         private StudentViewHelper $studentViewHelper,
     ) {}
 
@@ -58,14 +57,9 @@ final readonly class CourseProgressThematicProcessor implements ProcessorInterfa
             throw new BadRequestHttpException('The request payload is invalid.');
         }
 
-        $request = $this->requestStack->getCurrentRequest();
-        if (!$request instanceof Request) {
-            throw new BadRequestHttpException('The current request is required.');
-        }
-
-        $course = $this->getCourseProgressCourse($request, $this->entityManager);
+        $course = $this->getCourseProgressCourse($this->cidReqHelper);
         $this->assertCourseProgressToolEnabled($this->entityManager, $course);
-        $session = $this->getCourseProgressSession($request, $this->entityManager);
+        $session = $this->getCourseProgressSession($this->cidReqHelper);
         $this->assertSessionBelongsToCourse($session, $course);
 
         if ($this->isCourseProgressStudentView($this->studentViewHelper, (int) $course->getId())

--- a/src/CoreBundle/State/CourseProgress/CourseProgressThematicProcessor.php
+++ b/src/CoreBundle/State/CourseProgress/CourseProgressThematicProcessor.php
@@ -13,6 +13,7 @@ use Chamilo\CoreBundle\ApiResource\CourseProgress\CourseProgressThematic;
 use Chamilo\CoreBundle\Entity\Course;
 use Chamilo\CoreBundle\Entity\Language;
 use Chamilo\CoreBundle\Entity\Session;
+use Chamilo\CoreBundle\Helpers\StudentViewHelper;
 use Chamilo\CoreBundle\Settings\SettingsManager;
 use Chamilo\CourseBundle\Entity\CThematic;
 use Chamilo\CourseBundle\Repository\CThematicRepository;
@@ -44,6 +45,7 @@ final readonly class CourseProgressThematicProcessor implements ProcessorInterfa
         private Security $security,
         private SettingsManager $settingsManager,
         private CsrfTokenManagerInterface $csrfTokenManager,
+        private StudentViewHelper $studentViewHelper,
     ) {}
 
     /**
@@ -66,7 +68,7 @@ final readonly class CourseProgressThematicProcessor implements ProcessorInterfa
         $session = $this->getCourseProgressSession($request, $this->entityManager);
         $this->assertSessionBelongsToCourse($session, $course);
 
-        if ($this->isCourseProgressStudentView($request, (int) $course->getId())
+        if ($this->isCourseProgressStudentView($this->studentViewHelper, (int) $course->getId())
             || !$this->canManageCourseProgress(
                 $this->entityManager,
                 $this->security,

--- a/src/CoreBundle/State/CourseProgress/CourseProgressThematicProvider.php
+++ b/src/CoreBundle/State/CourseProgress/CourseProgressThematicProvider.php
@@ -12,6 +12,7 @@ use Chamilo\CoreBundle\ApiResource\CourseProgress\CourseProgressThematic;
 use Chamilo\CoreBundle\Entity\Course;
 use Chamilo\CoreBundle\Entity\Language;
 use Chamilo\CoreBundle\Entity\Session;
+use Chamilo\CoreBundle\Helpers\StudentViewHelper;
 use Chamilo\CoreBundle\Settings\SettingsManager;
 use Chamilo\CourseBundle\Entity\CThematic;
 use Chamilo\CourseBundle\Repository\CThematicRepository;
@@ -40,6 +41,7 @@ final readonly class CourseProgressThematicProvider implements ProviderInterface
         private Security $security,
         private SettingsManager $settingsManager,
         private CsrfTokenManagerInterface $csrfTokenManager,
+        private StudentViewHelper $studentViewHelper,
     ) {}
 
     /**
@@ -58,7 +60,7 @@ final readonly class CourseProgressThematicProvider implements ProviderInterface
         $session = $this->getCourseProgressSession($request, $this->entityManager);
         $this->assertSessionBelongsToCourse($session, $course);
 
-        if ($this->isCourseProgressStudentView($request, (int) $course->getId())
+        if ($this->isCourseProgressStudentView($this->studentViewHelper, (int) $course->getId())
             || !$this->canManageCourseProgress(
                 $this->entityManager,
                 $this->security,

--- a/src/CoreBundle/State/CourseProgress/CourseProgressThematicProvider.php
+++ b/src/CoreBundle/State/CourseProgress/CourseProgressThematicProvider.php
@@ -12,6 +12,7 @@ use Chamilo\CoreBundle\ApiResource\CourseProgress\CourseProgressThematic;
 use Chamilo\CoreBundle\Entity\Course;
 use Chamilo\CoreBundle\Entity\Language;
 use Chamilo\CoreBundle\Entity\Session;
+use Chamilo\CoreBundle\Helpers\CidReqHelper;
 use Chamilo\CoreBundle\Helpers\StudentViewHelper;
 use Chamilo\CoreBundle\Settings\SettingsManager;
 use Chamilo\CourseBundle\Entity\CThematic;
@@ -41,6 +42,7 @@ final readonly class CourseProgressThematicProvider implements ProviderInterface
         private Security $security,
         private SettingsManager $settingsManager,
         private CsrfTokenManagerInterface $csrfTokenManager,
+        private CidReqHelper $cidReqHelper,
         private StudentViewHelper $studentViewHelper,
     ) {}
 
@@ -55,9 +57,9 @@ final readonly class CourseProgressThematicProvider implements ProviderInterface
             throw new BadRequestHttpException('The current request is required.');
         }
 
-        $course = $this->getCourseProgressCourse($request, $this->entityManager);
+        $course = $this->getCourseProgressCourse($this->cidReqHelper);
         $this->assertCourseProgressToolEnabled($this->entityManager, $course);
-        $session = $this->getCourseProgressSession($request, $this->entityManager);
+        $session = $this->getCourseProgressSession($this->cidReqHelper);
         $this->assertSessionBelongsToCourse($session, $course);
 
         if ($this->isCourseProgressStudentView($this->studentViewHelper, (int) $course->getId())

--- a/src/CoreBundle/State/CourseUser/CourseUserActionProcessor.php
+++ b/src/CoreBundle/State/CourseUser/CourseUserActionProcessor.php
@@ -48,7 +48,7 @@ final readonly class CourseUserActionProcessor implements ProcessorInterface
             throw new AccessDeniedHttpException('The CSRF token is invalid.');
         }
 
-        [$course, $session] = $this->courseUserManager->resolveContext($request);
+        [$course, $session] = $this->courseUserManager->resolveContext();
         $type = $this->courseUserManager->normalizeType($request);
         $operationName = (string) $operation->getName();
 

--- a/src/CoreBundle/State/CourseUser/CourseUserImportProcessor.php
+++ b/src/CoreBundle/State/CourseUser/CourseUserImportProcessor.php
@@ -50,7 +50,7 @@ final readonly class CourseUserImportProcessor implements ProcessorInterface
             throw new AccessDeniedHttpException('The CSRF token is invalid.');
         }
 
-        [$course, $session] = $this->courseUserManager->resolveContext($request);
+        [$course, $session] = $this->courseUserManager->resolveContext();
         $this->courseUserManager->assertCanManage($course, $session);
         if (!$this->courseUserManager->canUnsubscribe($course, $session)) {
             throw new AccessDeniedHttpException('Course user import is disabled for the current manager.');

--- a/src/CoreBundle/State/CourseUser/CourseUserImportProvider.php
+++ b/src/CoreBundle/State/CourseUser/CourseUserImportProvider.php
@@ -9,9 +9,7 @@ namespace Chamilo\CoreBundle\State\CourseUser;
 use ApiPlatform\Metadata\Operation;
 use ApiPlatform\State\ProviderInterface;
 use Chamilo\CoreBundle\ApiResource\CourseUser\CourseUserImport;
-use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
-use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 use Symfony\Component\Security\Csrf\CsrfTokenManagerInterface;
 
 /**
@@ -20,7 +18,6 @@ use Symfony\Component\Security\Csrf\CsrfTokenManagerInterface;
 final readonly class CourseUserImportProvider implements ProviderInterface
 {
     public function __construct(
-        private RequestStack $requestStack,
         private CourseUserManager $courseUserManager,
         private CsrfTokenManagerInterface $csrfTokenManager,
     ) {}
@@ -31,12 +28,7 @@ final readonly class CourseUserImportProvider implements ProviderInterface
      */
     public function provide(Operation $operation, array $uriVariables = [], array $context = []): CourseUserImport
     {
-        $request = $this->requestStack->getCurrentRequest();
-        if (null === $request) {
-            throw new BadRequestHttpException('The current request is required.');
-        }
-
-        [$course, $session] = $this->courseUserManager->resolveContext($request);
+        [$course, $session] = $this->courseUserManager->resolveContext();
         $this->courseUserManager->assertCanManage($course, $session);
         if (!$this->courseUserManager->canUnsubscribe($course, $session)) {
             throw new AccessDeniedHttpException('Course user import is disabled for the current manager.');

--- a/src/CoreBundle/State/CourseUser/CourseUserManager.php
+++ b/src/CoreBundle/State/CourseUser/CourseUserManager.php
@@ -10,6 +10,7 @@ use Chamilo\CoreBundle\Entity\Course;
 use Chamilo\CoreBundle\Entity\CourseRelUser;
 use Chamilo\CoreBundle\Entity\Session;
 use Chamilo\CoreBundle\Entity\User;
+use Chamilo\CoreBundle\Helpers\CidReqHelper;
 use Chamilo\CoreBundle\Repository\Node\IllustrationRepository;
 use Chamilo\CoreBundle\Settings\SettingsManager;
 use CourseManager;
@@ -37,35 +38,22 @@ final readonly class CourseUserManager
         private Security $security,
         private SettingsManager $settingsManager,
         private IllustrationRepository $illustrationRepository,
+        private CidReqHelper $cidReqHelper,
     ) {}
 
     /**
      * @return array{0: Course, 1: Session|null}
      */
-    public function resolveContext(Request $request): array
+    public function resolveContext(): array
     {
-        $courseId = $request->query->getInt('cid');
-        if ($courseId <= 0) {
-            throw new BadRequestHttpException('A valid course id is required.');
-        }
+        $course = $this->cidReqHelper->getDoctrineCourseEntity()
+            ?? throw new BadRequestHttpException('A valid course id is required.');
 
-        $course = $this->entityManager->getRepository(Course::class)->find($courseId);
-        if (!$course instanceof Course) {
-            throw new BadRequestHttpException('The requested course was not found.');
-        }
-
-        $sessionId = $request->query->getInt('sid');
-        $session = null;
-
-        if ($sessionId > 0) {
-            $session = $this->entityManager->getRepository(Session::class)->find($sessionId);
-            if (!$session instanceof Session) {
-                throw new BadRequestHttpException('The requested session was not found.');
-            }
-
-            if (!$session->hasCourse($course)) {
-                throw new AccessDeniedHttpException('The requested session does not contain the current course.');
-            }
+        // SessionVoter only proves the course/session pairing for students and course coaches,
+        // so assert it here for general coaches and admins too.
+        $session = $this->cidReqHelper->getDoctrineSessionEntity();
+        if ($session instanceof Session && !$session->hasCourse($course)) {
+            throw new AccessDeniedHttpException('The requested session does not contain the current course.');
         }
 
         return [$course, $session];
@@ -212,7 +200,7 @@ final readonly class CourseUserManager
      */
     public function getListData(Request $request): array
     {
-        [$course, $session] = $this->resolveContext($request);
+        [$course, $session] = $this->resolveContext();
         $this->assertCanRead($course, $session);
 
         $type = $this->normalizeType($request);
@@ -291,7 +279,7 @@ final readonly class CourseUserManager
             'showClasses' => $this->canManageClasses($course, $session),
             'showSubscriptionTabs' => $this->canShowSubscriptionTabs($course, $session),
             'groupsUrl' => $this->buildLegacyUrl('/main/group/group.php', $course, $session, [
-                'gid' => $request->query->getInt('gid'),
+                'gid' => (int) ($this->cidReqHelper->getGroupId() ?? 0),
             ]),
         ];
     }
@@ -301,7 +289,7 @@ final readonly class CourseUserManager
      */
     public function getAvailableData(Request $request): array
     {
-        [$course, $session] = $this->resolveContext($request);
+        [$course, $session] = $this->resolveContext();
         $this->assertCanManage($course, $session);
         if (!$this->canSubscribe($course, $session)) {
             throw new AccessDeniedHttpException('Course user subscription is disabled for the current manager.');
@@ -365,7 +353,7 @@ final readonly class CourseUserManager
             'showSubscriptionTabs' => $this->canShowSubscriptionTabs($course, $session),
             'showClasses' => $this->canManageClasses($course, $session),
             'groupsUrl' => $this->buildLegacyUrl('/main/group/group.php', $course, $session, [
-                'gid' => $request->query->getInt('gid'),
+                'gid' => (int) ($this->cidReqHelper->getGroupId() ?? 0),
             ]),
             'canSubscribe' => $this->canSubscribe($course, $session)
                 && (self::TYPE_TEACHER === $type || '' === $this->getLimitWarning($course, $session)),

--- a/src/CoreBundle/State/Forum/ForumCategoryCollectionStateProvider.php
+++ b/src/CoreBundle/State/Forum/ForumCategoryCollectionStateProvider.php
@@ -13,6 +13,7 @@ use Chamilo\CoreBundle\Entity\ExtraField;
 use Chamilo\CoreBundle\Entity\ExtraFieldValues;
 use Chamilo\CoreBundle\Entity\Session;
 use Chamilo\CoreBundle\Helpers\CidReqHelper;
+use Chamilo\CoreBundle\Helpers\StudentViewHelper;
 use Chamilo\CoreBundle\Repository\ExtraFieldRepository;
 use Chamilo\CoreBundle\Repository\ExtraFieldValuesRepository;
 use Chamilo\CoreBundle\Settings\SettingsManager;
@@ -39,6 +40,7 @@ final class ForumCategoryCollectionStateProvider implements ProviderInterface
         private readonly ExtraFieldRepository $extraFieldRepository,
         private readonly ExtraFieldValuesRepository $extraFieldValuesRepository,
         private readonly CidReqHelper $cidReqHelper,
+        private readonly StudentViewHelper $studentViewHelper,
     ) {}
 
     /**
@@ -81,7 +83,7 @@ final class ForumCategoryCollectionStateProvider implements ProviderInterface
         $session = $this->cidReqHelper->getDoctrineSessionEntity();
         $group = $this->getGroup($this->entityManager, $this->cidReqHelper);
         $parentNode = $this->getParentNode($this->entityManager, $request);
-        $showHidden = $this->canManageForumsInCurrentView($this->security, $request);
+        $showHidden = $this->canManageForumsInCurrentView($this->security, $this->studentViewHelper);
         $languageField = $this->getForumCategoryLanguageField();
         $selectedLanguages = $this->getSelectedLanguageFilterValues($request);
 

--- a/src/CoreBundle/State/Forum/ForumCollectionStateProvider.php
+++ b/src/CoreBundle/State/Forum/ForumCollectionStateProvider.php
@@ -13,6 +13,7 @@ use Chamilo\CoreBundle\Entity\ResourceNode;
 use Chamilo\CoreBundle\Entity\Session;
 use Chamilo\CoreBundle\Entity\User;
 use Chamilo\CoreBundle\Helpers\CidReqHelper;
+use Chamilo\CoreBundle\Helpers\StudentViewHelper;
 use Chamilo\CoreBundle\Settings\SettingsManager;
 use Chamilo\CourseBundle\Entity\CForum;
 use Chamilo\CourseBundle\Entity\CForumCategory;
@@ -44,6 +45,7 @@ final class ForumCollectionStateProvider implements ProviderInterface
         private readonly Security $security,
         private readonly SettingsManager $settingsManager,
         private readonly CidReqHelper $cidReqHelper,
+        private readonly StudentViewHelper $studentViewHelper,
     ) {}
 
     /**
@@ -86,7 +88,7 @@ final class ForumCollectionStateProvider implements ProviderInterface
         $session = $this->cidReqHelper->getDoctrineSessionEntity();
         $group = $this->getGroup($this->entityManager, $this->cidReqHelper);
         $parentNode = $this->getParentNode($this->entityManager, $request);
-        $showHidden = $this->canManageForumsInCurrentView($this->security, $request);
+        $showHidden = $this->canManageForumsInCurrentView($this->security, $this->studentViewHelper);
         $user = $this->getCurrentUser();
         $displayGroupForums = $this->shouldDisplayGroupForumsInGeneralTool($this->cidReqHelper);
 

--- a/src/CoreBundle/State/Forum/ForumGradingOptionsProvider.php
+++ b/src/CoreBundle/State/Forum/ForumGradingOptionsProvider.php
@@ -11,6 +11,7 @@ use ApiPlatform\State\ProviderInterface;
 use Chamilo\CoreBundle\ApiResource\Forum\ForumGradingOptions;
 use Chamilo\CoreBundle\Entity\GradebookCategory;
 use Chamilo\CoreBundle\Helpers\CidReqHelper;
+use Chamilo\CoreBundle\Helpers\StudentViewHelper;
 use Chamilo\CoreBundle\Repository\GradeBookCategoryRepository;
 use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\HttpFoundation\RequestStack;
@@ -28,6 +29,7 @@ final class ForumGradingOptionsProvider implements ProviderInterface
         private readonly Security $security,
         private readonly GradeBookCategoryRepository $gradeBookCategoryRepository,
         private readonly CidReqHelper $cidReqHelper,
+        private readonly StudentViewHelper $studentViewHelper,
     ) {}
 
     /**
@@ -41,7 +43,7 @@ final class ForumGradingOptionsProvider implements ProviderInterface
             return ForumGradingOptions::fromCategories([]);
         }
 
-        if (!$this->canManageForumsInCurrentView($this->security, $request)) {
+        if (!$this->canManageForumsInCurrentView($this->security, $this->studentViewHelper)) {
             throw new AccessDeniedHttpException('You are not allowed to manage forum grading.');
         }
 

--- a/src/CoreBundle/State/Forum/ForumSearchStateProvider.php
+++ b/src/CoreBundle/State/Forum/ForumSearchStateProvider.php
@@ -13,6 +13,7 @@ use Chamilo\CoreBundle\Entity\AbstractResource;
 use Chamilo\CoreBundle\Entity\Course;
 use Chamilo\CoreBundle\Entity\Session;
 use Chamilo\CoreBundle\Helpers\CidReqHelper;
+use Chamilo\CoreBundle\Helpers\StudentViewHelper;
 use Chamilo\CoreBundle\Settings\SettingsManager;
 use Chamilo\CourseBundle\Entity\CForum;
 use Chamilo\CourseBundle\Entity\CForumCategory;
@@ -45,6 +46,7 @@ final class ForumSearchStateProvider implements ProviderInterface
         private readonly Security $security,
         private readonly SettingsManager $settingsManager,
         private readonly CidReqHelper $cidReqHelper,
+        private readonly StudentViewHelper $studentViewHelper,
     ) {}
 
     /**
@@ -90,7 +92,7 @@ final class ForumSearchStateProvider implements ProviderInterface
 
         $course = $this->getCourse($this->cidReqHelper);
         $session = $this->cidReqHelper->getDoctrineSessionEntity();
-        $showHidden = $this->canManageForumsInCurrentView($this->security, $request);
+        $showHidden = $this->canManageForumsInCurrentView($this->security, $this->studentViewHelper);
         $displayGroupForums = $this->shouldDisplayGroupForumsInGeneralTool($this->cidReqHelper);
         $terms = $this->getSearchTerms($query);
         if ([] === $terms) {

--- a/src/CoreBundle/State/Forum/ForumStateHelperTrait.php
+++ b/src/CoreBundle/State/Forum/ForumStateHelperTrait.php
@@ -11,6 +11,7 @@ use Chamilo\CoreBundle\Entity\Course;
 use Chamilo\CoreBundle\Entity\ResourceNode;
 use Chamilo\CoreBundle\Entity\Session;
 use Chamilo\CoreBundle\Helpers\CidReqHelper;
+use Chamilo\CoreBundle\Helpers\StudentViewHelper;
 use Chamilo\CourseBundle\Entity\CForum;
 use Chamilo\CourseBundle\Entity\CGroup;
 use DateTimeImmutable;
@@ -46,14 +47,9 @@ trait ForumStateHelperTrait
             || $security->isGranted('ROLE_ADMIN');
     }
 
-    private function isStudentView(Request $request): bool
+    private function canManageForumsInCurrentView(Security $security, StudentViewHelper $studentViewHelper): bool
     {
-        return 'studentview' === $request->getSession()->get('studentview');
-    }
-
-    private function canManageForumsInCurrentView(Security $security, Request $request): bool
-    {
-        return $this->isTeacher($security) && !$this->isStudentView($request);
+        return $studentViewHelper->canManageInCurrentView($this->isTeacher($security));
     }
 
     /**

--- a/src/CoreBundle/State/Forum/ForumThreadCollectionStateProvider.php
+++ b/src/CoreBundle/State/Forum/ForumThreadCollectionStateProvider.php
@@ -13,6 +13,7 @@ use Chamilo\CoreBundle\Entity\Course;
 use Chamilo\CoreBundle\Entity\Session;
 use Chamilo\CoreBundle\Entity\User;
 use Chamilo\CoreBundle\Helpers\CidReqHelper;
+use Chamilo\CoreBundle\Helpers\StudentViewHelper;
 use Chamilo\CoreBundle\Repository\Node\IllustrationRepository;
 use Chamilo\CoreBundle\Security\Authorization\Voter\ResourceNodeVoter;
 use Chamilo\CoreBundle\Security\CourseAccessResolver;
@@ -56,6 +57,7 @@ final class ForumThreadCollectionStateProvider implements ProviderInterface
         private readonly IllustrationRepository $illustrationRepository,
         private readonly CourseAccessResolver $courseAccessResolver,
         private readonly CidReqHelper $cidReqHelper,
+        private readonly StudentViewHelper $studentViewHelper,
     ) {}
 
     /**
@@ -112,7 +114,7 @@ final class ForumThreadCollectionStateProvider implements ProviderInterface
             throw new AccessDeniedHttpException('You are not allowed to access this forum category.');
         }
 
-        $showHidden = $this->canManageForumsInCurrentView($this->security, $request);
+        $showHidden = $this->canManageForumsInCurrentView($this->security, $this->studentViewHelper);
         $showPosterAvatar = $this->arePosterImagesAllowed($course);
         $user = $this->getCurrentUser();
         $canSubscribe = !$this->areForumPostNotificationsHidden($course);

--- a/src/CoreBundle/State/Forum/ForumThreadGradingProcessor.php
+++ b/src/CoreBundle/State/Forum/ForumThreadGradingProcessor.php
@@ -16,6 +16,7 @@ use Chamilo\CoreBundle\Entity\Session;
 use Chamilo\CoreBundle\Entity\SessionRelCourseRelUser;
 use Chamilo\CoreBundle\Entity\User;
 use Chamilo\CoreBundle\Helpers\CidReqHelper;
+use Chamilo\CoreBundle\Helpers\StudentViewHelper;
 use Chamilo\CoreBundle\Settings\SettingsManager;
 use Chamilo\CourseBundle\Entity\CForum;
 use Chamilo\CourseBundle\Entity\CForumPost;
@@ -56,6 +57,7 @@ final class ForumThreadGradingProcessor implements ProcessorInterface
         private readonly CsrfTokenManagerInterface $csrfTokenManager,
         private readonly SettingsManager $settingsManager,
         private readonly CidReqHelper $cidReqHelper,
+        private readonly StudentViewHelper $studentViewHelper,
     ) {}
 
     public function process(mixed $data, Operation $operation, array $uriVariables = [], array $context = []): JsonResponse
@@ -188,7 +190,7 @@ final class ForumThreadGradingProcessor implements ProcessorInterface
 
         $this->assertForumThreadNotLockedByGradebook($this->entityManager, $this->settingsManager, $this->security, $course, $thread);
 
-        $canManage = $this->canManageForumsInCurrentView($this->security, $request);
+        $canManage = $this->canManageForumsInCurrentView($this->security, $this->studentViewHelper);
         if ($canManage) {
             $this->assertEditableForumResource($thread->getResourceNode(), $this->security);
         } elseif (!$this->canScoreThreadAsPeer($thread, $course, $session, $user, $qualifyUser)) {

--- a/src/CoreBundle/State/Forum/ForumThreadGradingProvider.php
+++ b/src/CoreBundle/State/Forum/ForumThreadGradingProvider.php
@@ -17,6 +17,7 @@ use Chamilo\CoreBundle\Entity\Session;
 use Chamilo\CoreBundle\Entity\SessionRelCourseRelUser;
 use Chamilo\CoreBundle\Entity\User;
 use Chamilo\CoreBundle\Helpers\CidReqHelper;
+use Chamilo\CoreBundle\Helpers\StudentViewHelper;
 use Chamilo\CoreBundle\Repository\GradeBookCategoryRepository;
 use Chamilo\CourseBundle\Entity\CForum;
 use Chamilo\CourseBundle\Entity\CForumPost;
@@ -49,6 +50,7 @@ final class ForumThreadGradingProvider implements ProviderInterface
         private readonly GradeBookCategoryRepository $gradebookCategoryRepository,
         private readonly Security $security,
         private readonly CidReqHelper $cidReqHelper,
+        private readonly StudentViewHelper $studentViewHelper,
     ) {}
 
     /**
@@ -80,7 +82,7 @@ final class ForumThreadGradingProvider implements ProviderInterface
             throw new AccessDeniedHttpException('A valid user is required.');
         }
 
-        $canManage = $this->canManageForumsInCurrentView($this->security, $request);
+        $canManage = $this->canManageForumsInCurrentView($this->security, $this->studentViewHelper);
         $canPeerGrade = $this->canPeerGradeThread($thread, $forum, $course, $session, $currentUser);
         if (!$canManage && !$canPeerGrade) {
             throw new AccessDeniedHttpException('You are not allowed to grade this forum thread.');

--- a/src/CoreBundle/State/Forum/ForumThreadPostsStateProvider.php
+++ b/src/CoreBundle/State/Forum/ForumThreadPostsStateProvider.php
@@ -14,6 +14,7 @@ use Chamilo\CoreBundle\Entity\ResourceNode;
 use Chamilo\CoreBundle\Entity\Session;
 use Chamilo\CoreBundle\Entity\User;
 use Chamilo\CoreBundle\Helpers\CidReqHelper;
+use Chamilo\CoreBundle\Helpers\StudentViewHelper;
 use Chamilo\CoreBundle\Repository\ExtraFieldValuesRepository;
 use Chamilo\CoreBundle\Repository\Node\IllustrationRepository;
 use Chamilo\CoreBundle\Security\Authorization\Voter\ResourceNodeVoter;
@@ -66,6 +67,7 @@ final class ForumThreadPostsStateProvider implements ProviderInterface
         private readonly IllustrationRepository $illustrationRepository,
         private readonly CourseAccessResolver $courseAccessResolver,
         private readonly CidReqHelper $cidReqHelper,
+        private readonly StudentViewHelper $studentViewHelper,
     ) {}
 
     /**
@@ -132,7 +134,7 @@ final class ForumThreadPostsStateProvider implements ProviderInterface
         $course = $this->getCourse($this->cidReqHelper);
         $session = $this->cidReqHelper->getDoctrineSessionEntity();
         $group = $this->getGroup($this->entityManager, $this->cidReqHelper);
-        $canManage = $this->canManageForumsInCurrentView($this->security, $request);
+        $canManage = $this->canManageForumsInCurrentView($this->security, $this->studentViewHelper);
         $user = $this->getCurrentUser();
         $canSubscribe = !$this->areForumPostNotificationsHidden($course);
 

--- a/src/CoreBundle/State/LearningPath/LearningPathCategoryCollectionProvider.php
+++ b/src/CoreBundle/State/LearningPath/LearningPathCategoryCollectionProvider.php
@@ -13,13 +13,13 @@ use Chamilo\CoreBundle\Entity\ResourceLink;
 use Chamilo\CoreBundle\Entity\Session;
 use Chamilo\CoreBundle\Entity\SessionRelCourse;
 use Chamilo\CoreBundle\Helpers\CidReqHelper;
+use Chamilo\CoreBundle\Helpers\StudentViewHelper;
 use Chamilo\CoreBundle\Settings\SettingsManager;
 use Chamilo\CourseBundle\Entity\CLpCategory;
 use Chamilo\CourseBundle\Repository\CLpCategoryRepository;
 use Chamilo\CourseBundle\Repository\CShortcutRepository;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\SecurityBundle\Security;
-use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 
 /**
@@ -34,9 +34,9 @@ final readonly class LearningPathCategoryCollectionProvider implements ProviderI
         private CLpCategoryRepository $categoryRepository,
         private Security $security,
         private CidReqHelper $cidReqHelper,
-        private RequestStack $requestStack,
         private CShortcutRepository $shortcutRepository,
         private SettingsManager $settingsManager,
+        private StudentViewHelper $studentViewHelper,
     ) {}
 
     /**
@@ -83,7 +83,7 @@ final readonly class LearningPathCategoryCollectionProvider implements ProviderI
 
         $group = $this->getContextGroup($this->entityManager, $this->cidReqHelper, $course);
         $canManage = $this->canManageLearningPaths($this->security)
-            && !$this->isStudentViewRequest($this->requestStack);
+            && !$this->studentViewHelper->isStudentView();
 
         /** @var array<int, CLpCategory> $categories */
         $categories = $this->categoryRepository

--- a/src/CoreBundle/State/LearningPath/LearningPathCollectionProvider.php
+++ b/src/CoreBundle/State/LearningPath/LearningPathCollectionProvider.php
@@ -15,6 +15,7 @@ use Chamilo\CoreBundle\Entity\SessionRelCourse;
 use Chamilo\CoreBundle\Entity\User;
 use Chamilo\CoreBundle\Helpers\CidReqHelper;
 use Chamilo\CoreBundle\Helpers\LpAdvancedAccessHelper;
+use Chamilo\CoreBundle\Helpers\StudentViewHelper;
 use Chamilo\CoreBundle\Settings\SettingsManager;
 use Chamilo\CourseBundle\Entity\CGroup;
 use Chamilo\CourseBundle\Entity\CLp;
@@ -25,7 +26,6 @@ use DateTimeInterface;
 use DateTimeZone;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\SecurityBundle\Security;
-use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 
 /**
@@ -43,7 +43,7 @@ readonly class LearningPathCollectionProvider implements ProviderInterface
         private SettingsManager $settingsManager,
         private LpAdvancedAccessHelper $advancedAccessHelper,
         private CidReqHelper $cidReqHelper,
-        private RequestStack $requestStack,
+        private StudentViewHelper $studentViewHelper,
     ) {}
 
     /**
@@ -91,7 +91,7 @@ readonly class LearningPathCollectionProvider implements ProviderInterface
         $group = $this->getContextGroup($this->entityManager, $this->cidReqHelper, $course);
         $title = isset($filters['title']) ? trim((string) $filters['title']) : null;
         $canManage = $this->canManageLearningPaths($this->security)
-            && !$this->isStudentViewRequest($this->requestStack);
+            && !$this->studentViewHelper->isStudentView();
 
         /** @var array<int, CLp> $learningPaths */
         $learningPaths = $this->learningPathRepository

--- a/src/CoreBundle/State/LearningPath/LearningPathRuntimeProvider.php
+++ b/src/CoreBundle/State/LearningPath/LearningPathRuntimeProvider.php
@@ -16,6 +16,7 @@ use Chamilo\CoreBundle\Entity\Session;
 use Chamilo\CoreBundle\Entity\User;
 use Chamilo\CoreBundle\Helpers\CidReqHelper;
 use Chamilo\CoreBundle\Helpers\LpAdvancedAccessHelper;
+use Chamilo\CoreBundle\Helpers\StudentViewHelper;
 use Chamilo\CoreBundle\Repository\ResourceNodeRepository;
 use Chamilo\CoreBundle\Service\LearningPath\LearningPathAccessChecker;
 use Chamilo\CoreBundle\Service\LearningPath\LearningPathFinalItemManager;
@@ -78,6 +79,7 @@ final readonly class LearningPathRuntimeProvider implements ProviderInterface
         private CLpRepository $lpRepository,
         private CLpItemRepository $lpItemRepository,
         private CidReqHelper $cidReqHelper,
+        private StudentViewHelper $studentViewHelper,
     ) {}
 
     /**
@@ -101,7 +103,7 @@ final readonly class LearningPathRuntimeProvider implements ProviderInterface
         }
 
         $canEdit = $this->canManageLearningPaths($this->security);
-        $canManage = $canEdit && !$this->isStudentViewRequest($this->requestStack);
+        $canManage = $canEdit && !$this->studentViewHelper->isStudentView();
         $this->assertRuntimeAccess($lp, $course, $session, $group, $user, $canEdit);
 
         $items = $this->getLearningPathItems($lp);
@@ -1061,7 +1063,7 @@ final readonly class LearningPathRuntimeProvider implements ProviderInterface
             'sid' => (int) ($session?->getId() ?? 0),
             'gid' => (int) ($group?->getIid() ?? 0),
             'origin' => 'learnpath',
-            'isStudentView' => $this->isStudentViewRequest($this->requestStack) ? 'true' : 'false',
+            'isStudentView' => $this->studentViewHelper->isStudentView() ? 'true' : 'false',
             'gradebook' => $request->query->getInt('gradebook'),
         ];
     }

--- a/src/CoreBundle/State/LearningPath/LearningPathStateHelperTrait.php
+++ b/src/CoreBundle/State/LearningPath/LearningPathStateHelperTrait.php
@@ -17,7 +17,6 @@ use Doctrine\ORM\EntityManagerInterface;
 use JsonException;
 use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
@@ -57,13 +56,6 @@ trait LearningPathStateHelperTrait
         if (!$csrfTokenManager->isTokenValid(new CsrfToken(self::ACTION_TOKEN_INTENTION, $token))) {
             throw new AccessDeniedHttpException('Invalid CSRF token.');
         }
-    }
-
-    private function isStudentViewRequest(RequestStack $requestStack): bool
-    {
-        $value = strtolower(trim((string) $requestStack->getCurrentRequest()?->query->get('isStudentView', 'false')));
-
-        return \in_array($value, ['1', 'true', 'yes', 'on'], true);
     }
 
     private function assertLearningPathTeacher(Security $security): void

--- a/src/CoreBundle/State/Notebook/NotebookAccessHelperTrait.php
+++ b/src/CoreBundle/State/Notebook/NotebookAccessHelperTrait.php
@@ -11,6 +11,7 @@ use Chamilo\CoreBundle\Entity\ExtraField;
 use Chamilo\CoreBundle\Entity\ExtraFieldValues;
 use Chamilo\CoreBundle\Entity\Session;
 use Chamilo\CoreBundle\Entity\User;
+use Chamilo\CoreBundle\Helpers\CidReqHelper;
 use Chamilo\CoreBundle\Helpers\UserHelper;
 use Chamilo\CoreBundle\Repository\ExtraFieldValuesRepository;
 use Chamilo\CoreBundle\Security\Authorization\Voter\CourseVoter;
@@ -20,7 +21,6 @@ use Chamilo\CourseBundle\Repository\CNotebookRepository;
 use Doctrine\ORM\EntityManagerInterface;
 use Event;
 use Symfony\Bundle\SecurityBundle\Security;
-use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
@@ -28,34 +28,25 @@ use Throwable;
 
 trait NotebookAccessHelperTrait
 {
-    private function getNotebookCourse(EntityManagerInterface $entityManager, Request $request): Course
+    /**
+     * CidReqListener already resolved and validated the course, so a missing entity here
+     * can only mean the request carried no course context at all.
+     */
+    private function getNotebookCourse(CidReqHelper $cidReqHelper): Course
     {
-        $courseId = $request->query->getInt('cid');
-        if ($courseId <= 0) {
-            throw new BadRequestHttpException('A valid course id is required.');
-        }
-
-        $course = $entityManager->getRepository(Course::class)->find($courseId);
-        if (!$course instanceof Course) {
-            throw new BadRequestHttpException('The requested course was not found.');
-        }
-
-        return $course;
+        return $cidReqHelper->getDoctrineCourseEntity()
+            ?? throw new BadRequestHttpException('A valid course id is required.');
     }
 
-    private function getNotebookSession(EntityManagerInterface $entityManager, Request $request): ?Session
+    private function getNotebookSession(CidReqHelper $cidReqHelper): ?Session
     {
-        $sessionId = $request->query->getInt('sid');
+        $sessionId = (int) ($cidReqHelper->getSessionId() ?? 0);
         if ($sessionId <= 0) {
             return null;
         }
 
-        $session = $entityManager->getRepository(Session::class)->find($sessionId);
-        if (!$session instanceof Session) {
-            throw new BadRequestHttpException('The requested session was not found.');
-        }
-
-        return $session;
+        return $cidReqHelper->getDoctrineSessionEntity()
+            ?? throw new BadRequestHttpException('The requested session was not found.');
     }
 
     private function assertNotebookSessionBelongsToCourse(?Session $session, Course $course): void

--- a/src/CoreBundle/State/Notebook/NotebookAccessHelperTrait.php
+++ b/src/CoreBundle/State/Notebook/NotebookAccessHelperTrait.php
@@ -274,19 +274,6 @@ trait NotebookAccessHelperTrait
         return \in_array(strtolower(trim((string) $value)), ['1', 'true', 'yes', 'on'], true);
     }
 
-    private function isNotebookStudentView(Request $request): bool
-    {
-        if ($request->query->has('isStudentView')) {
-            return $request->query->getBoolean('isStudentView');
-        }
-
-        if (!$request->hasSession()) {
-            return false;
-        }
-
-        return 'studentview' === $request->getSession()->get('studentview');
-    }
-
     private function findOwnedNotebookInContext(
         CNotebookRepository $notebookRepository,
         User $user,

--- a/src/CoreBundle/State/Notebook/NotebookDeleteProcessor.php
+++ b/src/CoreBundle/State/Notebook/NotebookDeleteProcessor.php
@@ -9,6 +9,7 @@ namespace Chamilo\CoreBundle\State\Notebook;
 use ApiPlatform\Metadata\Operation;
 use ApiPlatform\State\ProcessorInterface;
 use Chamilo\CoreBundle\ApiResource\Notebook\NotebookItem;
+use Chamilo\CoreBundle\Helpers\StudentViewHelper;
 use Chamilo\CoreBundle\Helpers\UserHelper;
 use Chamilo\CoreBundle\Settings\SettingsManager;
 use Chamilo\CourseBundle\Repository\CNotebookRepository;
@@ -37,6 +38,7 @@ final readonly class NotebookDeleteProcessor implements ProcessorInterface
         private UserHelper $userHelper,
         private SettingsManager $settingsManager,
         private NotebookWriteProtection $writeProtection,
+        private StudentViewHelper $studentViewHelper,
     ) {}
 
     /**
@@ -64,7 +66,7 @@ final readonly class NotebookDeleteProcessor implements ProcessorInterface
             throw new AccessDeniedHttpException('You are not allowed to view Notebook in this context.');
         }
 
-        $studentView = $this->isNotebookStudentView($request);
+        $studentView = $this->studentViewHelper->isStudentView();
         if (!$this->canWriteNotebook(
             $this->entityManager,
             $this->security,

--- a/src/CoreBundle/State/Notebook/NotebookDeleteProcessor.php
+++ b/src/CoreBundle/State/Notebook/NotebookDeleteProcessor.php
@@ -9,6 +9,7 @@ namespace Chamilo\CoreBundle\State\Notebook;
 use ApiPlatform\Metadata\Operation;
 use ApiPlatform\State\ProcessorInterface;
 use Chamilo\CoreBundle\ApiResource\Notebook\NotebookItem;
+use Chamilo\CoreBundle\Helpers\CidReqHelper;
 use Chamilo\CoreBundle\Helpers\StudentViewHelper;
 use Chamilo\CoreBundle\Helpers\UserHelper;
 use Chamilo\CoreBundle\Settings\SettingsManager;
@@ -38,6 +39,7 @@ final readonly class NotebookDeleteProcessor implements ProcessorInterface
         private UserHelper $userHelper,
         private SettingsManager $settingsManager,
         private NotebookWriteProtection $writeProtection,
+        private CidReqHelper $cidReqHelper,
         private StudentViewHelper $studentViewHelper,
     ) {}
 
@@ -52,8 +54,8 @@ final readonly class NotebookDeleteProcessor implements ProcessorInterface
             throw new BadRequestHttpException('The current request is required.');
         }
 
-        $course = $this->getNotebookCourse($this->entityManager, $request);
-        $session = $this->getNotebookSession($this->entityManager, $request);
+        $course = $this->getNotebookCourse($this->cidReqHelper);
+        $session = $this->getNotebookSession($this->cidReqHelper);
         $this->assertNotebookSessionBelongsToCourse($session, $course);
 
         if (!$this->canReadNotebook(

--- a/src/CoreBundle/State/Notebook/NotebookItemProcessor.php
+++ b/src/CoreBundle/State/Notebook/NotebookItemProcessor.php
@@ -11,6 +11,7 @@ use ApiPlatform\Metadata\Put;
 use ApiPlatform\State\ProcessorInterface;
 use Chamilo\CoreBundle\ApiResource\Notebook\NotebookItem;
 use Chamilo\CoreBundle\Entity\Language;
+use Chamilo\CoreBundle\Helpers\StudentViewHelper;
 use Chamilo\CoreBundle\Helpers\UserHelper;
 use Chamilo\CoreBundle\Settings\SettingsManager;
 use Chamilo\CourseBundle\Entity\CNotebook;
@@ -44,6 +45,7 @@ final readonly class NotebookItemProcessor implements ProcessorInterface
         private SettingsManager $settingsManager,
         private NotebookWriteProtection $writeProtection,
         private CsrfTokenManagerInterface $csrfTokenManager,
+        private StudentViewHelper $studentViewHelper,
     ) {}
 
     /**
@@ -75,7 +77,7 @@ final readonly class NotebookItemProcessor implements ProcessorInterface
             throw new AccessDeniedHttpException('You are not allowed to view Notebook in this context.');
         }
 
-        $studentView = $this->isNotebookStudentView($request);
+        $studentView = $this->studentViewHelper->isStudentView();
         if (!$this->canWriteNotebook(
             $this->entityManager,
             $this->security,

--- a/src/CoreBundle/State/Notebook/NotebookItemProcessor.php
+++ b/src/CoreBundle/State/Notebook/NotebookItemProcessor.php
@@ -11,6 +11,7 @@ use ApiPlatform\Metadata\Put;
 use ApiPlatform\State\ProcessorInterface;
 use Chamilo\CoreBundle\ApiResource\Notebook\NotebookItem;
 use Chamilo\CoreBundle\Entity\Language;
+use Chamilo\CoreBundle\Helpers\CidReqHelper;
 use Chamilo\CoreBundle\Helpers\StudentViewHelper;
 use Chamilo\CoreBundle\Helpers\UserHelper;
 use Chamilo\CoreBundle\Settings\SettingsManager;
@@ -19,8 +20,6 @@ use Chamilo\CourseBundle\Repository\CNotebookRepository;
 use Doctrine\ORM\EntityManagerInterface;
 use Security as LegacySecurity;
 use Symfony\Bundle\SecurityBundle\Security;
-use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 use Symfony\Component\Security\Csrf\CsrfTokenManagerInterface;
@@ -37,7 +36,6 @@ final readonly class NotebookItemProcessor implements ProcessorInterface
     use NotebookAccessHelperTrait;
 
     public function __construct(
-        private RequestStack $requestStack,
         private EntityManagerInterface $entityManager,
         private CNotebookRepository $notebookRepository,
         private Security $security,
@@ -45,6 +43,7 @@ final readonly class NotebookItemProcessor implements ProcessorInterface
         private SettingsManager $settingsManager,
         private NotebookWriteProtection $writeProtection,
         private CsrfTokenManagerInterface $csrfTokenManager,
+        private CidReqHelper $cidReqHelper,
         private StudentViewHelper $studentViewHelper,
     ) {}
 
@@ -58,13 +57,8 @@ final readonly class NotebookItemProcessor implements ProcessorInterface
             throw new BadRequestHttpException('The request payload is invalid.');
         }
 
-        $request = $this->requestStack->getCurrentRequest();
-        if (!$request instanceof Request) {
-            throw new BadRequestHttpException('The current request is required.');
-        }
-
-        $course = $this->getNotebookCourse($this->entityManager, $request);
-        $session = $this->getNotebookSession($this->entityManager, $request);
+        $course = $this->getNotebookCourse($this->cidReqHelper);
+        $session = $this->getNotebookSession($this->cidReqHelper);
         $this->assertNotebookSessionBelongsToCourse($session, $course);
 
         if (!$this->canReadNotebook(

--- a/src/CoreBundle/State/Notebook/NotebookItemProvider.php
+++ b/src/CoreBundle/State/Notebook/NotebookItemProvider.php
@@ -10,6 +10,7 @@ use ApiPlatform\Metadata\Operation;
 use ApiPlatform\State\ProviderInterface;
 use Chamilo\CoreBundle\ApiResource\Notebook\NotebookItem;
 use Chamilo\CoreBundle\Entity\Language;
+use Chamilo\CoreBundle\Helpers\CidReqHelper;
 use Chamilo\CoreBundle\Helpers\StudentViewHelper;
 use Chamilo\CoreBundle\Helpers\UserHelper;
 use Chamilo\CoreBundle\Settings\SettingsManager;
@@ -45,6 +46,7 @@ final readonly class NotebookItemProvider implements ProviderInterface
         private UserHelper $userHelper,
         private SettingsManager $settingsManager,
         private CsrfTokenManagerInterface $csrfTokenManager,
+        private CidReqHelper $cidReqHelper,
         private StudentViewHelper $studentViewHelper,
     ) {}
 
@@ -59,8 +61,8 @@ final readonly class NotebookItemProvider implements ProviderInterface
             throw new BadRequestHttpException('The current request is required.');
         }
 
-        $course = $this->getNotebookCourse($this->entityManager, $request);
-        $session = $this->getNotebookSession($this->entityManager, $request);
+        $course = $this->getNotebookCourse($this->cidReqHelper);
+        $session = $this->getNotebookSession($this->cidReqHelper);
         $this->assertNotebookSessionBelongsToCourse($session, $course);
 
         if (!$this->canReadNotebook(

--- a/src/CoreBundle/State/Notebook/NotebookItemProvider.php
+++ b/src/CoreBundle/State/Notebook/NotebookItemProvider.php
@@ -10,6 +10,7 @@ use ApiPlatform\Metadata\Operation;
 use ApiPlatform\State\ProviderInterface;
 use Chamilo\CoreBundle\ApiResource\Notebook\NotebookItem;
 use Chamilo\CoreBundle\Entity\Language;
+use Chamilo\CoreBundle\Helpers\StudentViewHelper;
 use Chamilo\CoreBundle\Helpers\UserHelper;
 use Chamilo\CoreBundle\Settings\SettingsManager;
 use Chamilo\CourseBundle\Entity\CNotebook;
@@ -44,6 +45,7 @@ final readonly class NotebookItemProvider implements ProviderInterface
         private UserHelper $userHelper,
         private SettingsManager $settingsManager,
         private CsrfTokenManagerInterface $csrfTokenManager,
+        private StudentViewHelper $studentViewHelper,
     ) {}
 
     /**
@@ -71,7 +73,7 @@ final readonly class NotebookItemProvider implements ProviderInterface
             throw new AccessDeniedHttpException('You are not allowed to view Notebook in this context.');
         }
 
-        $studentView = $this->isNotebookStudentView($request);
+        $studentView = $this->studentViewHelper->isStudentView();
         $canWrite = $this->canWriteNotebook(
             $this->entityManager,
             $this->security,

--- a/src/CoreBundle/State/Notebook/NotebookListProvider.php
+++ b/src/CoreBundle/State/Notebook/NotebookListProvider.php
@@ -12,6 +12,7 @@ use Chamilo\CoreBundle\ApiResource\Notebook\NotebookList;
 use Chamilo\CoreBundle\Entity\Course;
 use Chamilo\CoreBundle\Entity\ResourceLink;
 use Chamilo\CoreBundle\Entity\Session;
+use Chamilo\CoreBundle\Helpers\CidReqHelper;
 use Chamilo\CoreBundle\Helpers\StudentViewHelper;
 use Chamilo\CoreBundle\Helpers\UserHelper;
 use Chamilo\CoreBundle\Settings\SettingsManager;
@@ -46,6 +47,7 @@ final readonly class NotebookListProvider implements ProviderInterface
         private UserHelper $userHelper,
         private SettingsManager $settingsManager,
         private CsrfTokenManagerInterface $csrfTokenManager,
+        private CidReqHelper $cidReqHelper,
         private StudentViewHelper $studentViewHelper,
     ) {}
 
@@ -60,8 +62,8 @@ final readonly class NotebookListProvider implements ProviderInterface
             throw new BadRequestHttpException('The current request is required.');
         }
 
-        $course = $this->getNotebookCourse($this->entityManager, $request);
-        $session = $this->getNotebookSession($this->entityManager, $request);
+        $course = $this->getNotebookCourse($this->cidReqHelper);
+        $session = $this->getNotebookSession($this->cidReqHelper);
         $this->assertNotebookSessionBelongsToCourse($session, $course);
 
         if (!$this->canReadNotebook(

--- a/src/CoreBundle/State/Notebook/NotebookListProvider.php
+++ b/src/CoreBundle/State/Notebook/NotebookListProvider.php
@@ -12,6 +12,7 @@ use Chamilo\CoreBundle\ApiResource\Notebook\NotebookList;
 use Chamilo\CoreBundle\Entity\Course;
 use Chamilo\CoreBundle\Entity\ResourceLink;
 use Chamilo\CoreBundle\Entity\Session;
+use Chamilo\CoreBundle\Helpers\StudentViewHelper;
 use Chamilo\CoreBundle\Helpers\UserHelper;
 use Chamilo\CoreBundle\Settings\SettingsManager;
 use Chamilo\CourseBundle\Entity\CNotebook;
@@ -45,6 +46,7 @@ final readonly class NotebookListProvider implements ProviderInterface
         private UserHelper $userHelper,
         private SettingsManager $settingsManager,
         private CsrfTokenManagerInterface $csrfTokenManager,
+        private StudentViewHelper $studentViewHelper,
     ) {}
 
     /**
@@ -73,7 +75,7 @@ final readonly class NotebookListProvider implements ProviderInterface
         }
 
         $user = $this->getNotebookUser($this->userHelper);
-        $studentView = $this->isNotebookStudentView($request);
+        $studentView = $this->studentViewHelper->isStudentView();
         $canWrite = $this->canWriteNotebook(
             $this->entityManager,
             $this->security,

--- a/src/CoreBundle/State/Wiki/WikiAccessHelperTrait.php
+++ b/src/CoreBundle/State/Wiki/WikiAccessHelperTrait.php
@@ -12,6 +12,7 @@ use Chamilo\CoreBundle\Entity\ExtraFieldValues;
 use Chamilo\CoreBundle\Entity\ResourceLink;
 use Chamilo\CoreBundle\Entity\Session;
 use Chamilo\CoreBundle\Entity\User;
+use Chamilo\CoreBundle\Helpers\CidReqHelper;
 use Chamilo\CoreBundle\Repository\ExtraFieldValuesRepository;
 use Chamilo\CoreBundle\Security\Authorization\Voter\CourseVoter;
 use Chamilo\CoreBundle\Settings\SettingsManager;
@@ -26,39 +27,30 @@ use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 
 trait WikiAccessHelperTrait
 {
-    private function getWikiCourse(EntityManagerInterface $entityManager, Request $request): Course
+    /**
+     * CidReqListener already resolved and validated the course, so a missing entity here
+     * can only mean the request carried no course context at all.
+     */
+    private function getWikiCourse(CidReqHelper $cidReqHelper): Course
     {
-        $courseId = $request->query->getInt('cid');
-        if ($courseId <= 0) {
-            throw new BadRequestHttpException('A valid course id is required.');
-        }
-
-        $course = $entityManager->getRepository(Course::class)->find($courseId);
-        if (!$course instanceof Course) {
-            throw new BadRequestHttpException('The requested course was not found.');
-        }
-
-        return $course;
+        return $cidReqHelper->getDoctrineCourseEntity()
+            ?? throw new BadRequestHttpException('A valid course id is required.');
     }
 
-    private function getWikiSession(EntityManagerInterface $entityManager, Request $request): ?Session
+    private function getWikiSession(CidReqHelper $cidReqHelper): ?Session
     {
-        $sessionId = $request->query->getInt('sid');
+        $sessionId = (int) ($cidReqHelper->getSessionId() ?? 0);
         if ($sessionId <= 0) {
             return null;
         }
 
-        $session = $entityManager->getRepository(Session::class)->find($sessionId);
-        if (!$session instanceof Session) {
-            throw new BadRequestHttpException('The requested session was not found.');
-        }
-
-        return $session;
+        return $cidReqHelper->getDoctrineSessionEntity()
+            ?? throw new BadRequestHttpException('The requested session was not found.');
     }
 
-    private function getWikiGroup(EntityManagerInterface $entityManager, Request $request): ?CGroup
+    private function getWikiGroup(EntityManagerInterface $entityManager, CidReqHelper $cidReqHelper): ?CGroup
     {
-        $groupId = $request->query->getInt('gid');
+        $groupId = (int) ($cidReqHelper->getGroupId() ?? 0);
         if ($groupId <= 0) {
             return null;
         }

--- a/src/CoreBundle/State/Wiki/WikiAccessHelperTrait.php
+++ b/src/CoreBundle/State/Wiki/WikiAccessHelperTrait.php
@@ -368,19 +368,6 @@ trait WikiAccessHelperTrait
         return $nodeId;
     }
 
-    private function isWikiStudentView(Request $request): bool
-    {
-        if ($request->query->has('isStudentView')) {
-            return $request->query->getBoolean('isStudentView');
-        }
-
-        if (!$request->hasSession()) {
-            return false;
-        }
-
-        return 'studentview' === $request->getSession()->get('studentview');
-    }
-
     private function isWikiCourseSettingEnabled(
         EntityManagerInterface $entityManager,
         Course $course,

--- a/src/CoreBundle/State/Wiki/WikiCategoryProcessor.php
+++ b/src/CoreBundle/State/Wiki/WikiCategoryProcessor.php
@@ -11,6 +11,7 @@ use ApiPlatform\State\ProcessorInterface;
 use Chamilo\CoreBundle\ApiResource\Wiki\WikiCategoryInput;
 use Chamilo\CoreBundle\Entity\Course;
 use Chamilo\CoreBundle\Entity\Session;
+use Chamilo\CoreBundle\Helpers\StudentViewHelper;
 use Chamilo\CoreBundle\Settings\SettingsManager;
 use Chamilo\CourseBundle\Entity\CWikiCategory;
 use Chamilo\CourseBundle\Repository\CWikiCategoryRepository;
@@ -38,6 +39,7 @@ final readonly class WikiCategoryProcessor implements ProcessorInterface
         private SettingsManager $settingsManager,
         private CsrfTokenManagerInterface $csrfTokenManager,
         private WikiCategoryService $categoryService,
+        private StudentViewHelper $studentViewHelper,
     ) {}
 
     /**
@@ -63,7 +65,7 @@ final readonly class WikiCategoryProcessor implements ProcessorInterface
         $group = $this->getWikiGroup($this->entityManager, $request);
         $this->assertWikiGroupBelongsToContext($group, $course, $session);
 
-        if ($this->isWikiStudentView($request)) {
+        if ($this->studentViewHelper->isStudentView()) {
             throw new AccessDeniedHttpException('Wiki categories cannot be managed in student view.');
         }
 

--- a/src/CoreBundle/State/Wiki/WikiCategoryProcessor.php
+++ b/src/CoreBundle/State/Wiki/WikiCategoryProcessor.php
@@ -11,6 +11,7 @@ use ApiPlatform\State\ProcessorInterface;
 use Chamilo\CoreBundle\ApiResource\Wiki\WikiCategoryInput;
 use Chamilo\CoreBundle\Entity\Course;
 use Chamilo\CoreBundle\Entity\Session;
+use Chamilo\CoreBundle\Helpers\CidReqHelper;
 use Chamilo\CoreBundle\Helpers\StudentViewHelper;
 use Chamilo\CoreBundle\Settings\SettingsManager;
 use Chamilo\CourseBundle\Entity\CWikiCategory;
@@ -40,6 +41,7 @@ final readonly class WikiCategoryProcessor implements ProcessorInterface
         private CsrfTokenManagerInterface $csrfTokenManager,
         private WikiCategoryService $categoryService,
         private StudentViewHelper $studentViewHelper,
+        private CidReqHelper $cidReqHelper,
     ) {}
 
     /**
@@ -57,12 +59,12 @@ final readonly class WikiCategoryProcessor implements ProcessorInterface
             throw new BadRequestHttpException('The current request is required.');
         }
 
-        $course = $this->getWikiCourse($this->entityManager, $request);
+        $course = $this->getWikiCourse($this->cidReqHelper);
         $this->assertWikiToolEnabled($this->entityManager, $course);
         $this->assertWikiRouteNode($course, $request);
-        $session = $this->getWikiSession($this->entityManager, $request);
+        $session = $this->getWikiSession($this->cidReqHelper);
         $this->assertWikiSessionBelongsToCourse($session, $course);
-        $group = $this->getWikiGroup($this->entityManager, $request);
+        $group = $this->getWikiGroup($this->entityManager, $this->cidReqHelper);
         $this->assertWikiGroupBelongsToContext($group, $course, $session);
 
         if ($this->studentViewHelper->isStudentView()) {

--- a/src/CoreBundle/State/Wiki/WikiCategoryProvider.php
+++ b/src/CoreBundle/State/Wiki/WikiCategoryProvider.php
@@ -9,6 +9,7 @@ namespace Chamilo\CoreBundle\State\Wiki;
 use ApiPlatform\Metadata\Operation;
 use ApiPlatform\State\ProviderInterface;
 use Chamilo\CoreBundle\ApiResource\Wiki\WikiCategoryCollection;
+use Chamilo\CoreBundle\Helpers\CidReqHelper;
 use Chamilo\CoreBundle\Helpers\StudentViewHelper;
 use Chamilo\CoreBundle\Settings\SettingsManager;
 use Doctrine\ORM\EntityManagerInterface;
@@ -36,6 +37,7 @@ final readonly class WikiCategoryProvider implements ProviderInterface
         private CsrfTokenManagerInterface $csrfTokenManager,
         private WikiCategoryService $categoryService,
         private StudentViewHelper $studentViewHelper,
+        private CidReqHelper $cidReqHelper,
     ) {}
 
     /**
@@ -49,12 +51,12 @@ final readonly class WikiCategoryProvider implements ProviderInterface
             throw new BadRequestHttpException('The current request is required.');
         }
 
-        $course = $this->getWikiCourse($this->entityManager, $request);
+        $course = $this->getWikiCourse($this->cidReqHelper);
         $this->assertWikiToolEnabled($this->entityManager, $course);
         $this->assertWikiRouteNode($course, $request);
-        $session = $this->getWikiSession($this->entityManager, $request);
+        $session = $this->getWikiSession($this->cidReqHelper);
         $this->assertWikiSessionBelongsToCourse($session, $course);
-        $group = $this->getWikiGroup($this->entityManager, $request);
+        $group = $this->getWikiGroup($this->entityManager, $this->cidReqHelper);
         $this->assertWikiGroupBelongsToContext($group, $course, $session);
 
         if ($this->studentViewHelper->isStudentView()) {

--- a/src/CoreBundle/State/Wiki/WikiCategoryProvider.php
+++ b/src/CoreBundle/State/Wiki/WikiCategoryProvider.php
@@ -9,6 +9,7 @@ namespace Chamilo\CoreBundle\State\Wiki;
 use ApiPlatform\Metadata\Operation;
 use ApiPlatform\State\ProviderInterface;
 use Chamilo\CoreBundle\ApiResource\Wiki\WikiCategoryCollection;
+use Chamilo\CoreBundle\Helpers\StudentViewHelper;
 use Chamilo\CoreBundle\Settings\SettingsManager;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\SecurityBundle\Security;
@@ -34,6 +35,7 @@ final readonly class WikiCategoryProvider implements ProviderInterface
         private SettingsManager $settingsManager,
         private CsrfTokenManagerInterface $csrfTokenManager,
         private WikiCategoryService $categoryService,
+        private StudentViewHelper $studentViewHelper,
     ) {}
 
     /**
@@ -55,7 +57,7 @@ final readonly class WikiCategoryProvider implements ProviderInterface
         $group = $this->getWikiGroup($this->entityManager, $request);
         $this->assertWikiGroupBelongsToContext($group, $course, $session);
 
-        if ($this->isWikiStudentView($request)) {
+        if ($this->studentViewHelper->isStudentView()) {
             throw new AccessDeniedHttpException('Wiki categories cannot be managed in student view.');
         }
 

--- a/src/CoreBundle/State/Wiki/WikiDiscussionActionProcessor.php
+++ b/src/CoreBundle/State/Wiki/WikiDiscussionActionProcessor.php
@@ -11,6 +11,7 @@ use ApiPlatform\State\ProcessorInterface;
 use Chamilo\CoreBundle\ApiResource\Wiki\WikiDiscussion;
 use Chamilo\CoreBundle\ApiResource\Wiki\WikiDiscussionAction;
 use Chamilo\CoreBundle\Entity\User;
+use Chamilo\CoreBundle\Helpers\CidReqHelper;
 use Chamilo\CoreBundle\Helpers\StudentViewHelper;
 use Chamilo\CoreBundle\Settings\SettingsManager;
 use Chamilo\CourseBundle\Entity\CWiki;
@@ -42,6 +43,7 @@ final readonly class WikiDiscussionActionProcessor implements ProcessorInterface
         private SettingsManager $settingsManager,
         private CsrfTokenManagerInterface $csrfTokenManager,
         private StudentViewHelper $studentViewHelper,
+        private CidReqHelper $cidReqHelper,
     ) {}
 
     /**
@@ -59,12 +61,12 @@ final readonly class WikiDiscussionActionProcessor implements ProcessorInterface
             throw new BadRequestHttpException('The current request is required.');
         }
 
-        $course = $this->getWikiCourse($this->entityManager, $request);
+        $course = $this->getWikiCourse($this->cidReqHelper);
         $this->assertWikiToolEnabled($this->entityManager, $course);
         $this->assertWikiRouteNode($course, $request);
-        $session = $this->getWikiSession($this->entityManager, $request);
+        $session = $this->getWikiSession($this->cidReqHelper);
         $this->assertWikiSessionBelongsToCourse($session, $course);
-        $group = $this->getWikiGroup($this->entityManager, $request);
+        $group = $this->getWikiGroup($this->entityManager, $this->cidReqHelper);
         $this->assertWikiGroupBelongsToContext($group, $course, $session);
 
         if (!$this->canReadWikiContext($this->security, $this->settingsManager, $course, $session, $group)) {

--- a/src/CoreBundle/State/Wiki/WikiDiscussionActionProcessor.php
+++ b/src/CoreBundle/State/Wiki/WikiDiscussionActionProcessor.php
@@ -11,6 +11,7 @@ use ApiPlatform\State\ProcessorInterface;
 use Chamilo\CoreBundle\ApiResource\Wiki\WikiDiscussion;
 use Chamilo\CoreBundle\ApiResource\Wiki\WikiDiscussionAction;
 use Chamilo\CoreBundle\Entity\User;
+use Chamilo\CoreBundle\Helpers\StudentViewHelper;
 use Chamilo\CoreBundle\Settings\SettingsManager;
 use Chamilo\CourseBundle\Entity\CWiki;
 use Chamilo\CourseBundle\Entity\CWikiMailcue;
@@ -40,6 +41,7 @@ final readonly class WikiDiscussionActionProcessor implements ProcessorInterface
         private Security $security,
         private SettingsManager $settingsManager,
         private CsrfTokenManagerInterface $csrfTokenManager,
+        private StudentViewHelper $studentViewHelper,
     ) {}
 
     /**
@@ -69,7 +71,7 @@ final readonly class WikiDiscussionActionProcessor implements ProcessorInterface
             throw new AccessDeniedHttpException('You are not allowed to use Wiki discussions in this context.');
         }
 
-        if ($this->isWikiStudentView($request)) {
+        if ($this->studentViewHelper->isStudentView()) {
             throw new AccessDeniedHttpException('Wiki discussion actions are not available in student view.');
         }
 

--- a/src/CoreBundle/State/Wiki/WikiDiscussionProcessor.php
+++ b/src/CoreBundle/State/Wiki/WikiDiscussionProcessor.php
@@ -10,6 +10,7 @@ use ApiPlatform\Metadata\Operation;
 use ApiPlatform\State\ProcessorInterface;
 use Chamilo\CoreBundle\ApiResource\Wiki\WikiDiscussion;
 use Chamilo\CoreBundle\Entity\User;
+use Chamilo\CoreBundle\Helpers\StudentViewHelper;
 use Chamilo\CoreBundle\Settings\SettingsManager;
 use Chamilo\CourseBundle\Entity\CWiki;
 use Chamilo\CourseBundle\Entity\CWikiDiscuss;
@@ -43,6 +44,7 @@ final readonly class WikiDiscussionProcessor implements ProcessorInterface
         private CsrfTokenManagerInterface $csrfTokenManager,
         private WikiDiscussionScoreCalculator $scoreCalculator,
         private WikiNotificationService $notificationService,
+        private StudentViewHelper $studentViewHelper,
     ) {}
 
     /**
@@ -72,7 +74,7 @@ final readonly class WikiDiscussionProcessor implements ProcessorInterface
             throw new AccessDeniedHttpException('You are not allowed to use Wiki discussions in this context.');
         }
 
-        if ($this->isWikiStudentView($request)) {
+        if ($this->studentViewHelper->isStudentView()) {
             throw new AccessDeniedHttpException('Wiki discussion comments are not available in student view.');
         }
 

--- a/src/CoreBundle/State/Wiki/WikiDiscussionProcessor.php
+++ b/src/CoreBundle/State/Wiki/WikiDiscussionProcessor.php
@@ -10,6 +10,7 @@ use ApiPlatform\Metadata\Operation;
 use ApiPlatform\State\ProcessorInterface;
 use Chamilo\CoreBundle\ApiResource\Wiki\WikiDiscussion;
 use Chamilo\CoreBundle\Entity\User;
+use Chamilo\CoreBundle\Helpers\CidReqHelper;
 use Chamilo\CoreBundle\Helpers\StudentViewHelper;
 use Chamilo\CoreBundle\Settings\SettingsManager;
 use Chamilo\CourseBundle\Entity\CWiki;
@@ -45,6 +46,7 @@ final readonly class WikiDiscussionProcessor implements ProcessorInterface
         private WikiDiscussionScoreCalculator $scoreCalculator,
         private WikiNotificationService $notificationService,
         private StudentViewHelper $studentViewHelper,
+        private CidReqHelper $cidReqHelper,
     ) {}
 
     /**
@@ -62,12 +64,12 @@ final readonly class WikiDiscussionProcessor implements ProcessorInterface
             throw new BadRequestHttpException('The current request is required.');
         }
 
-        $course = $this->getWikiCourse($this->entityManager, $request);
+        $course = $this->getWikiCourse($this->cidReqHelper);
         $this->assertWikiToolEnabled($this->entityManager, $course);
         $this->assertWikiRouteNode($course, $request);
-        $session = $this->getWikiSession($this->entityManager, $request);
+        $session = $this->getWikiSession($this->cidReqHelper);
         $this->assertWikiSessionBelongsToCourse($session, $course);
-        $group = $this->getWikiGroup($this->entityManager, $request);
+        $group = $this->getWikiGroup($this->entityManager, $this->cidReqHelper);
         $this->assertWikiGroupBelongsToContext($group, $course, $session);
 
         if (!$this->canReadWikiContext($this->security, $this->settingsManager, $course, $session, $group)) {

--- a/src/CoreBundle/State/Wiki/WikiDiscussionProvider.php
+++ b/src/CoreBundle/State/Wiki/WikiDiscussionProvider.php
@@ -10,6 +10,7 @@ use ApiPlatform\Metadata\Operation;
 use ApiPlatform\State\ProviderInterface;
 use Chamilo\CoreBundle\ApiResource\Wiki\WikiDiscussion;
 use Chamilo\CoreBundle\Entity\User;
+use Chamilo\CoreBundle\Helpers\StudentViewHelper;
 use Chamilo\CoreBundle\Settings\SettingsManager;
 use Chamilo\CourseBundle\Entity\CWiki;
 use Chamilo\CourseBundle\Entity\CWikiDiscuss;
@@ -45,6 +46,7 @@ final readonly class WikiDiscussionProvider implements ProviderInterface
         private CsrfTokenManagerInterface $csrfTokenManager,
         private WikiPageRenderer $renderer,
         private WikiDiscussionScoreCalculator $scoreCalculator,
+        private StudentViewHelper $studentViewHelper,
     ) {}
 
     /**
@@ -84,7 +86,7 @@ final readonly class WikiDiscussionProvider implements ProviderInterface
             throw new NotFoundHttpException('The requested Wiki discussion was not found in the current context.');
         }
 
-        $studentView = $this->isWikiStudentView($request);
+        $studentView = $this->studentViewHelper->isStudentView();
         $canManage = !$studentView && $this->canManageWikiContext(
             $this->entityManager,
             $this->security,

--- a/src/CoreBundle/State/Wiki/WikiDiscussionProvider.php
+++ b/src/CoreBundle/State/Wiki/WikiDiscussionProvider.php
@@ -10,6 +10,7 @@ use ApiPlatform\Metadata\Operation;
 use ApiPlatform\State\ProviderInterface;
 use Chamilo\CoreBundle\ApiResource\Wiki\WikiDiscussion;
 use Chamilo\CoreBundle\Entity\User;
+use Chamilo\CoreBundle\Helpers\CidReqHelper;
 use Chamilo\CoreBundle\Helpers\StudentViewHelper;
 use Chamilo\CoreBundle\Settings\SettingsManager;
 use Chamilo\CourseBundle\Entity\CWiki;
@@ -47,6 +48,7 @@ final readonly class WikiDiscussionProvider implements ProviderInterface
         private WikiPageRenderer $renderer,
         private WikiDiscussionScoreCalculator $scoreCalculator,
         private StudentViewHelper $studentViewHelper,
+        private CidReqHelper $cidReqHelper,
     ) {}
 
     /**
@@ -60,12 +62,12 @@ final readonly class WikiDiscussionProvider implements ProviderInterface
             throw new BadRequestHttpException('The current request is required.');
         }
 
-        $course = $this->getWikiCourse($this->entityManager, $request);
+        $course = $this->getWikiCourse($this->cidReqHelper);
         $this->assertWikiToolEnabled($this->entityManager, $course);
         $nodeId = $this->assertWikiRouteNode($course, $request);
-        $session = $this->getWikiSession($this->entityManager, $request);
+        $session = $this->getWikiSession($this->cidReqHelper);
         $this->assertWikiSessionBelongsToCourse($session, $course);
-        $group = $this->getWikiGroup($this->entityManager, $request);
+        $group = $this->getWikiGroup($this->entityManager, $this->cidReqHelper);
         $this->assertWikiGroupBelongsToContext($group, $course, $session);
 
         if (!$this->canReadWikiContext($this->security, $this->settingsManager, $course, $session, $group)) {

--- a/src/CoreBundle/State/Wiki/WikiPageActionProcessor.php
+++ b/src/CoreBundle/State/Wiki/WikiPageActionProcessor.php
@@ -12,6 +12,7 @@ use Chamilo\CoreBundle\ApiResource\Wiki\WikiPageAction;
 use Chamilo\CoreBundle\Entity\Course;
 use Chamilo\CoreBundle\Entity\Session;
 use Chamilo\CoreBundle\Entity\User;
+use Chamilo\CoreBundle\Helpers\StudentViewHelper;
 use Chamilo\CoreBundle\Settings\SettingsManager;
 use Chamilo\CourseBundle\Entity\CGroup;
 use Chamilo\CourseBundle\Entity\CWiki;
@@ -46,6 +47,7 @@ final readonly class WikiPageActionProcessor implements ProcessorInterface
         private SettingsManager $settingsManager,
         private CsrfTokenManagerInterface $csrfTokenManager,
         private WikiNotificationService $notificationService,
+        private StudentViewHelper $studentViewHelper,
     ) {}
 
     /**
@@ -71,7 +73,7 @@ final readonly class WikiPageActionProcessor implements ProcessorInterface
         $group = $this->getWikiGroup($this->entityManager, $request);
         $this->assertWikiGroupBelongsToContext($group, $course, $session);
 
-        if ($this->isWikiStudentView($request)) {
+        if ($this->studentViewHelper->isStudentView()) {
             throw new AccessDeniedHttpException('Wiki management actions are not available in student view.');
         }
 

--- a/src/CoreBundle/State/Wiki/WikiPageActionProcessor.php
+++ b/src/CoreBundle/State/Wiki/WikiPageActionProcessor.php
@@ -12,6 +12,7 @@ use Chamilo\CoreBundle\ApiResource\Wiki\WikiPageAction;
 use Chamilo\CoreBundle\Entity\Course;
 use Chamilo\CoreBundle\Entity\Session;
 use Chamilo\CoreBundle\Entity\User;
+use Chamilo\CoreBundle\Helpers\CidReqHelper;
 use Chamilo\CoreBundle\Helpers\StudentViewHelper;
 use Chamilo\CoreBundle\Settings\SettingsManager;
 use Chamilo\CourseBundle\Entity\CGroup;
@@ -48,6 +49,7 @@ final readonly class WikiPageActionProcessor implements ProcessorInterface
         private CsrfTokenManagerInterface $csrfTokenManager,
         private WikiNotificationService $notificationService,
         private StudentViewHelper $studentViewHelper,
+        private CidReqHelper $cidReqHelper,
     ) {}
 
     /**
@@ -65,12 +67,12 @@ final readonly class WikiPageActionProcessor implements ProcessorInterface
             throw new BadRequestHttpException('The current request is required.');
         }
 
-        $course = $this->getWikiCourse($this->entityManager, $request);
+        $course = $this->getWikiCourse($this->cidReqHelper);
         $this->assertWikiToolEnabled($this->entityManager, $course);
         $this->assertWikiRouteNode($course, $request);
-        $session = $this->getWikiSession($this->entityManager, $request);
+        $session = $this->getWikiSession($this->cidReqHelper);
         $this->assertWikiSessionBelongsToCourse($session, $course);
-        $group = $this->getWikiGroup($this->entityManager, $request);
+        $group = $this->getWikiGroup($this->entityManager, $this->cidReqHelper);
         $this->assertWikiGroupBelongsToContext($group, $course, $session);
 
         if ($this->studentViewHelper->isStudentView()) {

--- a/src/CoreBundle/State/Wiki/WikiPageExportProcessor.php
+++ b/src/CoreBundle/State/Wiki/WikiPageExportProcessor.php
@@ -11,6 +11,7 @@ use ApiPlatform\State\ProcessorInterface;
 use Chamilo\CoreBundle\ApiResource\Wiki\WikiPageAction;
 use Chamilo\CoreBundle\ApiResource\Wiki\WikiPageExportAction;
 use Chamilo\CoreBundle\Entity\ResourceLink;
+use Chamilo\CoreBundle\Helpers\CidReqHelper;
 use Chamilo\CoreBundle\Helpers\StudentViewHelper;
 use Chamilo\CoreBundle\Settings\SettingsManager;
 use Chamilo\CourseBundle\Entity\CDocument;
@@ -48,6 +49,7 @@ final readonly class WikiPageExportProcessor implements ProcessorInterface
         #[Autowire('%kernel.cache_dir%')]
         private string $cacheDir,
         private StudentViewHelper $studentViewHelper,
+        private CidReqHelper $cidReqHelper,
     ) {}
 
     /**
@@ -65,12 +67,12 @@ final readonly class WikiPageExportProcessor implements ProcessorInterface
             throw new BadRequestHttpException('The current request is required.');
         }
 
-        $course = $this->getWikiCourse($this->entityManager, $request);
+        $course = $this->getWikiCourse($this->cidReqHelper);
         $this->assertWikiToolEnabled($this->entityManager, $course);
         $nodeId = $this->assertWikiRouteNode($course, $request);
-        $session = $this->getWikiSession($this->entityManager, $request);
+        $session = $this->getWikiSession($this->cidReqHelper);
         $this->assertWikiSessionBelongsToCourse($session, $course);
-        $group = $this->getWikiGroup($this->entityManager, $request);
+        $group = $this->getWikiGroup($this->entityManager, $this->cidReqHelper);
         $this->assertWikiGroupBelongsToContext($group, $course, $session);
 
         if ($this->studentViewHelper->isStudentView() || !$this->canManageWikiContext(

--- a/src/CoreBundle/State/Wiki/WikiPageExportProcessor.php
+++ b/src/CoreBundle/State/Wiki/WikiPageExportProcessor.php
@@ -11,6 +11,7 @@ use ApiPlatform\State\ProcessorInterface;
 use Chamilo\CoreBundle\ApiResource\Wiki\WikiPageAction;
 use Chamilo\CoreBundle\ApiResource\Wiki\WikiPageExportAction;
 use Chamilo\CoreBundle\Entity\ResourceLink;
+use Chamilo\CoreBundle\Helpers\StudentViewHelper;
 use Chamilo\CoreBundle\Settings\SettingsManager;
 use Chamilo\CourseBundle\Entity\CDocument;
 use Chamilo\CourseBundle\Entity\CWiki;
@@ -46,6 +47,7 @@ final readonly class WikiPageExportProcessor implements ProcessorInterface
         private WikiPageExportService $exportService,
         #[Autowire('%kernel.cache_dir%')]
         private string $cacheDir,
+        private StudentViewHelper $studentViewHelper,
     ) {}
 
     /**
@@ -71,7 +73,7 @@ final readonly class WikiPageExportProcessor implements ProcessorInterface
         $group = $this->getWikiGroup($this->entityManager, $request);
         $this->assertWikiGroupBelongsToContext($group, $course, $session);
 
-        if ($this->isWikiStudentView($request) || !$this->canManageWikiContext(
+        if ($this->studentViewHelper->isStudentView() || !$this->canManageWikiContext(
             $this->entityManager,
             $this->security,
             $this->settingsManager,

--- a/src/CoreBundle/State/Wiki/WikiPageFormProcessor.php
+++ b/src/CoreBundle/State/Wiki/WikiPageFormProcessor.php
@@ -13,6 +13,7 @@ use Chamilo\CoreBundle\Entity\Course;
 use Chamilo\CoreBundle\Entity\Language;
 use Chamilo\CoreBundle\Entity\Session;
 use Chamilo\CoreBundle\Entity\User;
+use Chamilo\CoreBundle\Helpers\StudentViewHelper;
 use Chamilo\CoreBundle\Settings\SettingsManager;
 use Chamilo\CourseBundle\Entity\CGroup;
 use Chamilo\CourseBundle\Entity\CWiki;
@@ -57,6 +58,7 @@ final readonly class WikiPageFormProcessor implements ProcessorInterface
         private WikiNotificationService $notificationService,
         private WikiAssignmentService $assignmentService,
         private WikiCategoryService $categoryService,
+        private StudentViewHelper $studentViewHelper,
     ) {}
 
     /**
@@ -82,7 +84,7 @@ final readonly class WikiPageFormProcessor implements ProcessorInterface
         $group = $this->getWikiGroup($this->entityManager, $request);
         $this->assertWikiGroupBelongsToContext($group, $course, $session);
 
-        if ($this->isWikiStudentView($request)) {
+        if ($this->studentViewHelper->isStudentView()) {
             throw new AccessDeniedHttpException('Wiki pages cannot be edited in student view.');
         }
 

--- a/src/CoreBundle/State/Wiki/WikiPageFormProcessor.php
+++ b/src/CoreBundle/State/Wiki/WikiPageFormProcessor.php
@@ -13,6 +13,7 @@ use Chamilo\CoreBundle\Entity\Course;
 use Chamilo\CoreBundle\Entity\Language;
 use Chamilo\CoreBundle\Entity\Session;
 use Chamilo\CoreBundle\Entity\User;
+use Chamilo\CoreBundle\Helpers\CidReqHelper;
 use Chamilo\CoreBundle\Helpers\StudentViewHelper;
 use Chamilo\CoreBundle\Settings\SettingsManager;
 use Chamilo\CourseBundle\Entity\CGroup;
@@ -59,6 +60,7 @@ final readonly class WikiPageFormProcessor implements ProcessorInterface
         private WikiAssignmentService $assignmentService,
         private WikiCategoryService $categoryService,
         private StudentViewHelper $studentViewHelper,
+        private CidReqHelper $cidReqHelper,
     ) {}
 
     /**
@@ -76,12 +78,12 @@ final readonly class WikiPageFormProcessor implements ProcessorInterface
             throw new BadRequestHttpException('The current request is required.');
         }
 
-        $course = $this->getWikiCourse($this->entityManager, $request);
+        $course = $this->getWikiCourse($this->cidReqHelper);
         $this->assertWikiToolEnabled($this->entityManager, $course);
         $this->assertWikiRouteNode($course, $request);
-        $session = $this->getWikiSession($this->entityManager, $request);
+        $session = $this->getWikiSession($this->cidReqHelper);
         $this->assertWikiSessionBelongsToCourse($session, $course);
-        $group = $this->getWikiGroup($this->entityManager, $request);
+        $group = $this->getWikiGroup($this->entityManager, $this->cidReqHelper);
         $this->assertWikiGroupBelongsToContext($group, $course, $session);
 
         if ($this->studentViewHelper->isStudentView()) {

--- a/src/CoreBundle/State/Wiki/WikiPageFormProvider.php
+++ b/src/CoreBundle/State/Wiki/WikiPageFormProvider.php
@@ -11,6 +11,7 @@ use ApiPlatform\State\ProviderInterface;
 use Chamilo\CoreBundle\ApiResource\Wiki\WikiPageForm;
 use Chamilo\CoreBundle\Entity\Language;
 use Chamilo\CoreBundle\Entity\User;
+use Chamilo\CoreBundle\Helpers\CidReqHelper;
 use Chamilo\CoreBundle\Helpers\StudentViewHelper;
 use Chamilo\CoreBundle\Settings\SettingsManager;
 use Chamilo\CourseBundle\Entity\CWiki;
@@ -48,6 +49,7 @@ final readonly class WikiPageFormProvider implements ProviderInterface
         private WikiAssignmentService $assignmentService,
         private WikiCategoryService $categoryService,
         private StudentViewHelper $studentViewHelper,
+        private CidReqHelper $cidReqHelper,
     ) {}
 
     /**
@@ -61,12 +63,12 @@ final readonly class WikiPageFormProvider implements ProviderInterface
             throw new BadRequestHttpException('The current request is required.');
         }
 
-        $course = $this->getWikiCourse($this->entityManager, $request);
+        $course = $this->getWikiCourse($this->cidReqHelper);
         $this->assertWikiToolEnabled($this->entityManager, $course);
         $this->assertWikiRouteNode($course, $request);
-        $session = $this->getWikiSession($this->entityManager, $request);
+        $session = $this->getWikiSession($this->cidReqHelper);
         $this->assertWikiSessionBelongsToCourse($session, $course);
-        $group = $this->getWikiGroup($this->entityManager, $request);
+        $group = $this->getWikiGroup($this->entityManager, $this->cidReqHelper);
         $this->assertWikiGroupBelongsToContext($group, $course, $session);
 
         if ($this->studentViewHelper->isStudentView()) {

--- a/src/CoreBundle/State/Wiki/WikiPageFormProvider.php
+++ b/src/CoreBundle/State/Wiki/WikiPageFormProvider.php
@@ -11,6 +11,7 @@ use ApiPlatform\State\ProviderInterface;
 use Chamilo\CoreBundle\ApiResource\Wiki\WikiPageForm;
 use Chamilo\CoreBundle\Entity\Language;
 use Chamilo\CoreBundle\Entity\User;
+use Chamilo\CoreBundle\Helpers\StudentViewHelper;
 use Chamilo\CoreBundle\Settings\SettingsManager;
 use Chamilo\CourseBundle\Entity\CWiki;
 use Chamilo\CourseBundle\Entity\CWikiConf;
@@ -46,6 +47,7 @@ final readonly class WikiPageFormProvider implements ProviderInterface
         private WikiPageRenderer $renderer,
         private WikiAssignmentService $assignmentService,
         private WikiCategoryService $categoryService,
+        private StudentViewHelper $studentViewHelper,
     ) {}
 
     /**
@@ -67,7 +69,7 @@ final readonly class WikiPageFormProvider implements ProviderInterface
         $group = $this->getWikiGroup($this->entityManager, $request);
         $this->assertWikiGroupBelongsToContext($group, $course, $session);
 
-        if ($this->isWikiStudentView($request)) {
+        if ($this->studentViewHelper->isStudentView()) {
             throw new AccessDeniedHttpException('Wiki pages cannot be edited in student view.');
         }
 
@@ -205,7 +207,7 @@ final readonly class WikiPageFormProvider implements ProviderInterface
         $form->canConfigureAssignment = $canManage && 'index' !== ($sourcePage?->getReflink() ?? $reflink);
         $form->categoriesEnabled = $categoriesEnabled;
         $form->canManageCategories = $categoriesEnabled
-            && !$this->isWikiStudentView($request)
+            && !$this->studentViewHelper->isStudentView()
             && $this->canManageWikiContext(
                 $this->entityManager,
                 $this->security,

--- a/src/CoreBundle/State/Wiki/WikiPageHistoryProvider.php
+++ b/src/CoreBundle/State/Wiki/WikiPageHistoryProvider.php
@@ -10,6 +10,7 @@ use ApiPlatform\Metadata\Operation;
 use ApiPlatform\State\ProviderInterface;
 use Chamilo\CoreBundle\ApiResource\Wiki\WikiPageHistory;
 use Chamilo\CoreBundle\Entity\User;
+use Chamilo\CoreBundle\Helpers\StudentViewHelper;
 use Chamilo\CoreBundle\Settings\SettingsManager;
 use Chamilo\CourseBundle\Entity\CWiki;
 use Chamilo\CourseBundle\Repository\CWikiRepository;
@@ -42,6 +43,7 @@ final readonly class WikiPageHistoryProvider implements ProviderInterface
         private CsrfTokenManagerInterface $csrfTokenManager,
         private WikiPageRenderer $renderer,
         private WikiPageDiffService $diffService,
+        private StudentViewHelper $studentViewHelper,
     ) {}
 
     /**
@@ -97,7 +99,7 @@ final readonly class WikiPageHistoryProvider implements ProviderInterface
             throw new NotFoundHttpException('The requested Wiki page was not found in the current context.');
         }
 
-        $studentView = $this->isWikiStudentView($request);
+        $studentView = $this->studentViewHelper->isStudentView();
         $canManage = !$studentView && $this->canManageWikiContext(
             $this->entityManager,
             $this->security,

--- a/src/CoreBundle/State/Wiki/WikiPageHistoryProvider.php
+++ b/src/CoreBundle/State/Wiki/WikiPageHistoryProvider.php
@@ -10,6 +10,7 @@ use ApiPlatform\Metadata\Operation;
 use ApiPlatform\State\ProviderInterface;
 use Chamilo\CoreBundle\ApiResource\Wiki\WikiPageHistory;
 use Chamilo\CoreBundle\Entity\User;
+use Chamilo\CoreBundle\Helpers\CidReqHelper;
 use Chamilo\CoreBundle\Helpers\StudentViewHelper;
 use Chamilo\CoreBundle\Settings\SettingsManager;
 use Chamilo\CourseBundle\Entity\CWiki;
@@ -44,6 +45,7 @@ final readonly class WikiPageHistoryProvider implements ProviderInterface
         private WikiPageRenderer $renderer,
         private WikiPageDiffService $diffService,
         private StudentViewHelper $studentViewHelper,
+        private CidReqHelper $cidReqHelper,
     ) {}
 
     /**
@@ -57,12 +59,12 @@ final readonly class WikiPageHistoryProvider implements ProviderInterface
             throw new BadRequestHttpException('The current request is required.');
         }
 
-        $course = $this->getWikiCourse($this->entityManager, $request);
+        $course = $this->getWikiCourse($this->cidReqHelper);
         $this->assertWikiToolEnabled($this->entityManager, $course);
         $nodeId = $this->assertWikiRouteNode($course, $request);
-        $session = $this->getWikiSession($this->entityManager, $request);
+        $session = $this->getWikiSession($this->cidReqHelper);
         $this->assertWikiSessionBelongsToCourse($session, $course);
-        $group = $this->getWikiGroup($this->entityManager, $request);
+        $group = $this->getWikiGroup($this->entityManager, $this->cidReqHelper);
         $this->assertWikiGroupBelongsToContext($group, $course, $session);
 
         if (!$this->canReadWikiContext($this->security, $this->settingsManager, $course, $session, $group)) {

--- a/src/CoreBundle/State/Wiki/WikiPageLockProcessor.php
+++ b/src/CoreBundle/State/Wiki/WikiPageLockProcessor.php
@@ -10,6 +10,7 @@ use ApiPlatform\Metadata\Operation;
 use ApiPlatform\State\ProcessorInterface;
 use Chamilo\CoreBundle\ApiResource\Wiki\WikiPageForm;
 use Chamilo\CoreBundle\Entity\User;
+use Chamilo\CoreBundle\Helpers\StudentViewHelper;
 use Chamilo\CoreBundle\Settings\SettingsManager;
 use Chamilo\CourseBundle\Entity\CWiki;
 use Chamilo\CourseBundle\Repository\CWikiRepository;
@@ -43,6 +44,7 @@ final readonly class WikiPageLockProcessor implements ProcessorInterface
         private Security $security,
         private SettingsManager $settingsManager,
         private CsrfTokenManagerInterface $csrfTokenManager,
+        private StudentViewHelper $studentViewHelper,
     ) {}
 
     /**
@@ -68,7 +70,7 @@ final readonly class WikiPageLockProcessor implements ProcessorInterface
         $group = $this->getWikiGroup($this->entityManager, $request);
         $this->assertWikiGroupBelongsToContext($group, $course, $session);
 
-        if ($this->isWikiStudentView($request)) {
+        if ($this->studentViewHelper->isStudentView()) {
             throw new AccessDeniedHttpException('Wiki pages cannot be edited in student view.');
         }
 

--- a/src/CoreBundle/State/Wiki/WikiPageLockProcessor.php
+++ b/src/CoreBundle/State/Wiki/WikiPageLockProcessor.php
@@ -10,6 +10,7 @@ use ApiPlatform\Metadata\Operation;
 use ApiPlatform\State\ProcessorInterface;
 use Chamilo\CoreBundle\ApiResource\Wiki\WikiPageForm;
 use Chamilo\CoreBundle\Entity\User;
+use Chamilo\CoreBundle\Helpers\CidReqHelper;
 use Chamilo\CoreBundle\Helpers\StudentViewHelper;
 use Chamilo\CoreBundle\Settings\SettingsManager;
 use Chamilo\CourseBundle\Entity\CWiki;
@@ -45,6 +46,7 @@ final readonly class WikiPageLockProcessor implements ProcessorInterface
         private SettingsManager $settingsManager,
         private CsrfTokenManagerInterface $csrfTokenManager,
         private StudentViewHelper $studentViewHelper,
+        private CidReqHelper $cidReqHelper,
     ) {}
 
     /**
@@ -62,12 +64,12 @@ final readonly class WikiPageLockProcessor implements ProcessorInterface
             throw new BadRequestHttpException('The current request is required.');
         }
 
-        $course = $this->getWikiCourse($this->entityManager, $request);
+        $course = $this->getWikiCourse($this->cidReqHelper);
         $this->assertWikiToolEnabled($this->entityManager, $course);
         $this->assertWikiRouteNode($course, $request);
-        $session = $this->getWikiSession($this->entityManager, $request);
+        $session = $this->getWikiSession($this->cidReqHelper);
         $this->assertWikiSessionBelongsToCourse($session, $course);
-        $group = $this->getWikiGroup($this->entityManager, $request);
+        $group = $this->getWikiGroup($this->entityManager, $this->cidReqHelper);
         $this->assertWikiGroupBelongsToContext($group, $course, $session);
 
         if ($this->studentViewHelper->isStudentView()) {

--- a/src/CoreBundle/State/Wiki/WikiPageProvider.php
+++ b/src/CoreBundle/State/Wiki/WikiPageProvider.php
@@ -11,6 +11,7 @@ use ApiPlatform\State\ProviderInterface;
 use Chamilo\CoreBundle\ApiResource\Wiki\WikiPage;
 use Chamilo\CoreBundle\ApiResource\Wiki\WikiPageAction;
 use Chamilo\CoreBundle\Entity\User;
+use Chamilo\CoreBundle\Helpers\CidReqHelper;
 use Chamilo\CoreBundle\Helpers\StudentViewHelper;
 use Chamilo\CoreBundle\Settings\SettingsManager;
 use Chamilo\CourseBundle\Entity\CWiki;
@@ -48,6 +49,7 @@ final readonly class WikiPageProvider implements ProviderInterface
         private WikiAssignmentFeedbackResolver $feedbackResolver,
         private WikiCategoryService $categoryService,
         private StudentViewHelper $studentViewHelper,
+        private CidReqHelper $cidReqHelper,
     ) {}
 
     /**
@@ -61,12 +63,12 @@ final readonly class WikiPageProvider implements ProviderInterface
             throw new BadRequestHttpException('The current request is required.');
         }
 
-        $course = $this->getWikiCourse($this->entityManager, $request);
+        $course = $this->getWikiCourse($this->cidReqHelper);
         $this->assertWikiToolEnabled($this->entityManager, $course);
         $nodeId = $this->assertWikiRouteNode($course, $request);
-        $session = $this->getWikiSession($this->entityManager, $request);
+        $session = $this->getWikiSession($this->cidReqHelper);
         $this->assertWikiSessionBelongsToCourse($session, $course);
-        $group = $this->getWikiGroup($this->entityManager, $request);
+        $group = $this->getWikiGroup($this->entityManager, $this->cidReqHelper);
         $this->assertWikiGroupBelongsToContext($group, $course, $session);
 
         if (!$this->canReadWikiContext($this->security, $this->settingsManager, $course, $session, $group)) {

--- a/src/CoreBundle/State/Wiki/WikiPageProvider.php
+++ b/src/CoreBundle/State/Wiki/WikiPageProvider.php
@@ -11,6 +11,7 @@ use ApiPlatform\State\ProviderInterface;
 use Chamilo\CoreBundle\ApiResource\Wiki\WikiPage;
 use Chamilo\CoreBundle\ApiResource\Wiki\WikiPageAction;
 use Chamilo\CoreBundle\Entity\User;
+use Chamilo\CoreBundle\Helpers\StudentViewHelper;
 use Chamilo\CoreBundle\Settings\SettingsManager;
 use Chamilo\CourseBundle\Entity\CWiki;
 use Chamilo\CourseBundle\Entity\CWikiConf;
@@ -46,6 +47,7 @@ final readonly class WikiPageProvider implements ProviderInterface
         private WikiPageRenderer $renderer,
         private WikiAssignmentFeedbackResolver $feedbackResolver,
         private WikiCategoryService $categoryService,
+        private StudentViewHelper $studentViewHelper,
     ) {}
 
     /**
@@ -73,7 +75,7 @@ final readonly class WikiPageProvider implements ProviderInterface
 
         $this->registerToolAccess();
 
-        $studentView = $this->isWikiStudentView($request);
+        $studentView = $this->studentViewHelper->isStudentView();
         $canManage = !$studentView && $this->canManageWikiContext(
             $this->entityManager,
             $this->security,

--- a/src/CoreBundle/State/Wiki/WikiPageRestoreProcessor.php
+++ b/src/CoreBundle/State/Wiki/WikiPageRestoreProcessor.php
@@ -10,6 +10,7 @@ use ApiPlatform\Metadata\Operation;
 use ApiPlatform\State\ProcessorInterface;
 use Chamilo\CoreBundle\ApiResource\Wiki\WikiPageHistory;
 use Chamilo\CoreBundle\Entity\User;
+use Chamilo\CoreBundle\Helpers\CidReqHelper;
 use Chamilo\CoreBundle\Helpers\StudentViewHelper;
 use Chamilo\CoreBundle\Settings\SettingsManager;
 use Chamilo\CourseBundle\Entity\CWiki;
@@ -49,6 +50,7 @@ final readonly class WikiPageRestoreProcessor implements ProcessorInterface
         private WikiPageRenderer $renderer,
         private WikiNotificationService $notificationService,
         private StudentViewHelper $studentViewHelper,
+        private CidReqHelper $cidReqHelper,
     ) {}
 
     /**
@@ -66,12 +68,12 @@ final readonly class WikiPageRestoreProcessor implements ProcessorInterface
             throw new BadRequestHttpException('The current request is required.');
         }
 
-        $course = $this->getWikiCourse($this->entityManager, $request);
+        $course = $this->getWikiCourse($this->cidReqHelper);
         $this->assertWikiToolEnabled($this->entityManager, $course);
         $nodeId = $this->assertWikiRouteNode($course, $request);
-        $session = $this->getWikiSession($this->entityManager, $request);
+        $session = $this->getWikiSession($this->cidReqHelper);
         $this->assertWikiSessionBelongsToCourse($session, $course);
-        $group = $this->getWikiGroup($this->entityManager, $request);
+        $group = $this->getWikiGroup($this->entityManager, $this->cidReqHelper);
         $this->assertWikiGroupBelongsToContext($group, $course, $session);
 
         if ($this->studentViewHelper->isStudentView()) {

--- a/src/CoreBundle/State/Wiki/WikiPageRestoreProcessor.php
+++ b/src/CoreBundle/State/Wiki/WikiPageRestoreProcessor.php
@@ -10,6 +10,7 @@ use ApiPlatform\Metadata\Operation;
 use ApiPlatform\State\ProcessorInterface;
 use Chamilo\CoreBundle\ApiResource\Wiki\WikiPageHistory;
 use Chamilo\CoreBundle\Entity\User;
+use Chamilo\CoreBundle\Helpers\StudentViewHelper;
 use Chamilo\CoreBundle\Settings\SettingsManager;
 use Chamilo\CourseBundle\Entity\CWiki;
 use Chamilo\CourseBundle\Entity\CWikiConf;
@@ -47,6 +48,7 @@ final readonly class WikiPageRestoreProcessor implements ProcessorInterface
         private CsrfTokenManagerInterface $csrfTokenManager,
         private WikiPageRenderer $renderer,
         private WikiNotificationService $notificationService,
+        private StudentViewHelper $studentViewHelper,
     ) {}
 
     /**
@@ -72,7 +74,7 @@ final readonly class WikiPageRestoreProcessor implements ProcessorInterface
         $group = $this->getWikiGroup($this->entityManager, $request);
         $this->assertWikiGroupBelongsToContext($group, $course, $session);
 
-        if ($this->isWikiStudentView($request)) {
+        if ($this->studentViewHelper->isStudentView()) {
             throw new AccessDeniedHttpException('Wiki versions cannot be restored in student view.');
         }
 

--- a/src/CoreBundle/State/Wiki/WikiReportProvider.php
+++ b/src/CoreBundle/State/Wiki/WikiReportProvider.php
@@ -13,6 +13,7 @@ use Chamilo\CoreBundle\ApiResource\Wiki\WikiReport;
 use Chamilo\CoreBundle\Entity\Course;
 use Chamilo\CoreBundle\Entity\Session;
 use Chamilo\CoreBundle\Entity\User;
+use Chamilo\CoreBundle\Helpers\CidReqHelper;
 use Chamilo\CoreBundle\Helpers\StudentViewHelper;
 use Chamilo\CoreBundle\Settings\SettingsManager;
 use Chamilo\CourseBundle\Entity\CGroup;
@@ -66,6 +67,7 @@ final readonly class WikiReportProvider implements ProviderInterface
         private WikiPageRenderer $renderer,
         private WikiCategoryService $categoryService,
         private StudentViewHelper $studentViewHelper,
+        private CidReqHelper $cidReqHelper,
     ) {}
 
     /**
@@ -79,12 +81,12 @@ final readonly class WikiReportProvider implements ProviderInterface
             throw new BadRequestHttpException('The current request is required.');
         }
 
-        $course = $this->getWikiCourse($this->entityManager, $request);
+        $course = $this->getWikiCourse($this->cidReqHelper);
         $this->assertWikiToolEnabled($this->entityManager, $course);
         $nodeId = $this->assertWikiRouteNode($course, $request);
-        $session = $this->getWikiSession($this->entityManager, $request);
+        $session = $this->getWikiSession($this->cidReqHelper);
         $this->assertWikiSessionBelongsToCourse($session, $course);
-        $group = $this->getWikiGroup($this->entityManager, $request);
+        $group = $this->getWikiGroup($this->entityManager, $this->cidReqHelper);
         $this->assertWikiGroupBelongsToContext($group, $course, $session);
 
         if (!$this->canReadWikiContext($this->security, $this->settingsManager, $course, $session, $group)) {

--- a/src/CoreBundle/State/Wiki/WikiReportProvider.php
+++ b/src/CoreBundle/State/Wiki/WikiReportProvider.php
@@ -13,6 +13,7 @@ use Chamilo\CoreBundle\ApiResource\Wiki\WikiReport;
 use Chamilo\CoreBundle\Entity\Course;
 use Chamilo\CoreBundle\Entity\Session;
 use Chamilo\CoreBundle\Entity\User;
+use Chamilo\CoreBundle\Helpers\StudentViewHelper;
 use Chamilo\CoreBundle\Settings\SettingsManager;
 use Chamilo\CourseBundle\Entity\CGroup;
 use Chamilo\CourseBundle\Entity\CWiki;
@@ -64,6 +65,7 @@ final readonly class WikiReportProvider implements ProviderInterface
         private CsrfTokenManagerInterface $csrfTokenManager,
         private WikiPageRenderer $renderer,
         private WikiCategoryService $categoryService,
+        private StudentViewHelper $studentViewHelper,
     ) {}
 
     /**
@@ -89,7 +91,7 @@ final readonly class WikiReportProvider implements ProviderInterface
             throw new AccessDeniedHttpException('You are not allowed to read Wiki reports in this context.');
         }
 
-        $studentView = $this->isWikiStudentView($request);
+        $studentView = $this->studentViewHelper->isStudentView();
         $canManage = !$studentView && $this->canManageWikiContext(
             $this->entityManager,
             $this->security,

--- a/src/CoreBundle/State/Wiki/WikiSettingsProcessor.php
+++ b/src/CoreBundle/State/Wiki/WikiSettingsProcessor.php
@@ -9,6 +9,7 @@ namespace Chamilo\CoreBundle\State\Wiki;
 use ApiPlatform\Metadata\Operation;
 use ApiPlatform\State\ProcessorInterface;
 use Chamilo\CoreBundle\ApiResource\Wiki\WikiSettings;
+use Chamilo\CoreBundle\Helpers\CidReqHelper;
 use Chamilo\CoreBundle\Helpers\StudentViewHelper;
 use Chamilo\CourseBundle\Settings\SettingsCourseManager;
 use Doctrine\ORM\EntityManagerInterface;
@@ -32,6 +33,7 @@ final readonly class WikiSettingsProcessor implements ProcessorInterface
         private CsrfTokenManagerInterface $csrfTokenManager,
         private SettingsCourseManager $settingsCourseManager,
         private StudentViewHelper $studentViewHelper,
+        private CidReqHelper $cidReqHelper,
     ) {}
 
     /**
@@ -49,11 +51,11 @@ final readonly class WikiSettingsProcessor implements ProcessorInterface
             throw new BadRequestHttpException('The current request is required.');
         }
 
-        $course = $this->getWikiCourse($this->entityManager, $request);
+        $course = $this->getWikiCourse($this->cidReqHelper);
         $this->assertWikiRouteNode($course, $request);
-        $session = $this->getWikiSession($this->entityManager, $request);
+        $session = $this->getWikiSession($this->cidReqHelper);
         $this->assertWikiSessionBelongsToCourse($session, $course);
-        $group = $this->getWikiGroup($this->entityManager, $request);
+        $group = $this->getWikiGroup($this->entityManager, $this->cidReqHelper);
         $this->assertWikiGroupBelongsToContext($group, $course, $session);
 
         if ($this->studentViewHelper->isStudentView() || !$this->canManageWikiCourseSettings($this->security, $course)) {

--- a/src/CoreBundle/State/Wiki/WikiSettingsProcessor.php
+++ b/src/CoreBundle/State/Wiki/WikiSettingsProcessor.php
@@ -9,6 +9,7 @@ namespace Chamilo\CoreBundle\State\Wiki;
 use ApiPlatform\Metadata\Operation;
 use ApiPlatform\State\ProcessorInterface;
 use Chamilo\CoreBundle\ApiResource\Wiki\WikiSettings;
+use Chamilo\CoreBundle\Helpers\StudentViewHelper;
 use Chamilo\CourseBundle\Settings\SettingsCourseManager;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\SecurityBundle\Security;
@@ -30,6 +31,7 @@ final readonly class WikiSettingsProcessor implements ProcessorInterface
         private Security $security,
         private CsrfTokenManagerInterface $csrfTokenManager,
         private SettingsCourseManager $settingsCourseManager,
+        private StudentViewHelper $studentViewHelper,
     ) {}
 
     /**
@@ -54,7 +56,7 @@ final readonly class WikiSettingsProcessor implements ProcessorInterface
         $group = $this->getWikiGroup($this->entityManager, $request);
         $this->assertWikiGroupBelongsToContext($group, $course, $session);
 
-        if ($this->isWikiStudentView($request) || !$this->canManageWikiCourseSettings($this->security, $course)) {
+        if ($this->studentViewHelper->isStudentView() || !$this->canManageWikiCourseSettings($this->security, $course)) {
             throw new AccessDeniedHttpException('You are not allowed to manage Wiki settings.');
         }
 

--- a/src/CoreBundle/State/Wiki/WikiSettingsProvider.php
+++ b/src/CoreBundle/State/Wiki/WikiSettingsProvider.php
@@ -9,6 +9,7 @@ namespace Chamilo\CoreBundle\State\Wiki;
 use ApiPlatform\Metadata\Operation;
 use ApiPlatform\State\ProviderInterface;
 use Chamilo\CoreBundle\ApiResource\Wiki\WikiSettings;
+use Chamilo\CoreBundle\Helpers\CidReqHelper;
 use Chamilo\CoreBundle\Helpers\StudentViewHelper;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\SecurityBundle\Security;
@@ -29,6 +30,7 @@ final readonly class WikiSettingsProvider implements ProviderInterface
         private Security $security,
         private CsrfTokenManagerInterface $csrfTokenManager,
         private StudentViewHelper $studentViewHelper,
+        private CidReqHelper $cidReqHelper,
     ) {}
 
     /**
@@ -42,11 +44,11 @@ final readonly class WikiSettingsProvider implements ProviderInterface
             throw new BadRequestHttpException('The current request is required.');
         }
 
-        $course = $this->getWikiCourse($this->entityManager, $request);
+        $course = $this->getWikiCourse($this->cidReqHelper);
         $this->assertWikiRouteNode($course, $request);
-        $session = $this->getWikiSession($this->entityManager, $request);
+        $session = $this->getWikiSession($this->cidReqHelper);
         $this->assertWikiSessionBelongsToCourse($session, $course);
-        $group = $this->getWikiGroup($this->entityManager, $request);
+        $group = $this->getWikiGroup($this->entityManager, $this->cidReqHelper);
         $this->assertWikiGroupBelongsToContext($group, $course, $session);
 
         if ($this->studentViewHelper->isStudentView() || !$this->canManageWikiCourseSettings($this->security, $course)) {

--- a/src/CoreBundle/State/Wiki/WikiSettingsProvider.php
+++ b/src/CoreBundle/State/Wiki/WikiSettingsProvider.php
@@ -9,6 +9,7 @@ namespace Chamilo\CoreBundle\State\Wiki;
 use ApiPlatform\Metadata\Operation;
 use ApiPlatform\State\ProviderInterface;
 use Chamilo\CoreBundle\ApiResource\Wiki\WikiSettings;
+use Chamilo\CoreBundle\Helpers\StudentViewHelper;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\HttpFoundation\Request;
@@ -27,6 +28,7 @@ final readonly class WikiSettingsProvider implements ProviderInterface
         private EntityManagerInterface $entityManager,
         private Security $security,
         private CsrfTokenManagerInterface $csrfTokenManager,
+        private StudentViewHelper $studentViewHelper,
     ) {}
 
     /**
@@ -47,7 +49,7 @@ final readonly class WikiSettingsProvider implements ProviderInterface
         $group = $this->getWikiGroup($this->entityManager, $request);
         $this->assertWikiGroupBelongsToContext($group, $course, $session);
 
-        if ($this->isWikiStudentView($request) || !$this->canManageWikiCourseSettings($this->security, $course)) {
+        if ($this->studentViewHelper->isStudentView() || !$this->canManageWikiCourseSettings($this->security, $course)) {
             throw new AccessDeniedHttpException('You are not allowed to manage Wiki settings.');
         }
 


### PR DESCRIPTION
Refs #8817 — the three context managers, one commit each: `CourseClass`, `CourseUser` and `CourseGroup`. Follow-up to #8818, which covered the trait-based blocks.

These three resolve the course context in a shared manager service rather than in a trait, so the shape of the change differs: `resolveContext(Request $request)` becomes `resolveContext()` reading from `CidReqHelper`, and the `Request` argument disappears from every method that only carried it through. In `CourseGroupManager` that is 19 of its 24 public methods — only `getListData()`, `getOverviewData()`, `getGroupFormData()` and `saveMembers()` keep it, because they also read `search` and `categoryId`, which are filters and not course context.

`CourseGroup` was listed in the issue as a single class, `CourseGroupOverviewProvider`. That class only read `cid`/`sid` inline to build export URLs; the actual read was in the manager, which 12 providers/processors and `CourseGroupExportController` all depend on. `CourseUserManager` and `CourseClassManager` were never listed at all — their resources happened to declare the parameters through `openapi: new Parameter`, which only documents, so the audit considered them covered even though they read from the Request just the same.

Two details worth reviewing:

- **The export URLs still carry `cid`/`sid`.** `/api/course-groups/export.{csv,xlsx,pdf}` and its CourseUser equivalent are plain Symfony routes, navigated as downloads, that resolve context from their own query string. Only the source of those values changed, not the fact that they are emitted — there is a comment in `CourseGroupOverviewProvider` saying so, because removing them would look like a harmless simplification and would silently break the export.
- **`resolveContext()` keeps asserting the course/session pairing.** `SessionVoter` only proves it for students and course coaches (it calls `hasUserInCourse`/`hasCourseCoachInCourse` with the current course); general coaches and admins reach the provider with any pair. All three managers already had this check and it is preserved, matching the assertion added to Forum and LearningPath at the end of #8818.

Where `$request` was left unused the dependency and its imports were dropped: `CourseClassActionProcessor`, `CourseUserImportProvider` and `CourseGroupImportProvider` no longer take `RequestStack`. `CourseUserActionProcessor` keeps it, since `normalizeType()` reads the `type` filter.

On the metadata side, 41 operations across 15 resources now declare `cid` (required), `sid` and, where the code reads it, `gid`. The pre-existing cosmetic `openapi: new Parameter` entries for those names were *moved* rather than duplicated; the other filter parameters in those blocks (`search`, `view`, `groupFilter`, `sort`, `order`, `page`, `itemsPerPage`, `extraFieldId`, …) are left untouched.

Checks: ECS clean. PHPStan unchanged against a baseline captured per block before editing — CourseClass 1, CourseUser 3, CourseGroup 4, all pre-existing, with only line numbers shifting. `api:openapi:export` regenerates cleanly; all 29 `course-group` routes, all 7 `course-user` routes and all 4 `course-class` routes expose their context, with no duplicate parameter names. `tests/CoreBundle/State/` passes 33/33. None of these three blocks has test coverage of its own, so beyond that the guarantee is static analysis and the OpenAPI export.

With this, re-running the audit from the issue reports **0 classes** with undeclared course context, down from the original 50.
