### PR TITLE
Fix six export endpoints returning HTTP 500 after the CidReqHelper migration

### DIFF
--- a/src/CoreBundle/Controller/Api/LearningPathChamiloBackupExportAction.php
+++ b/src/CoreBundle/Controller/Api/LearningPathChamiloBackupExportAction.php
@@ -7,6 +7,7 @@ declare(strict_types=1);
 namespace Chamilo\CoreBundle\Controller\Api;
 
 use Chamilo\CoreBundle\Entity\ResourceLink;
+use Chamilo\CoreBundle\Helpers\CidReqHelper;
 use Chamilo\CoreBundle\Service\LearningPath\LearningPathBackupEmptyException;
 use Chamilo\CoreBundle\Service\LearningPath\LearningPathBackupResourceException;
 use Chamilo\CoreBundle\Service\LearningPath\LearningPathChamiloBackupExportService;
@@ -42,6 +43,7 @@ final class LearningPathChamiloBackupExportAction extends AbstractController
         private readonly SettingsManager $settingsManager,
         private readonly CLpRepository $learningPathRepository,
         private readonly LearningPathChamiloBackupExportService $exportService,
+        private readonly CidReqHelper $cidReqHelper,
     ) {}
 
     #[Route(
@@ -56,9 +58,9 @@ final class LearningPathChamiloBackupExportAction extends AbstractController
             throw new AccessDeniedHttpException('Chamilo learning path export is disabled.');
         }
 
-        $course = $this->getContextCourse($this->entityManager, $request);
-        $session = $this->getContextSession($this->entityManager, $request, $course);
-        $group = $this->getContextGroup($this->entityManager, $request, $course);
+        $course = $this->getContextCourse($this->cidReqHelper);
+        $session = $this->cidReqHelper->getDoctrineSessionEntity();
+        $group = $this->getContextGroup($this->entityManager, $this->cidReqHelper, $course);
         if (null !== $group) {
             throw new BadRequestHttpException('Chamilo learning path export is not available in a group context.');
         }

--- a/src/CoreBundle/Controller/Api/LearningPathContentPdfAction.php
+++ b/src/CoreBundle/Controller/Api/LearningPathContentPdfAction.php
@@ -11,6 +11,7 @@ use Chamilo\CoreBundle\Entity\Course;
 use Chamilo\CoreBundle\Entity\ResourceLink;
 use Chamilo\CoreBundle\Entity\Session;
 use Chamilo\CoreBundle\Entity\User;
+use Chamilo\CoreBundle\Helpers\CidReqHelper;
 use Chamilo\CoreBundle\Helpers\LpAdvancedAccessHelper;
 use Chamilo\CoreBundle\Service\LearningPath\LearningPathContentPdfService;
 use Chamilo\CoreBundle\Settings\SettingsManager;
@@ -56,6 +57,7 @@ final class LearningPathContentPdfAction extends AbstractController
         private readonly LearningPathContentPdfService $contentPdfService,
         #[Autowire('%kernel.cache_dir%')]
         private readonly string $cacheDir,
+        private readonly CidReqHelper $cidReqHelper,
     ) {}
 
     #[Route(
@@ -139,9 +141,9 @@ final class LearningPathContentPdfAction extends AbstractController
             throw new AccessDeniedHttpException('Learning path PDF export is disabled.');
         }
 
-        $course = $this->getContextCourse($this->entityManager, $request);
-        $session = $this->getContextSession($this->entityManager, $request, $course);
-        $group = $this->getContextGroup($this->entityManager, $request, $course);
+        $course = $this->getContextCourse($this->cidReqHelper);
+        $session = $this->cidReqHelper->getDoctrineSessionEntity();
+        $group = $this->getContextGroup($this->entityManager, $this->cidReqHelper, $course);
         $lp = $this->lpRepository->find($lpId);
         if (!$lp instanceof CLp) {
             throw new NotFoundHttpException('Learning path not found.');

--- a/src/CoreBundle/Controller/Api/LearningPathScormPackageAction.php
+++ b/src/CoreBundle/Controller/Api/LearningPathScormPackageAction.php
@@ -10,6 +10,7 @@ use Chamilo\CoreBundle\Entity\Asset;
 use Chamilo\CoreBundle\Entity\Course;
 use Chamilo\CoreBundle\Entity\ResourceFile;
 use Chamilo\CoreBundle\Entity\ResourceLink;
+use Chamilo\CoreBundle\Helpers\CidReqHelper;
 use Chamilo\CoreBundle\Repository\AssetRepository;
 use Chamilo\CoreBundle\Repository\ResourceNodeRepository;
 use Chamilo\CoreBundle\Settings\SettingsManager;
@@ -45,6 +46,7 @@ final readonly class LearningPathScormPackageAction
         private ResourceNodeRepository $resourceNodeRepository,
         private CDocumentRepository $documentRepository,
         private CLpRepository $learningPathRepository,
+        private CidReqHelper $cidReqHelper,
     ) {}
 
     public function __invoke(int $lpId, Request $request): Response
