### PR TITLE
Permitir reordenar lecciones de sesión / Allow session LP reordering

### DIFF
--- a/main/lp/learnpath.class.php
+++ b/main/lp/learnpath.class.php
@@ -8,6 +8,7 @@ use Chamilo\CoreBundle\Entity\Repository\ItemPropertyRepository;
 use Chamilo\CourseBundle\Component\CourseCopy\CourseArchiver;
 use Chamilo\CourseBundle\Component\CourseCopy\CourseBuilder;
 use Chamilo\CourseBundle\Component\CourseCopy\CourseRestorer;
+use Chamilo\CourseBundle\Component\Learnpath\SessionOrderPlanner;
 use Chamilo\CourseBundle\Entity\CDocument;
 use Chamilo\CourseBundle\Entity\CItemProperty;
 use Chamilo\CourseBundle\Entity\CLp;
@@ -4311,6 +4312,110 @@ class learnpath
         }
 
         return true;
+    }
+
+    /**
+     * Reorder only the LPs owned by the current session.
+     *
+     * Session pages also display base-course LPs. Their order must remain
+     * untouched, so each category's submitted LPs are required to match the
+     * complete set of session-owned LPs and only exchange their existing slots.
+     *
+     * @param int                      $courseId
+     * @param int                      $sessionId
+     * @param array<int|string, mixed> $lists
+     */
+    public static function reorderSessionLearningPaths($courseId, $sessionId, array $lists): bool
+    {
+        $courseId = (int) $courseId;
+        $sessionId = (int) $sessionId;
+        if ($courseId <= 0 || $sessionId <= 0 || empty($lists)) {
+            return false;
+        }
+
+        $lpTable = Database::get_course_table(TABLE_LP_MAIN);
+        $connection = Database::getManager()->getConnection();
+
+        try {
+            $connection->beginTransaction();
+            $updates = [];
+
+            // Validate and lock the complete request before changing any row.
+            foreach ($lists as $categoryIdValue => $orderedIds) {
+                $categoryIdValue = (string) $categoryIdValue;
+                if ('' === $categoryIdValue || !ctype_digit($categoryIdValue) || !is_array($orderedIds)) {
+                    throw new RuntimeException('Invalid session learning path order.');
+                }
+
+                $categoryId = (int) $categoryIdValue;
+                $categoryCondition = 0 === $categoryId
+                    ? '(category_id = 0 OR category_id IS NULL)'
+                    : "category_id = $categoryId";
+                $sql = "SELECT id, display_order
+                        FROM $lpTable
+                        WHERE c_id = $courseId
+                          AND session_id = $sessionId
+                          AND $categoryCondition
+                        ORDER BY display_order, id
+                        FOR UPDATE";
+                $result = Database::query($sql);
+                if (false === $result) {
+                    throw new RuntimeException('Could not lock session learning paths.');
+                }
+
+                $currentRows = [];
+                while ($row = Database::fetch_array($result)) {
+                    $currentRows[] = $row;
+                }
+
+                $plan = SessionOrderPlanner::buildPlan($currentRows, $orderedIds);
+                if (null === $plan) {
+                    throw new RuntimeException('Invalid session learning path order.');
+                }
+
+                foreach ($plan as $lpId => $displayOrder) {
+                    if (isset($updates[$lpId])) {
+                        throw new RuntimeException('Duplicate session learning path.');
+                    }
+
+                    $updates[$lpId] = [
+                        'category_id' => $categoryId,
+                        'display_order' => $displayOrder,
+                    ];
+                }
+            }
+
+            if (empty($updates)) {
+                throw new RuntimeException('The session learning path order is empty.');
+            }
+
+            foreach ($updates as $lpId => $update) {
+                $categoryId = $update['category_id'];
+                $displayOrder = $update['display_order'];
+                $categoryCondition = 0 === $categoryId
+                    ? '(category_id = 0 OR category_id IS NULL)'
+                    : "category_id = $categoryId";
+                $sql = "UPDATE $lpTable
+                        SET display_order = $displayOrder
+                        WHERE c_id = $courseId
+                          AND session_id = $sessionId
+                          AND $categoryCondition
+                          AND id = $lpId";
+                if (false === Database::query($sql)) {
+                    throw new RuntimeException('Could not reorder session learning paths.');
+                }
+            }
+
+            $connection->commit();
+
+            return true;
+        } catch (Throwable $exception) {
+            if ($connection->isTransactionActive()) {
+                $connection->rollBack();
+            }
+
+            return false;
+        }
     }
 
     /**

--- a/main/lp/lp_controller.php
+++ b/main/lp/lp_controller.php
@@ -1270,11 +1270,34 @@ switch ($action) {
         if (!api_is_allowed_to_edit(null, true)) {
             api_not_allowed(true);
         }
+        header('Content-Type: application/json');
+        if (!Security::check_token('post')) {
+            http_response_code(403);
+            echo json_encode(['error' => 'Invalid security token']);
+            exit;
+        }
+
         $courseId = api_get_course_int_id();
         $sessionId = api_get_session_id();
         $tableLp = Database::get_course_table(TABLE_LP_MAIN);
 
-        $lists = isset($_POST['lists']) ? (array) $_POST['lists'] : [];
+        $lists = isset($_POST['lists']) && is_array($_POST['lists']) ? $_POST['lists'] : [];
+        if (empty($lists)) {
+            http_response_code(400);
+            echo json_encode(['error' => 'Invalid learning path order']);
+            exit;
+        }
+
+        if ($sessionId > 0) {
+            if (!learnpath::reorderSessionLearningPaths($courseId, $sessionId, $lists)) {
+                http_response_code(400);
+                echo json_encode(['error' => 'Invalid session learning path order']);
+                exit;
+            }
+
+            echo json_encode(['ok' => true]);
+            exit;
+        }
 
         foreach ($lists as $categoryIdStr => $lpIds) {
             $categoryId = (int) $categoryIdStr;
@@ -1293,7 +1316,6 @@ switch ($action) {
             }
         }
 
-        header('Content-Type: application/json');
         echo json_encode(['ok' => true]);
         exit;
     case 'edit':

--- a/main/lp/lp_list.php
+++ b/main/lp/lp_list.php
@@ -280,7 +280,9 @@ foreach ($categories as $item) {
         $sessionId,
         null,
         false,
-        $categoryId
+        $categoryId,
+        false,
+        $is_allowed_to_edit
     );
 
     $flat_list = $list->get_flat_list();
@@ -943,6 +945,7 @@ foreach ($categories as $item) {
 
             $listData[] = [
                 'lp_id' => $id,
+                'can_reorder' => 0 === $sessionId || $sessionId === (int) $details['lp_session'],
                 'learnpath_icon' => $icon_learnpath,
                 'url_start' => $url_start_lp,
                 'title' => $my_title,

--- a/main/template/default/learnpath/list.tpl
+++ b/main/template/default/learnpath/list.tpl
@@ -46,7 +46,7 @@
         {% if categories|length > 1 and lp_data.category.id %}
         {% if is_allowed_to_edit %}
         <h3 class="page-header">
-            {% if is_allowed_to_edit %}
+            {% if is_allowed_to_edit and not _c.session_id %}
             <!-- drag handle for category -->
             <span class="drag-handle" title="Drag category to reorder" style="cursor:move;margin-right:6px;">
                     <img src="{{ 'move_everywhere.png'|icon }}" alt="drag">
@@ -105,7 +105,7 @@
         </h3>
         {% elseif lp_data.lp_list is not empty %}
         <h3 class="page-header">
-            {% if is_allowed_to_edit %}
+            {% if is_allowed_to_edit and not _c.session_id %}
             <span class="drag-handle" title="Drag category to reorder" style="cursor:move;margin-right:6px;">
                     <img src="{{ 'move_everywhere.png'|icon }}" alt="drag">
                   </span>
@@ -143,9 +143,9 @@
 
                 <tbody class="lp-sortable" data-cat-id="{{ lp_data.category.getId() }}">
                 {% for row in lp_data.lp_list %}
-                <tr class="lp-row" data-lp-id="{{ row.lp_id|default(row.url_start|split('lp_id=')[1]|split('&')[0]) }}">
+                <tr class="lp-row{% if row.can_reorder %} lp-row-reorderable{% endif %}" data-lp-id="{{ row.lp_id|default(row.url_start|split('lp_id=')[1]|split('&')[0]) }}">
                     <td>
-                        {% if is_allowed_to_edit %}
+                        {% if is_allowed_to_edit and row.can_reorder %}
                         <!-- drag handle for LP row -->
                         <span class="drag-handle" title="Drag to reorder" style="cursor:move;margin-right:6px;">
                             <img src="{{ 'move_everywhere.png'|icon }}" alt="drag">
@@ -242,9 +242,9 @@
 
             <tbody class="lp-sortable" data-cat-id="{{ lp_data.category.getId() }}">
             {% for row in lp_data.lp_list %}
-            <tr class="lp-row" data-lp-id="{{ row.lp_id|default(row.url_start|split('lp_id=')[1]|split('&')[0]) }}">
+            <tr class="lp-row{% if row.can_reorder %} lp-row-reorderable{% endif %}" data-lp-id="{{ row.lp_id|default(row.url_start|split('lp_id=')[1]|split('&')[0]) }}">
                 <td>
-                    {% if is_allowed_to_edit %}
+                    {% if is_allowed_to_edit and row.can_reorder %}
                     <!-- Drag handle (accordion/no-category) -->
                     <span class="drag-handle" title="Drag to reorder" style="cursor:move;margin-right:6px;">
                               <img src="{{ 'move_everywhere.png'|icon }}" alt="drag">
@@ -397,7 +397,7 @@
             </div>
             {% endif %}
             <h4 class="panel-title">
-                {% if is_allowed_to_edit %}
+                {% if is_allowed_to_edit and not _c.session_id %}
                 <!-- drag handle for category (accordion header) -->
                 <span class="drag-handle" title="Drag category to reorder" style="cursor:move;margin-right:6px;">
                     <img src="{{ 'move_everywhere.png'|icon }}" alt="drag">
@@ -443,9 +443,9 @@
 
                         <tbody class="lp-sortable" data-cat-id="{{ lp_data.category.getId() }}">
                         {% for row in lp_data.lp_list %}
-                        <tr class="lp-row" data-lp-id="{{ row.lp_id|default(row.url_start|split('lp_id=')[1]|split('&')[0]) }}">
+                        <tr class="lp-row{% if row.can_reorder %} lp-row-reorderable{% endif %}" data-lp-id="{{ row.lp_id|default(row.url_start|split('lp_id=')[1]|split('&')[0]) }}">
                             <td>
-                                {% if is_allowed_to_edit %}
+                                {% if is_allowed_to_edit and row.can_reorder %}
                                 <span class="drag-handle" title="Drag to reorder" style="cursor:move;margin-right:6px;">
                                     <img src="{{ 'move_everywhere.png'|icon }}" alt="drag">
                                   </span>
@@ -578,51 +578,73 @@
 
     var cidreq     = "{{ _p.web_cid_query|e('js') }}";
     var hasSession = {{ _c.session_id ? 'true' : 'false' }};
-  var canEdit    = {{ is_allowed_to_edit ? 'true' : 'false' }};
-  var secToken   = "{{ sec_token|e('js') }}"; // CSRF token required by controller
+    var canEdit    = {{ is_allowed_to_edit ? 'true' : 'false' }};
+    var secToken   = "{{ sec_token|e('js') }}";
 
-  function refreshPlaceholders(){
-    if (!canEdit) { return; }
-    $(".lp-sortable").each(function(){
-      var $tbody = $(this);
-      var hasRows = $tbody.find("tr.lp-row").length > 0;
-      var $ph = $tbody.find(".lp-empty-placeholder");
-      if (!hasRows && $ph.length === 0) {
-        $tbody.append('<tr class="lp-empty-placeholder"><td colspan="3"><em>Drop a learning path here</em></td></tr>');
-      } else if (hasRows) {
-        $ph.remove();
+    function collectLpIds($list, selector) {
+      var ids = [];
+      $list.find(selector).each(function(){
+        var id = parseInt($(this).data("lp-id"), 10);
+        if (!isNaN(id)) { ids.push(id); }
+      });
+
+      return ids;
+    }
+
+    function refreshPlaceholders(){
+      if (!canEdit) { return; }
+      if (hasSession) {
+        $(".lp-empty-placeholder").remove();
+        return;
+      }
+
+      $(".lp-sortable").each(function(){
+        var $tbody = $(this);
+        var hasRows = $tbody.find("tr.lp-row").length > 0;
+        var $ph = $tbody.find(".lp-empty-placeholder");
+        if (!hasRows && $ph.length === 0) {
+          $tbody.append('<tr class="lp-empty-placeholder"><td colspan="3"><em>Drop a learning path here</em></td></tr>');
+        } else if (hasRows) {
+          $ph.remove();
+        }
+      });
+    }
+
+    /* In sessions, only session-owned rows can move and only inside their category. */
+    $(".lp-sortable").sortable({
+      connectWith: hasSession ? false : ".lp-sortable",
+      items: hasSession ? "> tr.lp-row-reorderable" : "> tr.lp-row",
+      handle: ".drag-handle",
+      cancel: ".lp-empty-placeholder",
+      placeholder: "ui-state-highlight",
+      tolerance: "pointer",
+      update: function(){
+        var lists = {};
+        if (hasSession) {
+          var $list = $(this);
+          var categoryId = String($list.data("cat-id") || 0);
+          lists[categoryId] = collectLpIds($list, "tr.lp-row-reorderable");
+        } else {
+          $(".lp-sortable").each(function(){
+            var categoryId = String($(this).data("cat-id") || 0);
+            lists[categoryId] = collectLpIds($(this), "tr.lp-row");
+          });
+        }
+
+        $.post("lp_controller.php?action=reorder_lps&"+cidreq, {lists: lists, sec_token: secToken})
+          .done(function(){
+            if (hasSession) { window.location.reload(); }
+          })
+          .fail(function(){
+            console.warn("Failed to save LP order");
+            if (hasSession) { window.location.reload(); }
+          });
+        refreshPlaceholders();
+      },
+      receive: function(){
+        $(this).find(".lp-empty-placeholder").remove();
       }
     });
