### PR TITLE
Internal: Restore MCP allowed roles value template

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -28,7 +28,7 @@ jobs:
               uses: shivammathur/setup-php@v2
               with:
                   php-version: ${{ matrix.php-versions }}
-                  extensions: mbstring, xml, ctype, iconv, intl, pdo, pdo_mysql, pdo_sqlite, sqlite3, dom, gd, json, soap, zip, bcmath
+                  extensions: mbstring, xml, ctype, iconv, intl, pdo, pdo_mysql, dom, gd, json, soap, zip, bcmath
                   ini-values: post_max_size=256M, max_execution_time=600, memory_limit=4096M, date.timezone=Europe/Paris
                   coverage: pcov
 

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -28,7 +28,7 @@ jobs:
               uses: shivammathur/setup-php@v2
               with:
                   php-version: ${{ matrix.php-versions }}
-                  extensions: mbstring, xml, ctype, iconv, intl, pdo, pdo_mysql, dom, gd, json, soap, zip, bcmath
+                  extensions: mbstring, xml, ctype, iconv, intl, pdo, pdo_mysql, pdo_sqlite, sqlite3, dom, gd, json, soap, zip, bcmath
                   ini-values: post_max_size=256M, max_execution_time=600, memory_limit=4096M, date.timezone=Europe/Paris
                   coverage: pcov
 

--- a/src/CoreBundle/Migrations/Schema/V300/Version20260807125041.php
+++ b/src/CoreBundle/Migrations/Schema/V300/Version20260807125041.php
@@ -1,0 +1,72 @@
+<?php
+
+/* For licensing terms, see /license.txt */
+
+declare(strict_types=1);
+
+namespace Chamilo\CoreBundle\Migrations\Schema\V300;
+
+use Chamilo\CoreBundle\Migrations\AbstractMigrationChamilo;
+use Doctrine\DBAL\Schema\Schema;
+
+use const JSON_THROW_ON_ERROR;
+use const JSON_UNESCAPED_SLASHES;
+use const JSON_UNESCAPED_UNICODE;
+
+final class Version20260807125041 extends AbstractMigrationChamilo
+{
+    private const string VARIABLE = 'mcp_allowed_roles';
+
+    private const array DEFAULT_ALLOWED_ROLES = [
+        'ADMIN' => true,
+        'COURSEMANAGER' => true,
+        'STUDENT' => false,
+        'DRH' => false,
+        'SESSIONADMIN' => false,
+        'STUDENT_BOSS' => false,
+        'INVITEE' => false,
+    ];
+
+    public function getDescription(): string
+    {
+        return 'Restore the MCP allowed-roles value template omitted by an overwritten fixture group.';
+    }
+
+    public function up(Schema $schema): void
+    {
+        if (!$schema->hasTable('settings_value_template')) {
+            return;
+        }
+
+        $templateJson = json_encode(
+            self::DEFAULT_ALLOWED_ROLES,
+            JSON_THROW_ON_ERROR | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE
+        );
+
+        $this->addSql(
+            'INSERT INTO settings_value_template (variable, json_example, created_at, updated_at) '
+            .'SELECT ?, ?, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP '
+            .'WHERE NOT EXISTS (SELECT 1 FROM settings_value_template WHERE variable = ?)',
+            [self::VARIABLE, $templateJson, self::VARIABLE]
+        );
+        $this->addSql(
+            'UPDATE settings_value_template SET json_example = ?, updated_at = CURRENT_TIMESTAMP WHERE variable = ?',
+            [$templateJson, self::VARIABLE]
+        );
+
+        if (!$schema->hasTable('settings') || !$schema->getTable('settings')->hasColumn('value_template_id')) {
+            return;
+        }
+
+        $this->addSql(
+            'UPDATE settings SET value_template_id = '
+            .'(SELECT id FROM settings_value_template WHERE variable = ?) WHERE variable = ?',
+            [self::VARIABLE, self::VARIABLE]
+        );
+    }
+
+    public function down(Schema $schema): void
+    {
+        // Preserve the template and administrator settings repaired by this migration.
+    }
+}

