### PR TITLE
Security: harden PENS remote transport against SSRF

### DIFF
--- a/public/plugin/Pens/lib/PensProcessor.php
+++ b/public/plugin/Pens/lib/PensProcessor.php
@@ -1,8 +1,14 @@
 <?php
 
+declare(strict_types=1);
+
 /* For licensing terms, see /license.txt. */
 
+use Chamilo\CoreBundle\Service\Pens\PensRemoteException;
+use Chamilo\CoreBundle\Service\Pens\PensRemoteTransport;
+
 require_once __DIR__.'/../../../main/inc/global.inc.php';
+
 require_once __DIR__.'/pens.php';
 
 /**
@@ -10,11 +16,16 @@ require_once __DIR__.'/pens.php';
  */
 class PensProcessor
 {
-    private const TABLE_PENS = 'plugin_pens';
-    private const SUPPORTED_PACKAGE_TYPES = ['scorm-pif'];
-    private const SUPPORTED_PACKAGE_FORMATS = ['zip'];
-    private const ALLOWED_REMOTE_SCHEMES = ['http', 'https'];
-    private const MAX_PACKAGE_BYTES = 104857600; // 100 MB
+    private const string TABLE_PENS = 'plugin_pens';
+    private const array SUPPORTED_PACKAGE_TYPES = ['scorm-pif'];
+    private const array SUPPORTED_PACKAGE_FORMATS = ['zip'];
+
+    private PensRemoteTransport $remoteTransport;
+
+    public function __construct(?PensRemoteTransport $remoteTransport = null)
+    {
+        $this->remoteTransport = $remoteTransport ?? new PensRemoteTransport();
+    }
 
     /**
      * Handle a PENS collect request and return the plain-text PENS response.
@@ -105,126 +116,77 @@ class PensProcessor
      */
     private function collectPackage(PENSRequestCollect $request): string
     {
-        error_log('[Pens][collectPackage] start package-url='.$request->getPackageUrl());
+        error_log('[Pens][collectPackage] start');
 
         if (!in_array($request->getPackageType(), self::SUPPORTED_PACKAGE_TYPES, true)) {
             error_log('[Pens][collectPackage] invalid package type');
+
             throw new PENSException(1430);
         }
 
         if (!in_array($request->getPackageFormat(), self::SUPPORTED_PACKAGE_FORMATS, true)) {
             error_log('[Pens][collectPackage] invalid package format');
+
             throw new PENSException(1431);
         }
 
         if (!$this->isExpiryDateValid($request->getPackageUrlExpiry())) {
             error_log('[Pens][collectPackage] expired package url');
-            throw new PENSException(1322);
-        }
 
-        if (!$this->isAllowedPackageUrl($request->getPackageUrl())) {
-            error_log('[Pens][collectPackage] download url rejected');
-            throw new PENSException(1301);
+            throw new PENSException(1322);
         }
 
         $temporaryPackagePath = tempnam(sys_get_temp_dir(), 'pens_');
 
         if (false === $temporaryPackagePath) {
             error_log('[Pens][collectPackage] tempnam failed');
+
             throw new PENSException(1432);
         }
 
-        $fileHandle = fopen($temporaryPackagePath, 'w');
+        $fileHandle = fopen($temporaryPackagePath, 'wb');
 
         if (false === $fileHandle) {
+            unlink($temporaryPackagePath);
             error_log('[Pens][collectPackage] fopen failed');
+
             throw new PENSException(1432);
         }
 
-        $curlHandle = curl_init();
-        curl_setopt($curlHandle, CURLOPT_URL, $request->getPackageUrl());
-        curl_setopt($curlHandle, CURLOPT_HEADER, false);
-        curl_setopt($curlHandle, CURLOPT_FILE, $fileHandle);
-        curl_setopt($curlHandle, CURLOPT_FOLLOWLOCATION, false);
-        curl_setopt($curlHandle, CURLOPT_CONNECTTIMEOUT, 15);
-        curl_setopt($curlHandle, CURLOPT_TIMEOUT, 300);
-
-        if (null !== $request->getPackageUrlUserId()) {
-            curl_setopt(
-                $curlHandle,
-                CURLOPT_USERPWD,
-                $request->getPackageUrlUserId().':'.$request->getPackageUrlPassword()
+        try {
+            $downloadedSize = $this->remoteTransport->downloadToStream(
+                (string) $request->getPackageUrl(),
+                $fileHandle,
+                null !== $request->getPackageUrlUserId() ? (string) $request->getPackageUrlUserId() : null,
+                null !== $request->getPackageUrlPassword() ? (string) $request->getPackageUrlPassword() : null
             );
-        }
-
-        $result = curl_exec($curlHandle);
-        $curlErrorNumber = curl_errno($curlHandle);
-        $curlErrorMessage = curl_error($curlHandle);
-        $httpStatusCode = (int) curl_getinfo($curlHandle, CURLINFO_RESPONSE_CODE);
-
-        curl_close($curlHandle);
-        fclose($fileHandle);
-
-        error_log('[Pens][collectPackage] curl result='.var_export($result, true).' errno='.$curlErrorNumber.' http='.$httpStatusCode.' error='.$curlErrorMessage);
-
-        if (false === $result) {
-            if (is_file($temporaryPackagePath)) {
-                unlink($temporaryPackagePath);
-            }
-
-            switch ($curlErrorNumber) {
-                case CURLE_UNSUPPORTED_PROTOCOL:
-                    throw new PENSException(1301);
-
-                case CURLE_URL_MALFORMAT:
-                case CURLE_COULDNT_RESOLVE_PROXY:
-                case CURLE_COULDNT_RESOLVE_HOST:
-                case CURLE_COULDNT_CONNECT:
-                case CURLE_OPERATION_TIMEOUTED:
-                case 78: //CURLE_REMOTE_FILE_NOT_FOUND
-                    throw new PENSException(1310);
-
-                case CURLE_FTP_ACCESS_DENIED: //CURLE_REMOTE_ACCESS_DENIED
-                    throw new PENSException(1312);
-
-                default:
-                    throw new PENSException(1301);
-            }
-        }
-
-        if (401 === $httpStatusCode || 403 === $httpStatusCode) {
+        } catch (PensRemoteException $exception) {
+            fclose($fileHandle);
             unlink($temporaryPackagePath);
-            error_log('[Pens][collectPackage] rejected by remote server');
-            throw new PENSException(1312);
-        }
+            error_log('[Pens][collectPackage] safe download failed: '.$exception->getMessage());
 
-        if ($httpStatusCode >= 400) {
+            throw new PENSException($exception->getPensErrorCode());
+        } catch (Throwable $exception) {
+            fclose($fileHandle);
             unlink($temporaryPackagePath);
-            error_log('[Pens][collectPackage] remote server returned http >= 400');
-            throw new PENSException(1310);
+            error_log('[Pens][collectPackage] internal download failure: '.$exception->getMessage());
+
+            throw new PENSException(1432);
         }
 
-        $downloadedSize = @filesize($temporaryPackagePath);
-        error_log('[Pens][collectPackage] downloaded size='.var_export($downloadedSize, true));
-
-        if (false === $downloadedSize || 0 === $downloadedSize) {
-            if (is_file($temporaryPackagePath)) {
-                unlink($temporaryPackagePath);
-            }
-
-            error_log('[Pens][collectPackage] invalid downloaded size');
-            throw new PENSException(1310);
-        }
-
-        if ($downloadedSize > self::MAX_PACKAGE_BYTES) {
+        if (!fclose($fileHandle)) {
             unlink($temporaryPackagePath);
-            error_log('[Pens][collectPackage] file too large');
-            throw new PENSException(1310);
+            error_log('[Pens][collectPackage] closing temporary file failed');
+
+            throw new PENSException(1440);
         }
+
+        error_log('[Pens][collectPackage] downloaded size='.$downloadedSize);
 
         if (!$this->hasZipSignature($temporaryPackagePath)) {
             unlink($temporaryPackagePath);
             error_log('[Pens][collectPackage] invalid zip signature');
+
             throw new PENSException(1310);
         }
 
@@ -370,23 +332,15 @@ class PensProcessor
             return;
         }
 
-        if (!$this->isAllowedCallbackUrl($url)) {
-            return;
-        }
-
         $parameters = 'alert' === $mode
             ? array_merge($request->getSendAlertArray(), $response->getArray())
             : array_merge($request->getSendReceiptArray(), $response->getArray());
 
-        $curlHandle = curl_init($url);
-        curl_setopt($curlHandle, CURLOPT_POST, true);
-        curl_setopt($curlHandle, CURLOPT_POSTFIELDS, $parameters);
-        curl_setopt($curlHandle, CURLOPT_RETURNTRANSFER, true);
-        curl_setopt($curlHandle, CURLOPT_FOLLOWLOCATION, false);
-        curl_setopt($curlHandle, CURLOPT_CONNECTTIMEOUT, 15);
-        curl_setopt($curlHandle, CURLOPT_TIMEOUT, 60);
-        curl_exec($curlHandle);
-        curl_close($curlHandle);
+        try {
+            $this->remoteTransport->sendCallback($url, $parameters);
+        } catch (PensRemoteException $exception) {
+            error_log('[Pens][sendCallback] safe callback failed: '.$exception->getMessage());
+        }
     }
 
     /**
@@ -420,85 +374,6 @@ class PensProcessor
     }
 
     /**
-     * Allow package URLs pointing to public hosts or to the current Chamilo host.
-     */
-    private function isAllowedPackageUrl(string $url): bool
-    {
-        return $this->isAllowedRemoteUrl($url, true);
-    }
-
-    /**
-     * Allow callback URLs pointing to public hosts only (no private/reserved ranges).
-     */
-    private function isAllowedCallbackUrl(string $url): bool
-    {
-        return $this->isAllowedRemoteUrl($url, false);
-    }
-
-    /**
-     * Allow only public HTTP(S) URLs, except the current Chamilo host for local development.
-     */
-    private function isAllowedRemoteUrl(string $url, bool $allowCurrentHost): bool
-    {
-        $parts = parse_url($url);
-        if (!is_array($parts)) {
-            return false;
-        }
-
-        $scheme = strtolower((string) ($parts['scheme'] ?? ''));
-        if (!in_array($scheme, self::ALLOWED_REMOTE_SCHEMES, true)) {
-            return false;
-        }
-
-        $host = strtolower((string) ($parts['host'] ?? ''));
-        if ('' === $host) {
-            return false;
-        }
-
-        if ($this->isLocalHostName($host)) {
-            return $allowCurrentHost && $this->isCurrentApplicationHost($host);
-        }
-
-        $resolvedIp = gethostbyname($host);
-        if (filter_var($resolvedIp, FILTER_VALIDATE_IP)) {
-            $isPublicIp = filter_var(
-                $resolvedIp,
-                FILTER_VALIDATE_IP,
-                FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE
-            );
-
-            if (!$isPublicIp) {
-                return $allowCurrentHost && $this->isCurrentApplicationHost($host);
-            }
-        }
-
-        return true;
-    }
-
-    /**
-     * Check whether the host matches the current Chamilo host.
-     */
-    private function isCurrentApplicationHost(string $host): bool
-    {
-        $host = strtolower(trim($host));
-        $currentHost = strtolower((string) parse_url(api_get_path(WEB_PATH), PHP_URL_HOST));
-
-        if ('' !== $currentHost && $host === $currentHost) {
-            return true;
-        }
-
-        return false;
-    }
-
-    /**
-     * Check whether the host is a classic local hostname or loopback address.
-     */
-    private function isLocalHostName(string $host): bool
-    {
-        return in_array($host, ['localhost', '127.0.0.1', '::1'], true);
-    }
-
-    /**
      * Verify that the downloaded file looks like a ZIP archive.
      */
     private function hasZipSignature(string $path): bool
@@ -513,5 +388,4 @@ class PensProcessor
 
         return in_array($signature, ["PK\x03\x04", "PK\x05\x06", "PK\x07\x08"], true);
     }
-
 }

--- a/src/CoreBundle/Helpers/SafeHttpClientHelper.php
+++ b/src/CoreBundle/Helpers/SafeHttpClientHelper.php
@@ -27,9 +27,9 @@ final class SafeHttpClientHelper
      * SSRF-safe HTTP client. Construction has no side effects, so it is safe to
      * call from any context (no platform settings or container required).
      */
-    public static function create(): HttpClientInterface
+    public static function create(?HttpClientInterface $client = null): HttpClientInterface
     {
-        return new NoPrivateNetworkHttpClient(HttpClient::create());
+        return new NoPrivateNetworkHttpClient($client ?? HttpClient::create());
     }
 
     /**

--- a/src/CoreBundle/Service/Pens/PensRemoteException.php
+++ b/src/CoreBundle/Service/Pens/PensRemoteException.php
@@ -1,0 +1,34 @@
+<?php
+
+/* For licensing terms, see /license.txt */
+
+declare(strict_types=1);
+
+namespace Chamilo\CoreBundle\Service\Pens;
+
+use RuntimeException;
+use Symfony\Component\DependencyInjection\Attribute\Exclude;
+use Throwable;
+
+#[Exclude]
+final class PensRemoteException extends RuntimeException
+{
+    public const int INVALID_URL = 1301;
+    public const int RETRIEVAL_FAILED = 1310;
+    public const int ACCESS_DENIED = 1312;
+    public const int STORAGE_FAILURE = 1440;
+    public const int CALLBACK_FAILED = 1500;
+
+    public function __construct(
+        private readonly int $pensErrorCode,
+        string $message,
+        ?Throwable $previous = null
+    ) {
+        parent::__construct($message, $pensErrorCode, $previous);
+    }
+
+    public function getPensErrorCode(): int
+    {
+        return $this->pensErrorCode;
+    }
+}

--- a/src/CoreBundle/Service/Pens/PensRemoteTransport.php
+++ b/src/CoreBundle/Service/Pens/PensRemoteTransport.php
@@ -1,0 +1,243 @@
+<?php
+
+/* For licensing terms, see /license.txt */
+
+declare(strict_types=1);
+
+namespace Chamilo\CoreBundle\Service\Pens;
+
+use Chamilo\CoreBundle\Helpers\SafeHttpClientHelper;
+use Closure;
+use InvalidArgumentException;
+use Symfony\Component\HttpClient\Exception\TransportException;
+use Symfony\Contracts\HttpClient\Exception\ExceptionInterface;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+use Throwable;
+
+/**
+ * SSRF-safe transport for PENS package downloads and acknowledgement callbacks.
+ *
+ * The current Chamilo host receives no private-network exemption. A current-host
+ * URL is accepted only when it resolves to a public address, exactly like every
+ * other destination. Redirects remain disabled to preserve the previous cURL
+ * behavior and downloads are never buffered before the byte limit is enforced.
+ */
+final class PensRemoteTransport
+{
+    public const int DEFAULT_MAX_DOWNLOAD_BYTES = 104857600; // 100 MB
+
+    private const int CONNECTION_TIMEOUT_SECONDS = 15;
+    private const int DOWNLOAD_TIMEOUT_SECONDS = 300;
+    private const int CALLBACK_TIMEOUT_SECONDS = 60;
+
+    private HttpClientInterface $httpClient;
+
+    /**
+     * @var Closure(resource, string): (int|false)
+     */
+    private Closure $streamWriter;
+
+    /**
+     * @param null|callable(resource, string): (int|false) $streamWriter
+     */
+    public function __construct(
+        ?HttpClientInterface $httpClient = null,
+        private readonly int $maxDownloadBytes = self::DEFAULT_MAX_DOWNLOAD_BYTES,
+        ?callable $streamWriter = null
+    ) {
+        if ($this->maxDownloadBytes < 1) {
+            throw new InvalidArgumentException('The PENS download limit must be greater than zero.');
+        }
+
+        $this->httpClient = SafeHttpClientHelper::create($httpClient);
+
+        $defaultStreamWriter = static function (mixed $stream, string $content): false|int {
+            if (!\is_resource($stream)) {
+                return false;
+            }
+
+            return fwrite($stream, $content);
+        };
+        $this->streamWriter = null === $streamWriter
+            ? $defaultStreamWriter
+            : Closure::fromCallable($streamWriter);
+    }
+
+    /**
+     * @param mixed $destination
+     */
+    public function downloadToStream(
+        string $url,
+        $destination,
+        ?string $userId = null,
+        ?string $password = null
+    ): int {
+        $this->assertHttpUrl($url);
+
+        if (!\is_resource($destination)) {
+            throw new PensRemoteException(PensRemoteException::STORAGE_FAILURE, 'The PENS package destination is not writable.');
+        }
+
+        $options = [
+            'buffer' => false,
+            'max_redirects' => 0,
+            'timeout' => self::DOWNLOAD_TIMEOUT_SECONDS,
+            'max_duration' => self::DOWNLOAD_TIMEOUT_SECONDS,
+        ];
+
+        if (null !== $userId) {
+            $options['auth_basic'] = [$userId, (string) $password];
+        }
+
+        $response = null;
+
+        try {
+            $response = $this->httpClient->request('GET', $url, $options);
+            $this->awaitConnection($response);
+            $statusCode = $response->getStatusCode();
+            $headers = $response->getHeaders(false);
+        } catch (ExceptionInterface $exception) {
+            $response?->cancel();
+
+            throw new PensRemoteException(PensRemoteException::RETRIEVAL_FAILED, 'The PENS package URL could not be reached safely.', $exception);
+        }
+
+        if (401 === $statusCode || 403 === $statusCode) {
+            $response->cancel();
+
+            throw new PensRemoteException(PensRemoteException::ACCESS_DENIED, 'The PENS package server rejected the supplied credentials.');
+        }
+
+        if ($statusCode < 200 || $statusCode >= 300) {
+            $response->cancel();
+
+            throw new PensRemoteException(PensRemoteException::RETRIEVAL_FAILED, 'The PENS package server returned an unsuccessful response.');
+        }
+
+        $contentLength = $headers['content-length'][0] ?? null;
+        if (\is_string($contentLength)
+            && ctype_digit($contentLength)
+            && (int) $contentLength > $this->maxDownloadBytes
+        ) {
+            $response->cancel();
+
+            throw new PensRemoteException(PensRemoteException::RETRIEVAL_FAILED, 'The PENS package exceeds the configured download limit.');
+        }
+
+        $downloadedBytes = 0;
+
+        try {
+            foreach ($this->httpClient->stream($response) as $chunk) {
+                $content = $chunk->getContent();
+                $chunkBytes = \strlen($content);
+
+                if (0 === $chunkBytes) {
+                    continue;
+                }
+
+                if ($chunkBytes > $this->maxDownloadBytes - $downloadedBytes) {
+                    $response->cancel();
+
+                    throw new PensRemoteException(PensRemoteException::RETRIEVAL_FAILED, 'The PENS package exceeds the configured download limit.');
+                }
+
+                $this->writeAll($destination, $content);
+                $downloadedBytes += $chunkBytes;
+            }
+        } catch (PensRemoteException $exception) {
+            $response->cancel();
+
+            throw $exception;
+        } catch (ExceptionInterface $exception) {
+            $response->cancel();
+
+            throw new PensRemoteException(PensRemoteException::RETRIEVAL_FAILED, 'The PENS package download was interrupted.', $exception);
+        }
+
+        if (0 === $downloadedBytes) {
+            throw new PensRemoteException(PensRemoteException::RETRIEVAL_FAILED, 'The PENS package response was empty.');
+        }
+
+        return $downloadedBytes;
+    }
+
+    /**
+     * @param array<string, mixed> $parameters
+     */
+    public function sendCallback(string $url, array $parameters): void
+    {
+        $this->assertHttpUrl($url);
+
+        $response = null;
+
+        try {
+            $response = $this->httpClient->request('POST', $url, [
+                'body' => $parameters,
+                'buffer' => false,
+                'max_redirects' => 0,
+                'timeout' => self::CALLBACK_TIMEOUT_SECONDS,
+                'max_duration' => self::CALLBACK_TIMEOUT_SECONDS,
+            ]);
+            $this->awaitConnection($response);
+            $response->getStatusCode();
+            $response->cancel();
+        } catch (ExceptionInterface $exception) {
+            $response?->cancel();
+
+            throw new PensRemoteException(PensRemoteException::CALLBACK_FAILED, 'The PENS callback URL could not be reached safely.', $exception);
+        }
+    }
+
+    private function assertHttpUrl(string $url): void
+    {
+        if ($url !== trim($url)) {
+            throw new PensRemoteException(PensRemoteException::INVALID_URL, 'The PENS URL is malformed.');
+        }
+
+        $parts = parse_url($url);
+        $scheme = \is_array($parts) ? strtolower($parts['scheme'] ?? '') : '';
+        $host = \is_array($parts) ? $parts['host'] ?? '' : '';
+
+        if (!\in_array($scheme, ['http', 'https'], true) || '' === $host) {
+            throw new PensRemoteException(PensRemoteException::INVALID_URL, 'Only absolute HTTP(S) PENS URLs are allowed.');
+        }
+    }
+
+    /**
+     * Bound connection setup separately from the longer response-body timeout.
+     */
+    private function awaitConnection(ResponseInterface $response): void
+    {
+        foreach ($this->httpClient->stream($response, self::CONNECTION_TIMEOUT_SECONDS) as $chunk) {
+            if (!$chunk->isTimeout() || (float) $response->getInfo('pretransfer_time') > 0.0) {
+                return;
+            }
+
+            throw new TransportException('The PENS remote connection timed out.');
+        }
+    }
+
+    /**
+     * @param resource $destination
+     */
+    private function writeAll($destination, string $content): void
+    {
+        $offset = 0;
+        $contentLength = \strlen($content);
+
+        while ($offset < $contentLength) {
+            try {
+                $writtenBytes = ($this->streamWriter)($destination, substr($content, $offset));
+            } catch (Throwable $exception) {
+                throw new PensRemoteException(PensRemoteException::STORAGE_FAILURE, 'Writing the PENS package failed.', $exception);
+            }
+
+            if (false === $writtenBytes || $writtenBytes < 1 || $writtenBytes > $contentLength - $offset) {
+                throw new PensRemoteException(PensRemoteException::STORAGE_FAILURE, 'Writing the PENS package failed.');
+            }
+
+            $offset += $writtenBytes;
+        }
+    }
+}

--- a/tests/CoreBundle/Service/Pens/PensRemoteTransportTest.php
+++ b/tests/CoreBundle/Service/Pens/PensRemoteTransportTest.php
@@ -1,0 +1,558 @@
+<?php
+
+/* For licensing terms, see /license.txt */
+
+declare(strict_types=1);
+
+namespace Chamilo\Tests\CoreBundle\Service\Pens;
+
+use Chamilo\CoreBundle\Service\Pens\PensRemoteException;
+use Chamilo\CoreBundle\Service\Pens\PensRemoteTransport;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpClient\Exception\TransportException;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\MockResponse;
+use Symfony\Component\HttpClient\Response\ResponseStream;
+use Symfony\Contracts\HttpClient\ChunkInterface;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+use Symfony\Contracts\HttpClient\ResponseStreamInterface;
+
+use const SEEK_SET;
+
+final class PensRemoteTransportTest extends TestCase
+{
+    private const string PUBLIC_IPV4_URL = 'https://93.184.216.34/package.zip';
+
+    public function testDownloadsPublicPackageWithoutBufferingOrRedirects(): void
+    {
+        /** @var null|array{0: string, 1: string, 2: array<array-key, mixed>} $capturedRequest */
+        $capturedRequest = null;
+        $mockClient = new MockHttpClient(
+            static function (string $method, string $url, array $options) use (&$capturedRequest): MockResponse {
+                $capturedRequest = [$method, $url, $options];
+
+                return new MockResponse((static function (): iterable {
+                    yield "PK\x03\x04";
+
+                    yield 'package-data';
+                })());
+            }
+        );
+        $recordingClient = new PensRecordingHttpClient($mockClient);
+        $destination = $this->createDestination();
+
+        $downloadedBytes = (new PensRemoteTransport($recordingClient, 100))->downloadToStream(
+            self::PUBLIC_IPV4_URL,
+            $destination,
+            'pens-user',
+            'pens-password'
+        );
+
+        self::assertSame(16, $downloadedBytes);
+        self::assertSame("PK\x03\x04package-data", $this->readDestination($destination));
+        self::assertNotNull($capturedRequest);
+        self::assertSame('GET', $capturedRequest[0]);
+        self::assertSame(self::PUBLIC_IPV4_URL, $capturedRequest[1]);
+        self::assertFalse($capturedRequest[2]['buffer']);
+        self::assertSame(0, $capturedRequest[2]['max_redirects']);
+        self::assertSame(300.0, $capturedRequest[2]['timeout']);
+        self::assertSame(300.0, $capturedRequest[2]['max_duration']);
+        self::assertContains('Authorization: Basic cGVucy11c2VyOnBlbnMtcGFzc3dvcmQ=', $capturedRequest[2]['headers']);
+        self::assertSame([15.0, null], $recordingClient->streamTimeouts);
+
+        fclose($destination);
+    }
+
+    /**
+     * @dataProvider blockedUrlProvider
+     */
+    public function testBlocksPrivateTranslatedAndUnresolvedHosts(string $url): void
+    {
+        $mockClient = new MockHttpClient(new MockResponse("PK\x03\x04data"));
+        $destination = $this->createDestination();
+
+        try {
+            (new PensRemoteTransport($mockClient))->downloadToStream($url, $destination);
+            self::fail('The unsafe PENS URL was accepted.');
+        } catch (PensRemoteException $exception) {
+            self::assertSame(PensRemoteException::RETRIEVAL_FAILED, $exception->getPensErrorCode());
+        }
+
+        self::assertSame(0, $mockClient->getRequestsCount());
+        fclose($destination);
+    }
+
+    public static function blockedUrlProvider(): iterable
+    {
+        yield 'IPv4 loopback' => ['http://127.0.0.1/package.zip'];
+
+        yield 'IPv4 private' => ['http://192.168.10.12/package.zip'];
+
+        yield 'cloud metadata' => ['http://169.254.169.254/package.zip'];
+
+        yield 'current localhost has no exception' => ['http://localhost/package.zip'];
+
+        yield 'IPv6 loopback' => ['http://[::1]/package.zip'];
+
+        yield 'IPv6 unique local' => ['http://[fc00::1]/package.zip'];
+
+        yield 'IPv4-mapped IPv6' => ['http://[::ffff:127.0.0.1]/package.zip'];
+
+        yield 'expanded IPv4-mapped IPv6' => ['http://[0:0:0:0:0:ffff:7f00:1]/package.zip'];
+
+        yield 'IPv4-compatible IPv6' => ['http://[::127.0.0.1]/package.zip'];
+
+        yield 'NAT64' => ['http://[64:ff9b::7f00:1]/package.zip'];
+
+        yield '6to4' => ['http://[2002:7f00:1::]/package.zip'];
+
+        yield 'unresolved host' => ['http://does-not-resolve.invalid/package.zip'];
+    }
+
+    /**
+     * @dataProvider publicUrlProvider
+     */
+    public function testAllowsPublicIpv4AndIpv6Literals(string $url): void
+    {
+        $mockClient = new MockHttpClient(new MockResponse("PK\x03\x04data"));
+        $destination = $this->createDestination();
+
+        self::assertSame(8, (new PensRemoteTransport($mockClient))->downloadToStream($url, $destination));
+        self::assertSame(1, $mockClient->getRequestsCount());
+
+        fclose($destination);
+    }
+
+    public static function publicUrlProvider(): iterable
+    {
+        yield 'public IPv4' => [self::PUBLIC_IPV4_URL];
+
+        yield 'public IPv6' => ['https://[2606:4700:4700::1111]/package.zip'];
+    }
+
+    /**
+     * @dataProvider invalidUrlProvider
+     */
+    public function testRejectsNonHttpAndMalformedUrls(string $url): void
+    {
+        $mockClient = new MockHttpClient(new MockResponse("PK\x03\x04data"));
+        $destination = $this->createDestination();
+
+        try {
+            (new PensRemoteTransport($mockClient))->downloadToStream($url, $destination);
+            self::fail('The invalid PENS URL was accepted.');
+        } catch (PensRemoteException $exception) {
+            self::assertSame(PensRemoteException::INVALID_URL, $exception->getPensErrorCode());
+        }
+
+        self::assertSame(0, $mockClient->getRequestsCount());
+        fclose($destination);
+    }
+
+    public static function invalidUrlProvider(): iterable
+    {
+        yield 'file scheme' => ['file:///etc/passwd'];
+
+        yield 'FTP scheme' => ['ftp://93.184.216.34/package.zip'];
+
+        yield 'relative URL' => ['/package.zip'];
+
+        yield 'leading whitespace' => [' '.self::PUBLIC_IPV4_URL];
+
+        yield 'missing host' => ['https:///package.zip'];
+    }
+
+    public function testRejectsRedirectWithoutFollowingPrivateLocation(): void
+    {
+        $mockClient = new MockHttpClient(new MockResponse('', [
+            'http_code' => 302,
+            'response_headers' => ['location: http://127.0.0.1/internal'],
+        ]));
+        $destination = $this->createDestination();
+
+        try {
+            (new PensRemoteTransport($mockClient))->downloadToStream(self::PUBLIC_IPV4_URL, $destination);
+            self::fail('The redirecting PENS package URL was accepted.');
+        } catch (PensRemoteException $exception) {
+            self::assertSame(PensRemoteException::RETRIEVAL_FAILED, $exception->getPensErrorCode());
+        }
+
+        self::assertSame(1, $mockClient->getRequestsCount());
+        fclose($destination);
+    }
+
+    /**
+     * @dataProvider authenticationFailureProvider
+     */
+    public function testMapsAuthenticationFailure(int $statusCode): void
+    {
+        $mockClient = new MockHttpClient(new MockResponse('', ['http_code' => $statusCode]));
+        $destination = $this->createDestination();
+
+        try {
+            (new PensRemoteTransport($mockClient))->downloadToStream(self::PUBLIC_IPV4_URL, $destination);
+            self::fail('The authentication failure was ignored.');
+        } catch (PensRemoteException $exception) {
+            self::assertSame(PensRemoteException::ACCESS_DENIED, $exception->getPensErrorCode());
+        }
+
+        fclose($destination);
+    }
+
+    public static function authenticationFailureProvider(): iterable
+    {
+        yield 'unauthorized' => [401];
+
+        yield 'forbidden' => [403];
+    }
+
+    /**
+     * @dataProvider unsuccessfulStatusProvider
+     */
+    public function testMapsUnsuccessfulResponse(int $statusCode): void
+    {
+        $mockClient = new MockHttpClient(new MockResponse('', ['http_code' => $statusCode]));
+        $destination = $this->createDestination();
+
+        try {
+            (new PensRemoteTransport($mockClient))->downloadToStream(self::PUBLIC_IPV4_URL, $destination);
+            self::fail('The unsuccessful PENS package response was accepted.');
+        } catch (PensRemoteException $exception) {
+            self::assertSame(PensRemoteException::RETRIEVAL_FAILED, $exception->getPensErrorCode());
+        }
+
+        fclose($destination);
+    }
+
+    public static function unsuccessfulStatusProvider(): iterable
+    {
+        yield 'not found' => [404];
+
+        yield 'server error' => [500];
+    }
+
+    public function testMapsInterruptedAndEmptyResponses(): void
+    {
+        $interruptedClient = new MockHttpClient(new MockResponse((static function (): iterable {
+            yield "PK\x03\x04";
+
+            yield new TransportException('Connection interrupted.');
+        })()));
+        $interruptedDestination = $this->createDestination();
+
+        try {
+            (new PensRemoteTransport($interruptedClient))->downloadToStream(
+                self::PUBLIC_IPV4_URL,
+                $interruptedDestination
+            );
+            self::fail('The interrupted PENS package response was accepted.');
+        } catch (PensRemoteException $exception) {
+            self::assertSame(PensRemoteException::RETRIEVAL_FAILED, $exception->getPensErrorCode());
+        }
+
+        self::assertSame("PK\x03\x04", $this->readDestination($interruptedDestination));
+        fclose($interruptedDestination);
+
+        $emptyDestination = $this->createDestination();
+
+        try {
+            (new PensRemoteTransport(new MockHttpClient(new MockResponse())))->downloadToStream(
+                self::PUBLIC_IPV4_URL,
+                $emptyDestination
+            );
+            self::fail('The empty PENS package response was accepted.');
+        } catch (PensRemoteException $exception) {
+            self::assertSame(PensRemoteException::RETRIEVAL_FAILED, $exception->getPensErrorCode());
+        }
+
+        fclose($emptyDestination);
+    }
+
+    public function testMapsConnectionGateTimeout(): void
+    {
+        $mockClient = new MockHttpClient(new MockResponse("PK\x03\x04data"));
+        $recordingClient = new PensRecordingHttpClient($mockClient, true);
+        $destination = $this->createDestination();
+
+        try {
+            (new PensRemoteTransport($recordingClient))->downloadToStream(self::PUBLIC_IPV4_URL, $destination);
+            self::fail('The timed-out PENS connection was accepted.');
+        } catch (PensRemoteException $exception) {
+            self::assertSame(PensRemoteException::RETRIEVAL_FAILED, $exception->getPensErrorCode());
+        }
+
+        self::assertSame([15.0], $recordingClient->streamTimeouts);
+        self::assertSame('', $this->readDestination($destination));
+        fclose($destination);
+    }
+
+    public function testConnectionGateAllowsAnEstablishedConnectionToKeepWaiting(): void
+    {
+        $mockClient = new MockHttpClient(new MockResponse("PK\x03\x04data", [
+            'pretransfer_time' => 0.001,
+        ]));
+        $recordingClient = new PensRecordingHttpClient($mockClient, true);
+        $destination = $this->createDestination();
+
+        self::assertSame(
+            8,
+            (new PensRemoteTransport($recordingClient))->downloadToStream(self::PUBLIC_IPV4_URL, $destination)
+        );
+        self::assertSame("PK\x03\x04data", $this->readDestination($destination));
+        self::assertNotEmpty($recordingClient->streamTimeouts);
+        self::assertSame(15.0, $recordingClient->streamTimeouts[0]);
+        self::assertNull($recordingClient->streamTimeouts[array_key_last($recordingClient->streamTimeouts)]);
+        fclose($destination);
+    }
+
+    public function testRejectsDeclaredAndStreamedOversizePackagesBeforeWritingPastLimit(): void
+    {
+        $boundaryClient = new MockHttpClient(new MockResponse("PK\x03\x04data"));
+        $boundaryDestination = $this->createDestination();
+
+        self::assertSame(
+            8,
+            (new PensRemoteTransport($boundaryClient, 8))->downloadToStream(
+                self::PUBLIC_IPV4_URL,
+                $boundaryDestination
+            )
+        );
+        self::assertSame("PK\x03\x04data", $this->readDestination($boundaryDestination));
+        fclose($boundaryDestination);
+
+        $declaredOversizeClient = new MockHttpClient(new MockResponse("PK\x03\x04data", [
+            'response_headers' => ['content-length: 9'],
+        ]));
+        $declaredDestination = $this->createDestination();
+
+        try {
+            (new PensRemoteTransport($declaredOversizeClient, 8))->downloadToStream(
+                self::PUBLIC_IPV4_URL,
+                $declaredDestination
+            );
+            self::fail('The declared oversize PENS package was accepted.');
+        } catch (PensRemoteException $exception) {
+            self::assertSame(PensRemoteException::RETRIEVAL_FAILED, $exception->getPensErrorCode());
+        }
+
+        self::assertSame('', $this->readDestination($declaredDestination));
+        fclose($declaredDestination);
+
+        $streamedOversizeClient = new MockHttpClient(new MockResponse((static function (): iterable {
+            yield "PK\x03\x04";
+
+            yield '12345';
+        })()));
+        $streamedDestination = $this->createDestination();
+
+        try {
+            (new PensRemoteTransport($streamedOversizeClient, 8))->downloadToStream(
+                self::PUBLIC_IPV4_URL,
+                $streamedDestination
+            );
+            self::fail('The streamed oversize PENS package was accepted.');
+        } catch (PensRemoteException $exception) {
+            self::assertSame(PensRemoteException::RETRIEVAL_FAILED, $exception->getPensErrorCode());
+        }
+
+        self::assertSame("PK\x03\x04", $this->readDestination($streamedDestination));
+        fclose($streamedDestination);
+    }
+
+    public function testDetectsFailedWritesAndCompletesPartialWrites(): void
+    {
+        foreach ([false, 0] as $writeResult) {
+            $failedWriteClient = new MockHttpClient(new MockResponse("PK\x03\x04data"));
+            $failedDestination = $this->createDestination();
+            $failedWriter = static fn (mixed $stream, string $content): false|int => $writeResult;
+
+            try {
+                (new PensRemoteTransport($failedWriteClient, 100, $failedWriter))->downloadToStream(
+                    self::PUBLIC_IPV4_URL,
+                    $failedDestination
+                );
+                self::fail('The failed PENS package write was ignored.');
+            } catch (PensRemoteException $exception) {
+                self::assertSame(PensRemoteException::STORAGE_FAILURE, $exception->getPensErrorCode());
+            }
+
+            fclose($failedDestination);
+        }
+
+        $partialWriteClient = new MockHttpClient(new MockResponse("PK\x03\x04data"));
+        $partialDestination = $this->createDestination();
+
+        $partialWriter = static function (mixed $stream, string $content): false|int {
+            if (!\is_resource($stream)) {
+                return false;
+            }
+
+            return fwrite($stream, substr($content, 0, 2));
+        };
+
+        self::assertSame(
+            8,
+            (new PensRemoteTransport($partialWriteClient, 100, $partialWriter))->downloadToStream(
+                self::PUBLIC_IPV4_URL,
+                $partialDestination
+            )
+        );
+        self::assertSame("PK\x03\x04data", $this->readDestination($partialDestination));
+        fclose($partialDestination);
+    }
+
+    public function testSendsPublicCallbackWithoutFollowingRedirect(): void
+    {
+        /** @var null|array{0: string, 1: string, 2: array<array-key, mixed>} $capturedRequest */
+        $capturedRequest = null;
+        $mockClient = new MockHttpClient(
+            static function (string $method, string $url, array $options) use (&$capturedRequest): MockResponse {
+                $capturedRequest = [$method, $url, $options];
+
+                return new MockResponse((static function (): iterable {
+                    yield new TransportException('The callback body must not be consumed.');
+                })(), [
+                    'http_code' => 302,
+                    'response_headers' => ['location: http://127.0.0.1/internal'],
+                ]);
+            }
+        );
+        $recordingClient = new PensRecordingHttpClient($mockClient);
+
+        (new PensRemoteTransport($recordingClient))->sendCallback(
+            'https://93.184.216.34/callback',
+            ['command' => 'receipt', 'package-id' => '42']
+        );
+
+        self::assertSame(1, $mockClient->getRequestsCount());
+        self::assertNotNull($capturedRequest);
+        self::assertSame('POST', $capturedRequest[0]);
+        self::assertSame(0, $capturedRequest[2]['max_redirects']);
+        self::assertSame(60.0, $capturedRequest[2]['timeout']);
+        self::assertSame(60.0, $capturedRequest[2]['max_duration']);
+        self::assertSame('command=receipt&package-id=42', $capturedRequest[2]['body']);
+        self::assertSame([15.0], $recordingClient->streamTimeouts);
+    }
+
+    public function testBlocksPrivateCallbackBeforeInnerClientRequest(): void
+    {
+        $mockClient = new MockHttpClient(new MockResponse());
+
+        try {
+            (new PensRemoteTransport($mockClient))->sendCallback(
+                'http://[::ffff:127.0.0.1]/callback',
+                ['command' => 'alert']
+            );
+            self::fail('The private PENS callback URL was accepted.');
+        } catch (PensRemoteException $exception) {
+            self::assertSame(PensRemoteException::CALLBACK_FAILED, $exception->getPensErrorCode());
+        }
+
+        self::assertSame(0, $mockClient->getRequestsCount());
+    }
+
+    /**
+     * @return resource
+     */
+    private function createDestination()
+    {
+        $destination = fopen('php://temp', 'w+b');
+        self::assertIsResource($destination);
+
+        return $destination;
+    }
+
+    /**
+     * @param resource $destination
+     */
+    private function readDestination($destination): string
+    {
+        self::assertSame(0, fseek($destination, 0, SEEK_SET));
+
+        return (string) stream_get_contents($destination);
+    }
+}
+
+final class PensRecordingHttpClient implements HttpClientInterface
+{
+    /**
+     * @var list<?float>
+     */
+    public array $streamTimeouts = [];
+
+    public function __construct(
+        private HttpClientInterface $client,
+        private readonly bool $simulateConnectionTimeout = false
+    ) {}
+
+    public function request(string $method, string $url, array $options = []): ResponseInterface
+    {
+        return $this->client->request($method, $url, $options);
+    }
+
+    public function stream(iterable|ResponseInterface $responses, ?float $timeout = null): ResponseStreamInterface
+    {
+        $this->streamTimeouts[] = $timeout;
+
+        if ($this->simulateConnectionTimeout && 1 === \count($this->streamTimeouts)) {
+            if ($responses instanceof ResponseInterface) {
+                $responses = [$responses];
+            }
+
+            return new ResponseStream((static function () use ($responses): iterable {
+                foreach ($responses as $response) {
+                    yield $response => new PensTimeoutChunk();
+                }
+            })());
+        }
+
+        return $this->client->stream($responses, $timeout);
+    }
+
+    public function withOptions(array $options): static
+    {
+        $clone = clone $this;
+        $clone->client = $this->client->withOptions($options);
+
+        return $clone;
+    }
+}
+
+final class PensTimeoutChunk implements ChunkInterface
+{
+    public function isTimeout(): bool
+    {
+        return true;
+    }
+
+    public function isFirst(): bool
+    {
+        return false;
+    }
+
+    public function isLast(): bool
+    {
+        return false;
+    }
+
+    public function getInformationalStatus(): ?array
+    {
+        return null;
+    }
+
+    public function getContent(): string
+    {
+        return '';
+    }
+
+    public function getOffset(): int
+    {
+        return 0;
+    }
+
+    public function getError(): ?string
+    {
+        return 'Idle timeout reached.';
+    }
+}


### PR DESCRIPTION
## Summary

- Route PENS package downloads and HTTP callbacks through SafeHttpClientHelper so private, loopback, reserved, mapped IPv6, compatible IPv6, NAT64, 6to4, and unresolved targets are rejected at connection time.
- Preserve no-redirect behavior and the 15-second connection limit while retaining the existing 300-second download and 60-second callback totals.
- Stream downloads without buffering, enforce the 100 MB limit from headers and chunks, detect partial or failed writes, and cancel unused or failed responses.
- Remove full package URLs from logs and prevent the callback response body from being consumed.

This closes the IPv4-mapped IPv6 follow-up described by GHSA-2xvw-qqjj-q68r without granting a private-network exception to the current Chamilo host.

## Validation

- PHPUnit: 32 tests, 129 assertions
- ECS: clean
- Psalm: no errors on changed files
- PHP syntax checks: clean
- Symfony container lint: clean
- git diff --check: clean