@@ -53,15 +55,15 @@ final readonly class LearningPathScormPackageAction
             throw new AccessDeniedHttpException('SCORM package download is disabled.');
         }
 
-        $course = $this->getContextCourse($this->entityManager, $request);
+        $course = $this->getContextCourse($this->cidReqHelper);
         $requestedNodeId = $request->query->getInt('node');
         $courseNodeId = (int) ($course->getResourceNode()?->getId() ?? 0);
         if ($requestedNodeId > 0 && $requestedNodeId !== $courseNodeId) {
             throw new AccessDeniedHttpException('The requested resource node does not belong to this course.');
         }
 
-        $session = $this->getContextSession($this->entityManager, $request, $course);
-        $group = $this->getContextGroup($this->entityManager, $request, $course);
+        $session = $this->cidReqHelper->getDoctrineSessionEntity();
+        $group = $this->getContextGroup($this->entityManager, $this->cidReqHelper, $course);
 
         $learningPath = $this->learningPathRepository->find($lpId);
         if (!$learningPath instanceof CLp || CLp::SCORM_TYPE !== $learningPath->getLpType()) {

--- a/src/CoreBundle/Controller/Api/LearningPathScormRuntimePackageAction.php
+++ b/src/CoreBundle/Controller/Api/LearningPathScormRuntimePackageAction.php
@@ -11,6 +11,7 @@ use Chamilo\CoreBundle\Entity\Asset;
 use Chamilo\CoreBundle\Entity\Course;
 use Chamilo\CoreBundle\Entity\ResourceFile;
 use Chamilo\CoreBundle\Entity\ResourceLink;
+use Chamilo\CoreBundle\Helpers\CidReqHelper;
 use Chamilo\CoreBundle\Repository\AssetRepository;
 use Chamilo\CoreBundle\Repository\ResourceNodeRepository;
 use Chamilo\CoreBundle\Service\LearningPath\ScormRuntimeManager;
@@ -52,6 +53,7 @@ final readonly class LearningPathScormRuntimePackageAction
         private CLpItemRepository $learningPathItemRepository,
         private LearningPathRuntimeProvider $runtimeProvider,
         private ScormRuntimeManager $runtimeManager,
+        private CidReqHelper $cidReqHelper,
     ) {}
 
     public function __invoke(int $lpId, Request $request): Response
@@ -72,9 +74,9 @@ final readonly class LearningPathScormRuntimePackageAction
             throw new NotFoundHttpException('SCORM runtime package not found.');
         }
 
-        $course = $this->getContextCourse($this->entityManager, $request);
-        $session = $this->getContextSession($this->entityManager, $request, $course);
-        $group = $this->getContextGroup($this->entityManager, $request, $course);
+        $course = $this->getContextCourse($this->cidReqHelper);
+        $session = $this->cidReqHelper->getDoctrineSessionEntity();
+        $group = $this->getContextGroup($this->entityManager, $this->cidReqHelper, $course);
         $resourceNode = $learningPath->getResourceNode();
         if (null === $resourceNode || !$this->security->isGranted('VIEW', $resourceNode)) {
             throw new AccessDeniedHttpException('The SCORM learning path is not available.');

--- a/src/CoreBundle/Controller/Api/PortfolioExportController.php
+++ b/src/CoreBundle/Controller/Api/PortfolioExportController.php
@@ -14,6 +14,7 @@ use Chamilo\CoreBundle\Entity\Session;
 use Chamilo\CoreBundle\Entity\User;
 use Chamilo\CoreBundle\Event\Events;
 use Chamilo\CoreBundle\Event\PortfolioItemDownloadedEvent;
+use Chamilo\CoreBundle\Helpers\CidReqHelper;
 use Chamilo\CoreBundle\Helpers\UserHelper;
 use Chamilo\CoreBundle\Repository\Node\PortfolioCommentRepository;
 use Chamilo\CoreBundle\Repository\Node\PortfolioRepository;
@@ -55,6 +56,7 @@ final class PortfolioExportController extends AbstractController
         private readonly UserHelper $userHelper,
         private readonly SettingsManager $settingsManager,
         private readonly EventDispatcherInterface $eventDispatcher,
+        private readonly CidReqHelper $cidReqHelper,
     ) {}
 
     #[Route('/api/portfolio/export.pdf', name: 'api_portfolio_export_pdf', methods: ['GET'])]