-  }
-
-  /* LP rows drag & drop (move within and across categories) */
-  $(".lp-sortable").sortable({
-    connectWith: ".lp-sortable",
-    items: "> tr.lp-row",
-    handle: ".drag-handle",
-    cancel: ".lp-empty-placeholder",
-    placeholder: "ui-state-highlight",
-    tolerance: "pointer",
-    update: function(){
-      if (hasSession) { return; } // keep current behavior in sessions
-      var lists = {};
-      $(".lp-sortable").each(function(){
-        var catId = String($(this).data("cat-id") || 0);
-        lists[catId] = [];
-        $(this).find("tr.lp-row").each(function(){
-          var id = parseInt($(this).data("lp-id"),10);
-          if (!isNaN(id)) { lists[catId].push(id); }
-        });
-      });
-      // Send CSRF token
-      $.post("lp_controller.php?action=reorder_lps&"+cidreq, {lists: lists, sec_token: secToken})
-        .fail(function(){ console.warn("Failed to save LP order"); });
-      refreshPlaceholders();
-    },
-    receive: function(){
-      $(this).find(".lp-empty-placeholder").remove();
-    }
-  });
 
   /* Categories drag & drop (works for old view containers and accordion panels) */
   $("#lp-accordion").sortable({
@@ -646,8 +668,7 @@
   });
 
   if (hasSession) {
-    /* in session mode, keep current behavior (no drag/save) */
-    $(".lp-sortable").sortable("disable");
+    /* Category order is shared with the base course and cannot be session-specific. */
     $("#lp-accordion").sortable("disable");
   }
 