--- a/tests/CoreBundle/DataFixtures/SettingsValueTemplateFixturesTest.php
+++ b/tests/CoreBundle/DataFixtures/SettingsValueTemplateFixturesTest.php
@@ -1,0 +1,33 @@
+<?php
+
+/* For licensing terms, see /license.txt */
+
+declare(strict_types=1);
+
+namespace Chamilo\Tests\CoreBundle\DataFixtures;
+
+use Chamilo\CoreBundle\DataFixtures\SettingsValueTemplateFixtures;
+use PHPUnit\Framework\TestCase;
+
+final class SettingsValueTemplateFixturesTest extends TestCase
+{
+    public function testSecurityTemplatesIncludeMcpAllowedRoles(): void
+    {
+        $securityTemplates = SettingsValueTemplateFixtures::getTemplatesGrouped()['security'];
+        $templatesByVariable = array_column($securityTemplates, null, 'variable');
+
+        self::assertArrayHasKey('mcp_allowed_roles', $templatesByVariable);
+        self::assertSame(
+            [
+                'ADMIN' => true,
+                'COURSEMANAGER' => true,
+                'STUDENT' => false,
+                'DRH' => false,
+                'SESSIONADMIN' => false,
+                'STUDENT_BOSS' => false,
+                'INVITEE' => false,
+            ],
+            $templatesByVariable['mcp_allowed_roles']['json_example']
+        );
+    }
+}

