### PR TITLE
Course: restore general session coach notifications

### DIFF
--- a/main/inc/lib/course.lib.php
+++ b/main/inc/lib/course.lib.php
@@ -1980,11 +1980,11 @@ class CourseManager
             // We get the session coach.
             $sql = "SELECT id_coach FROM $table WHERE id = $session_id";
             $rs = Database::query($sql);
-            $session_id_coach = Database::result($rs, 0, 'id_coach');
-            if (is_int($session_id_coach)) {
-                $userInfo = api_get_user_info($session_id_coach);
+            $sessionCoachId = (int) Database::result($rs, 0, 'id_coach');
+            if ($sessionCoachId > 0) {
+                $userInfo = api_get_user_info($sessionCoachId);
                 if ($userInfo) {
-                    $users[$session_id_coach] = $userInfo;
+                    $users[$sessionCoachId] = $userInfo;
                 }
             }
         }

--- a/tests/unit/CourseManagerTest.php
+++ b/tests/unit/CourseManagerTest.php
@@ -1,0 +1,76 @@
+<?php
+
+/* For licensing terms, see /license.txt */
+
+use PHPUnit\Framework\TestCase;
+
+final class CourseManagerDatabaseStub
+{
+    public static $generalCoachId = '17';
+    public static $userLookups = [];
+
+    public static function escape_string($value)
+    {
+        return $value;
+    }
+
+    public static function get_main_table($table)
+    {
+        return $table;
+    }
+
+    public static function query($sql)
+    {
+        return $sql;
+    }
+
+    public static function fetch_array($resource)
+    {
+        return false;
+    }
+
+    public static function result($resource, $row, $field = '')
+    {
+        return self::$generalCoachId;
+    }
+}
+
+final class CourseManagerTest extends TestCase
+{
+    /**
+     * @runInSeparateProcess
+     * @preserveGlobalState disabled
+     */
+    public function testIncludesNumericStringGeneralCoachId(): void
+    {
+        define('TABLE_MAIN_SESSION_COURSE_USER', 'session_rel_course_rel_user');
+        define('TABLE_MAIN_SESSION', 'session');
+        class_alias(CourseManagerDatabaseStub::class, 'Database');
+
+        function api_get_course_info($courseCode)
+        {
+            return ['real_id' => 42];
+        }
+
+        function api_get_user_info($userId)
+        {
+            CourseManagerDatabaseStub::$userLookups[] = $userId;
+
+            return ['user_id' => (int) $userId];
+        }
+
+        require_once dirname(__DIR__, 2).'/main/inc/lib/course.lib.php';
+
+        self::assertSame(
+            [17 => ['user_id' => 17]],
+            CourseManager::get_coach_list_from_course_code('COURSE', 9)
+        );
+        self::assertSame([17], CourseManagerDatabaseStub::$userLookups);
+
+        CourseManagerDatabaseStub::$generalCoachId = 0;
+        CourseManagerDatabaseStub::$userLookups = [];
+
+        self::assertSame([], CourseManager::get_coach_list_from_course_code('COURSE', 9));
+        self::assertSame([], CourseManagerDatabaseStub::$userLookups);
+    }
+}


### PR DESCRIPTION
## Español

### Resumen

- Restaura la inclusión del tutor general de la sesión entre los destinatarios de las notificaciones de ejercicios.
- Normaliza id_coach a un entero positivo cuando la base de datos lo devuelve como cadena numérica.
- Evita que un ID vacío o cero termine buscando al usuario actual.
- Añade una prueba de regresión aislada para ambos casos.

### Causa

El control estricto is_int(), añadido después de Chamilo 1.11.6, descartaba IDs válidos devueltos por PDO como cadenas. Esto coincide con la regresión descrita en #3769 a partir de 1.11.8.

### Pruebas

- PHPUnit 9.6.22: 1 prueba, 4 aserciones
- Sintaxis PHP de los dos archivos modificados
- PHP-CS-Fixer en modo dry-run
- git diff --check

## English

### Summary

- Restores the general session coach as an exercise-notification recipient.
- Normalizes id_coach to a positive integer when the database returns a numeric string.
- Prevents an empty or zero ID from resolving to the current user.
- Adds an isolated regression test for both cases.

### Cause

The strict is_int() check added after Chamilo 1.11.6 discarded valid IDs returned by PDO as strings. This matches the regression reported in #3769 beginning with 1.11.8.

### Tests

- PHPUnit 9.6.22: 1 test, 4 assertions
- PHP syntax checks for both changed files
- PHP-CS-Fixer dry run
- git diff --check

Closes #3769