--- a/src/Chamilo/CourseBundle/Component/Learnpath/SessionOrderPlanner.php
+++ b/src/Chamilo/CourseBundle/Component/Learnpath/SessionOrderPlanner.php
@@ -1,0 +1,108 @@
+<?php
+
+/* For licensing terms, see /license.txt */
+
+namespace Chamilo\CourseBundle\Component\Learnpath;
+
+final class SessionOrderPlanner
+{
+    /**
+     * Build an LP-to-position map by permuting the session LPs' existing slots.
+     *
+     * Returning null means the submitted order is incomplete or invalid. Keeping
+     * the existing slots prevents a session-specific reorder from changing the
+     * relative positions reserved by base-course or other-session LPs.
+     *
+     * @param array<int, array{id: mixed, display_order: mixed}> $currentRows
+     * @param array<int, mixed>                                  $orderedIds
+     *
+     * @return array<int, int>|null
+     */
+    public static function buildPlan(array $currentRows, array $orderedIds): ?array
+    {
+        if (empty($currentRows) || count($currentRows) !== count($orderedIds)) {
+            return null;
+        }
+
+        $normalizedOrder = [];
+        foreach ($orderedIds as $id) {
+            $normalizedId = self::toPositiveInt($id);
+            if (null === $normalizedId) {
+                return null;
+            }
+
+            $normalizedOrder[] = $normalizedId;
+        }
+
+        if (count($normalizedOrder) !== count(array_unique($normalizedOrder))) {
+            return null;
+        }
+
+        $currentIds = [];
+        $positions = [];
+        foreach ($currentRows as $row) {
+            if (!array_key_exists('id', $row) || !array_key_exists('display_order', $row)) {
+                return null;
+            }
+
+            $id = self::toPositiveInt($row['id']);
+            $position = self::toNonNegativeInt($row['display_order']);
+            if (null === $id || null === $position) {
+                return null;
+            }
+
+            $currentIds[] = $id;
+            $positions[] = $position;
+        }
+
+        if (
+            count($currentIds) !== count(array_unique($currentIds)) ||
+            count($positions) !== count(array_unique($positions))
+        ) {
+            return null;
+        }
+
+        $expectedIds = $currentIds;
+        $submittedIds = $normalizedOrder;
+        sort($expectedIds, SORT_NUMERIC);
+        sort($submittedIds, SORT_NUMERIC);
+        if ($expectedIds !== $submittedIds) {
+            return null;
+        }
+
+        sort($positions, SORT_NUMERIC);
+
+        $plan = [];
+        foreach ($normalizedOrder as $index => $id) {
+            $plan[$id] = $positions[$index];
+        }
+
+        return $plan;
+    }
+
+    /**
+     * @param mixed $value
+     */
+    private static function toPositiveInt($value): ?int
+    {
+        $value = self::toNonNegativeInt($value);
+
+        return null !== $value && $value > 0 ? $value : null;
+    }
+
+    /**
+     * @param mixed $value
+     */
+    private static function toNonNegativeInt($value): ?int
+    {
+        if (is_int($value)) {
+            return $value >= 0 ? $value : null;
+        }
+
+        if (is_string($value) && '' !== $value && ctype_digit($value)) {
+            return (int) $value;
+        }
+
+        return null;
+    }
+}

