### PR TITLE
Corregir el tiempo de ejercicios en lecciones / Fix LP quiz time reporting

### DIFF
--- a/main/inc/lib/tracking.lib.php
+++ b/main/inc/lib/tracking.lib.php
@@ -2,6 +2,7 @@
 
 /* For licensing terms, see /license.txt */
 
+use Chamilo\CoreBundle\Component\Tracking\LearnpathQuizTimeCalculator;
 use Chamilo\CoreBundle\Entity\Course;
 use Chamilo\CoreBundle\Entity\Session as SessionEntity;
 use Chamilo\CourseBundle\Entity\CLpCategory;
@@ -7506,7 +7507,8 @@ class Tracking
                     user_id = $userId AND
                     c_id = $courseId AND
                     session_id = $sessionId AND
-                    login_as = 0 AND current_id <> 0";
+                    login_as = 0 AND current_id <> 0
+                ORDER BY current_id, tool, date_reg, id";
 
         $res = Database::query($sql);
         $reg = [];
@@ -7530,6 +7532,17 @@ class Tracking
             $max = 0;
             $sessionDiff = 0;
             foreach ($listPerTool as $tool => $results) {
+                if (TOOL_QUIZ === $tool) {
+                    $quizResult = LearnpathQuizTimeCalculator::calculate($results);
+                    $quizTime += $quizResult['quiz_time'];
+                    foreach ($quizResult['learnpath_time'] as $learnpathId => $time) {
+                        if (!isset($lpTime[$learnpathId])) {
+                            $lpTime[$learnpathId] = 0;
+                        }
+                        $lpTime[$learnpathId] += $time;
+                    }
+                }
+
                 $beforeItem = [];
                 foreach ($results as $item) {
                     if (empty($beforeItem)) {
@@ -7596,14 +7609,6 @@ class Tracking
                             }
                             break;
                         case TOOL_QUIZ:
-                            if (!isset($lpTime[$item['action_details']])) {
-                                $lpTime[$item['action_details']] = 0;
-                            }
-                            if ($beforeItem['action'] === 'learnpath_id') {
-                                $lpTime[$item['action_details']] += $partialTime;
-                            } else {
-                                $quizTime += $partialTime;
-                            }
                             break;
                     }
                     $beforeItem = $item;
@@ -8092,7 +8097,7 @@ class Tracking
             while ($row = Database::fetch_array($res, 'ASSOC')) {
                 $list[] = $row['id'];
             }
-    
+
             if (!empty($list)) {
                 foreach ($list as $id) {
                     if ($update_database) {

--- a/src/Chamilo/CoreBundle/Component/Tracking/LearnpathQuizTimeCalculator.php
+++ b/src/Chamilo/CoreBundle/Component/Tracking/LearnpathQuizTimeCalculator.php
@@ -1,0 +1,83 @@
+<?php
+
+/* For licensing terms, see /license.txt */
+
+namespace Chamilo\CoreBundle\Component\Tracking;
+
+final class LearnpathQuizTimeCalculator
+{
+    /**
+     * Calculate active quiz intervals from chronologically ordered access rows.
+     *
+     * A new learning-path quiz introduction is an interval boundary. Requiring
+     * the same exercise and learning-path context also prevents time away from
+     * a quiz, another exercise or another learning path from being counted.
+     * Standalone quiz intervals contribute only to quiz time.
+     *
+     * @param array<int, array<string, mixed>> $events
+     *
+     * @return array{quiz_time: int, learnpath_time: array<int, int>}
+     */
+    public static function calculate(array $events): array
+    {
+        $result = [
+            'quiz_time' => 0,
+            'learnpath_time' => [],
+        ];
+        $previous = null;
+
+        foreach ($events as $current) {
+            if (null === $previous) {
+                $previous = $current;
+                continue;
+            }
+
+            $elapsed = (int) ($current['date_reg'] ?? 0) - (int) ($previous['date_reg'] ?? 0);
+            $learnpathId = (int) ($current['action_details'] ?? 0);
+            $previousLearnpathId = (int) ($previous['action_details'] ?? 0);
+            $exerciseId = (int) ($current['tool_id'] ?? 0);
+            $previousExerciseId = (int) ($previous['tool_id'] ?? 0);
+            $isIntroduction = self::isIntroduction($current);
+
+            if (
+                $elapsed > 0 &&
+                $exerciseId > 0 &&
+                $exerciseId === $previousExerciseId &&
+                $learnpathId === $previousLearnpathId &&
+                !$isIntroduction
+            ) {
+                $result['quiz_time'] += $elapsed;
+
+                if ($learnpathId > 0) {
+                    if (!isset($result['learnpath_time'][$learnpathId])) {
+                        $result['learnpath_time'][$learnpathId] = 0;
+                    }
+                    $result['learnpath_time'][$learnpathId] += $elapsed;
+                }
+            }
+
+            $previous = $current;
+        }
+
+        return $result;
+    }
+
+    /**
+     * Learning-path introductions have an explicit action marker. Standalone
+     * introductions use empty action fields, so their logged request path is
+     * needed to distinguish them from question and result events.
+     *
+     * @param array<string, mixed> $event
+     */
+    private static function isIntroduction(array $event): bool
+    {
+        if ('learnpath_id' === ($event['action'] ?? '')) {
+            return true;
+        }
+
+        $path = parse_url((string) ($event['url'] ?? ''), PHP_URL_PATH);
+        $script = basename((string) $path);
+
+        return in_array($script, ['overview.php', 'exercise.php'], true);
+    }
+}

--- a/tests/unit/Chamilo/CoreBundle/Component/Tracking/LearnpathQuizTimeCalculatorTest.php
+++ b/tests/unit/Chamilo/CoreBundle/Component/Tracking/LearnpathQuizTimeCalculatorTest.php
@@ -1,0 +1,131 @@
+<?php
+
+/* For licensing terms, see /license.txt */
+
+namespace Chamilo\Tests\CoreBundle\Component\Tracking;
+
+use Chamilo\CoreBundle\Component\Tracking\LearnpathQuizTimeCalculator;
+use PHPUnit\Framework\TestCase;
+
+require_once dirname(__DIR__, 6).'/src/Chamilo/CoreBundle/Component/Tracking/LearnpathQuizTimeCalculator.php';
+
+final class LearnpathQuizTimeCalculatorTest extends TestCase
+{
+    public function testCountsEveryPageOfAnEmbeddedQuizInBothTotals(): void
+    {
+        $events = [
+            $this->event(0, 55, 'learnpath_id', 101),
+            $this->event(60, 55, '101', 101),
+            $this->event(120, 55, '101', 101),
+            $this->event(180, 55, '101', 101),
+        ];
+
+        self::assertSame(
+            ['quiz_time' => 180, 'learnpath_time' => [101 => 180]],
+            LearnpathQuizTimeCalculator::calculate($events)
+        );
+    }
+
+    public function testReopenedIntroductionDoesNotBridgeTimeAwayFromQuiz(): void
+    {
+        $events = [
+            $this->event(0, 55, 'learnpath_id', 101),
+            $this->event(480, 55, 'learnpath_id', 101),
+            $this->event(540, 55, '101', 101),
+            $this->event(600, 55, '101', 101),
+        ];
+
+        self::assertSame(
+            ['quiz_time' => 120, 'learnpath_time' => [101 => 120]],
+            LearnpathQuizTimeCalculator::calculate($events)
+        );
+    }
+
+    public function testDoesNotBridgeLearningPathsForTheSameExercise(): void
+    {
+        $events = [
+            $this->event(0, 55, 'learnpath_id', 101),
+            $this->event(480, 55, 'learnpath_id', 202),
+            $this->event(540, 55, '202', 202),
+            $this->event(600, 55, '202', 202),
+        ];
+
+        self::assertSame(
+            ['quiz_time' => 120, 'learnpath_time' => [202 => 120]],
+            LearnpathQuizTimeCalculator::calculate($events)
+        );
+    }
+
+    public function testDoesNotBridgeDifferentExercisesInTheSameLearningPath(): void
+    {
+        $events = [
+            $this->event(0, 55, '101', 101),
+            $this->event(600, 66, '101', 101),
+            $this->event(660, 66, '101', 101),
+        ];
+
+        self::assertSame(
+            ['quiz_time' => 60, 'learnpath_time' => [101 => 60]],
+            LearnpathQuizTimeCalculator::calculate($events)
+        );
+    }
+
+    public function testStandaloneQuizDoesNotInflateLearningPathTime(): void
+    {
+        $events = [
+            $this->event(0, 55, '', '', '/main/exercise/overview.php'),
+            $this->event(60, 55, '', '', '/main/exercise/exercise_submit.php'),
+        ];
+
+        self::assertSame(
+            ['quiz_time' => 60, 'learnpath_time' => []],
+            LearnpathQuizTimeCalculator::calculate($events)
+        );
+    }
+
+    public function testReopenedStandaloneQuizDoesNotBridgeTimeSpentElsewhere(): void
+    {
+        $events = [
+            $this->event(0, 55, '', '', '/main/exercise/overview.php'),
+            $this->event(60, 55, '', '', '/main/exercise/exercise_submit.php'),
+            $this->event(600, 55, '', '', '/main/exercise/overview.php'),
+            $this->event(660, 55, '', '', '/main/exercise/exercise_submit.php'),
+        ];
+
+        self::assertSame(
+            ['quiz_time' => 120, 'learnpath_time' => []],
+            LearnpathQuizTimeCalculator::calculate($events)
+        );
+    }
+
+    public function testIgnoresNonPositiveIntervals(): void
+    {
+        $events = [
+            $this->event(60, 55, '101', 101),
+            $this->event(60, 55, '101', 101),
+            $this->event(30, 55, '101', 101),
+        ];
+
+        self::assertSame(
+            ['quiz_time' => 0, 'learnpath_time' => []],
+            LearnpathQuizTimeCalculator::calculate($events)
+        );
+    }
+
+    /**
+     * @param int|string $action
+     * @param int|string $learnpathId
+     *
+     * @return array<string, int|string>
+     */
+    private function event(int $timestamp, int $exerciseId, $action, $learnpathId, string $url = ''): array
+    {
+        return [
+            'date_reg' => $timestamp,
+            'tool_id' => $exerciseId,
+            'action' => $action,
+            'action_details' => $learnpathId,
+            'url' => $url,
+        ];
+    }
+}


### PR DESCRIPTION
## Español

Corrige #5580.

### Cambios

- Ordena cronológicamente los eventos de acceso antes de calcular los intervalos.
- Cuenta únicamente intervalos consecutivos del mismo ejercicio y del mismo contexto de lección.
- Usa una nueva introducción como límite, evitando sumar el tiempo pasado fuera del ejercicio al volver a abrirlo.
- Incluye todas las páginas de un ejercicio dentro del tiempo de la lección y también en el acumulado de ejercicios.
- Mantiene los ejercicios independientes fuera del acumulado de lecciones y reconoce sus pantallas de introducción.

### Pruebas

- PHPUnit 9.6: 7 pruebas, 7 aserciones.
- Casos cubiertos: ejercicio multipágina, reapertura, cambio de lección, cambio de ejercicio, ejercicio independiente y duraciones no positivas.
- PHP-CS-Fixer 3.4 en modo dry-run.
- Sintaxis PHP y git diff --check.

## English

Fixes #5580.

### Changes

- Orders access events chronologically before reducing intervals.
- Counts only consecutive intervals from the same exercise and learning-path context.
- Treats a new introduction as a boundary, preventing time spent elsewhere from being charged when a quiz is reopened.
- Includes every page of an embedded quiz in both learning-path and quiz totals.
- Keeps standalone quizzes out of learning-path totals and recognizes their introduction pages.

### Tests

- PHPUnit 9.6: 7 tests, 7 assertions.
- Covers multi-page quizzes, reopening, LP changes, exercise changes, standalone quizzes, and non-positive intervals.
- PHP-CS-Fixer 3.4 dry-run.
- PHP syntax and git diff --check.