--- a/tests/CoreBundle/Migrations/Version20260807125041Test.php
+++ b/tests/CoreBundle/Migrations/Version20260807125041Test.php
@@ -1,0 +1,176 @@
+<?php
+
+/* For licensing terms, see /license.txt */
+
+declare(strict_types=1);
+
+namespace Chamilo\Tests\CoreBundle\Migrations;
+
+use Chamilo\CoreBundle\Migrations\Schema\V300\Version20260807125041;
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\DriverManager;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+
+use const JSON_THROW_ON_ERROR;
+
+final class Version20260807125041Test extends TestCase
+{
+    private const array DEFAULT_ALLOWED_ROLES = [
+        'ADMIN' => true,
+        'COURSEMANAGER' => true,
+        'STUDENT' => false,
+        'DRH' => false,
+        'SESSIONADMIN' => false,
+        'STUDENT_BOSS' => false,
+        'INVITEE' => false,
+    ];
+
+    private Connection $connection;
+
+    protected function setUp(): void
+    {
+        $this->connection = DriverManager::getConnection(['driver' => 'pdo_sqlite', 'memory' => true]);
+        $this->connection->executeStatement(
+            'CREATE TABLE settings_value_template (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                variable VARCHAR(190) NOT NULL UNIQUE,
+                description TEXT DEFAULT NULL,
+                json_example TEXT DEFAULT NULL,
+                created_at DATETIME DEFAULT NULL,
+                updated_at DATETIME DEFAULT NULL
+            )'
+        );
+        $this->connection->executeStatement(
+            'CREATE TABLE settings (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                variable VARCHAR(190) NOT NULL,
+                selected_value TEXT DEFAULT NULL,
+                value_template_id INTEGER DEFAULT NULL
+            )'
+        );
+    }
+
+    protected function tearDown(): void
+    {
+        $this->connection->close();
+    }
+
+    public function testRepairsMissingTemplateAndLinksEverySettingIdempotently(): void
+    {
+        $this->connection->executeStatement(
+            'INSERT INTO settings (variable, selected_value) VALUES (?, ?), (?, ?)',
+            ['mcp_allowed_roles', '{"ADMIN":true}', 'mcp_allowed_roles', '{"STUDENT":true}']
+        );
+
+        $this->executeMigration();
+        $templateId = (int) $this->connection->fetchOne(
+            'SELECT id FROM settings_value_template WHERE variable = ?',
+            ['mcp_allowed_roles']
+        );
+        $this->executeMigration();
+
+        self::assertSame(
+            1,
+            (int) $this->connection->fetchOne(
+                'SELECT COUNT(*) FROM settings_value_template WHERE variable = ?',
+                ['mcp_allowed_roles']
+            )
+        );
+        self::assertSame(
+            self::DEFAULT_ALLOWED_ROLES,
+            json_decode(
+                (string) $this->connection->fetchOne(
+                    'SELECT json_example FROM settings_value_template WHERE id = ?',
+                    [$templateId]
+                ),
+                true,
+                512,
+                JSON_THROW_ON_ERROR
+            )
+        );
+        self::assertSame(
+            [
+                ['selected_value' => '{"ADMIN":true}', 'value_template_id' => $templateId],
+                ['selected_value' => '{"STUDENT":true}', 'value_template_id' => $templateId],
+            ],
+            $this->connection->fetchAllAssociative(
+                'SELECT selected_value, value_template_id FROM settings WHERE variable = ? ORDER BY id',
+                ['mcp_allowed_roles']
+            )
+        );
+    }
+
+    public function testUpdatesStaleTemplateWithoutChangingUnrelatedSettings(): void
+    {
+        $this->connection->executeStatement(
+            'INSERT INTO settings_value_template (variable, json_example) VALUES (?, ?), (?, ?)',
+            ['unrelated', '{}', 'mcp_allowed_roles', '{"ADMIN":false}']
+        );
+        $unrelatedTemplateId = (int) $this->connection->fetchOne(
+            'SELECT id FROM settings_value_template WHERE variable = ?',
+            ['unrelated']
+        );
+        $mcpTemplateId = (int) $this->connection->fetchOne(
+            'SELECT id FROM settings_value_template WHERE variable = ?',
+            ['mcp_allowed_roles']
+        );
+        $this->connection->executeStatement(
+            'INSERT INTO settings (variable, selected_value, value_template_id) VALUES (?, ?, ?), (?, ?, ?)',
+            [
+                'mcp_allowed_roles',
+                '{"ADMIN":false}',
+                $unrelatedTemplateId,
+                'unrelated',
+                'keep-me',
+                $unrelatedTemplateId,
+            ]
+        );
+
+        $this->executeMigration();
+
+        self::assertSame(
+            self::DEFAULT_ALLOWED_ROLES,
+            json_decode(
+                (string) $this->connection->fetchOne(
+                    'SELECT json_example FROM settings_value_template WHERE id = ?',
+                    [$mcpTemplateId]
+                ),
+                true,
+                512,
+                JSON_THROW_ON_ERROR
+            )
+        );
+        self::assertSame(
+            [
+                [
+                    'variable' => 'mcp_allowed_roles',
+                    'selected_value' => '{"ADMIN":false}',
+                    'value_template_id' => $mcpTemplateId,
+                ],
+                [
+                    'variable' => 'unrelated',
+                    'selected_value' => 'keep-me',
+                    'value_template_id' => $unrelatedTemplateId,
+                ],
+            ],
+            $this->connection->fetchAllAssociative(
+                'SELECT variable, selected_value, value_template_id FROM settings ORDER BY id'
+            )
+        );
+    }
+
+    private function executeMigration(): void
+    {
+        $migration = new Version20260807125041($this->connection, new NullLogger());
+        $migration->up($this->connection->createSchemaManager()->introspectSchema());
+
+        foreach ($migration->getSql() as $query) {
+            $this->connection->executeStatement(
+                $query->getStatement(),
+                $query->getParameters(),
+                $query->getTypes()
+            );
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- add a focused fixture regression test so duplicate category keys cannot silently drop `mcp_allowed_roles`
- add an idempotent V300 repair migration for fresh 3.0 beta databases created during the broken-fixture window
- insert or refresh the template and link every matching settings row without changing administrator-selected values
- explicitly enable the SQLite extensions used by the migration regression tests

## Context

Upstream commit f4b1ed8526 fixed the duplicate `security` fixture key for future installs. The original MCP V300 migration already covers normal database upgrades, but a fresh install creates the current schema and loads fixtures without executing migrations. Fresh databases created between the MCP addition and the fixture fix could therefore retain a missing template after an in-place code update.

The forward repair belongs in V300 because MCP is a 3.0 feature. Its `down()` intentionally preserves repaired template and administrator data.

## Validation

- PHPUnit: 3 tests, 7 assertions
- PHP syntax checks
- ECS: no errors
- Psalm: no errors
- workflow YAML parse
- `git diff --check`

## Deployment note

The existing in-app update runner still hard-codes V210 migration paths. That stale version-policy restriction is tracked separately in #8845 rather than placing a 3.0 MCP repair in V210.