--- a/tests/unit/Chamilo/CourseBundle/Component/Learnpath/SessionOrderPlannerTest.php
+++ b/tests/unit/Chamilo/CourseBundle/Component/Learnpath/SessionOrderPlannerTest.php
@@ -1,0 +1,61 @@
+<?php
+
+/* For licensing terms, see /license.txt */
+
+namespace Chamilo\Tests\CourseBundle\Component\Learnpath;
+
+use Chamilo\CourseBundle\Component\Learnpath\SessionOrderPlanner;
+use PHPUnit\Framework\TestCase;
+
+require_once dirname(__DIR__, 6).'/src/Chamilo/CourseBundle/Component/Learnpath/SessionOrderPlanner.php';
+
+final class SessionOrderPlannerTest extends TestCase
+{
+    public function testBuildPlanPermutesExistingSparseSlots(): void
+    {
+        $rows = [
+            ['id' => '11', 'display_order' => '3'],
+            ['id' => '22', 'display_order' => '7'],
+            ['id' => '33', 'display_order' => '12'],
+        ];
+
+        self::assertSame(
+            [33 => 3, 11 => 7, 22 => 12],
+            SessionOrderPlanner::buildPlan($rows, ['33', '11', '22'])
+        );
+    }
+
+    /**
+     * @dataProvider invalidOrders
+     */
+    public function testBuildPlanRejectsIncompleteOrAmbiguousOrders(array $rows, array $order): void
+    {
+        self::assertNull(SessionOrderPlanner::buildPlan($rows, $order));
+    }
+
+    public static function invalidOrders(): iterable
+    {
+        $rows = [
+            ['id' => 11, 'display_order' => 3],
+            ['id' => 22, 'display_order' => 7],
+        ];
+
+        yield 'empty' => [[], []];
+        yield 'missing id' => [$rows, [11]];
+        yield 'unknown id' => [$rows, [11, 44]];
+        yield 'duplicate submitted id' => [$rows, [11, 11]];
+        yield 'invalid submitted id' => [$rows, [11, '22invalid']];
+        yield 'duplicate stored id' => [[
+            ['id' => 11, 'display_order' => 3],
+            ['id' => 11, 'display_order' => 7],
+        ], [11, 22]];
+        yield 'duplicate stored position' => [[
+            ['id' => 11, 'display_order' => 3],
+            ['id' => 22, 'display_order' => 3],
+        ], [11, 22]];
+        yield 'invalid stored position' => [[
+            ['id' => 11, 'display_order' => -1],
+            ['id' => 22, 'display_order' => 7],
+        ], [11, 22]];
+    }
+}