@@ -138,8 +140,8 @@ final class PortfolioExportController extends AbstractController
     private function resolveExport(Request $request): array
     {
         $currentUser = $this->getPortfolioCurrentUser($this->userHelper);
-        $course = $this->getPortfolioCourse($this->entityManager, $request);
-        $session = $this->getPortfolioSession($this->entityManager, $request, $course);
+        $course = $this->cidReqHelper->getDoctrineCourseEntity();
+        $session = $this->cidReqHelper->getDoctrineSessionEntity();
         if ($course instanceof Course && !$this->canReadPortfolioCourse(
             $this->security,
             $this->userHelper,

--- a/src/CoreBundle/Controller/LearningPathScormContentController.php
+++ b/src/CoreBundle/Controller/LearningPathScormContentController.php
@@ -8,6 +8,7 @@ namespace Chamilo\CoreBundle\Controller;
 
 use ApiPlatform\Metadata\Get;
 use Chamilo\CoreBundle\Entity\ResourceLink;
+use Chamilo\CoreBundle\Helpers\CidReqHelper;
 use Chamilo\CoreBundle\Repository\AssetRepository;
 use Chamilo\CoreBundle\Service\LearningPath\ScormRuntimeManager;
 use Chamilo\CoreBundle\State\LearningPath\LearningPathRuntimeProvider;
@@ -57,6 +58,7 @@ final class LearningPathScormContentController extends AbstractController
         string $path,
         Request $request,
         EntityManagerInterface $entityManager,
+        CidReqHelper $cidReqHelper,
         Security $security,
         LearningPathRuntimeProvider $runtimeProvider,
         ScormRuntimeManager $runtimeManager,
@@ -80,9 +82,9 @@ final class LearningPathScormContentController extends AbstractController
             throw new NotFoundHttpException('SCORM content not found.');
         }
 
-        $course = $this->getContextCourse($entityManager, $request);
-        $session = $this->getContextSession($entityManager, $request, $course);
-        $group = $this->getContextGroup($entityManager, $request, $course);
+        $course = $this->getContextCourse($cidReqHelper);
+        $session = $cidReqHelper->getDoctrineSessionEntity();
+        $group = $this->getContextGroup($entityManager, $cidReqHelper, $course);
         $resourceNode = $lp->getResourceNode();
         if (null === $resourceNode || !$security->isGranted('VIEW', $resourceNode)) {
             throw new AccessDeniedHttpException('The SCORM learning path is not available.');


### PR DESCRIPTION
Six export endpoints currently return HTTP 500 on master. This restores them; it is a hotfix, nothing else.

#8818 changed the signatures of the context helpers in `LearningPathStateHelperTrait` and `PortfolioAccessHelperTrait`, but those traits are also consumed from `src/CoreBundle/Controller/`, and those call sites were not updated. `getContextCourse()` now takes a `CidReqHelper`, and `getContextSession()` / `getPortfolioCourse()` / `getPortfolioSession()` no longer exist at all, so the calls fail with `ArgumentCountError` and `Error: Call to undefined method` respectively. The calls sit at the top level of each method, so the failure is unconditional — any request to these routes returns a 500:

| Route | Feature |
|---|---|
| `GET /learning-path/scorm/{cid}/{sid}/{gid}/{lpId}/{itemId}/{path}` | Serving the assets of a SCORM package while a learner plays it |
| `GET /api/learning_paths/{lpId}/scorm/package` | SCORM package download |
| `GET /api/learning_paths/{lpId}/runtime/scorm/package` | SCORM package at runtime |
| `GET /api/learning_paths/{lpId}/content.pdf` | Learning path PDF export |
| `GET /api/learning_paths/{lpId}/content-pdf/items` | Item list backing that export |
| `GET /api/learning_paths/{lpId}/chamilo-backup.zip` | Chamilo backup of a learning path |
| `GET /api/portfolio/export.pdf` and `export.zip` | Portfolio export |

The first one is the reason this is worth a dedicated PR: it serves every HTML, JS, CSS and image inside a SCORM package, so SCORM learning paths cannot be opened at all.

The change per file is one import, one constructor parameter and the call sites realigned with the signatures that are **already on master**. No behaviour is modified and no helper is touched — this only makes the callers match what the traits now expect. `WikiPageExportController` also uses one of these traits but is unaffected on master, so it is not included.

Checks: ECS clean, `php -l` clean, and PHPStan on `src/CoreBundle/Controller` goes from 246 to 224 errors — **22 fixed, 0 introduced** — measured against master with the same command before and after.

Worth verifying by hand before merging, since none of these endpoints has test coverage: open a course with a SCORM learning path and play it, then try a learning path PDF export and a portfolio export.