### PR DESCRIPTION
## Español

Corrige #8269.

### Cambios

- Permite reordenar las lecciones creadas en la sesión dentro de su propia categoría.
- Mantiene inmóviles las lecciones heredadas del curso base y el orden de las categorías.
- Valida el token CSRF y el conjunto completo de lecciones de sesión antes de guardar.
- Conserva las posiciones existentes mediante una transacción y bloqueos de filas, sin modificar otros cursos, sesiones ni categorías.
- Recarga la lista tras guardar para mostrar el orden persistido correctamente.

### Pruebas

- PHPUnit 9.6: 9 pruebas, 9 aserciones.
- PHP-CS-Fixer 3.4 en modo dry-run.
- Sintaxis PHP y JavaScript.
- git diff --check.
- Prueba de integración con MariaDB para filas del curso base, otra sesión, otro curso y otra categoría.

## English

Fixes #8269.

### Changes

- Allows learning paths created in the current session to be reordered within their own category.
- Keeps inherited base-course learning paths and category ordering immutable.
- Validates the CSRF token and the complete session learning-path set before saving.
- Permutes existing positions transactionally with row locks, without changing other courses, sessions, or categories.
- Reloads the list after persistence so the stored interleaving is rendered correctly.

### Tests

- PHPUnit 9.6: 9 tests, 9 assertions.
- PHP-CS-Fixer 3.4 dry-run.
- PHP and JavaScript syntax checks.
- git diff --check.
- MariaDB integration fixture covering base-course, other-session, other-course, and other-category rows.