### PR TITLE
Security: Require teacher rights to reorder course tools

### DIFF
--- a/src/CoreBundle/Controller/CourseController.php
+++ b/src/CoreBundle/Controller/CourseController.php
@@ -217,6 +217,13 @@ class CourseController extends ToolBaseController
                     );
                 }
 
+                // Reordering the course home is a teacher action: the drag &
+                // drop handle is only rendered when api_is_allowed_to_edit()
+                // grants it. Without this check the POST branch returns before
+                // reaching the GET flow's access check below, so any
+                // authenticated user could reorder any course's tools.
+                $this->denyAccessUnlessGranted(CourseVoter::EDIT, $course);
+
                 $sessionId = $this->getSessionId();
                 $toolId = (int) $requestData['toolId'];
                 $newIndex = (int) $requestData['index'];

--- a/tests/CoreBundle/Controller/CourseControllerTest.php
+++ b/tests/CoreBundle/Controller/CourseControllerTest.php
@@ -11,8 +11,11 @@ use Chamilo\CoreBundle\Repository\Node\CourseRepository;
 use Chamilo\CourseBundle\Entity\CCourseDescription;
 use Chamilo\CourseBundle\Settings\SettingsCourseManager;
 use Chamilo\Tests\ChamiloTestTrait;
+use Symfony\Bundle\FrameworkBundle\KernelBrowser;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 use Symfony\Component\HttpFoundation\Response;
+
+use const JSON_THROW_ON_ERROR;
 
 class CourseControllerTest extends WebTestCase
 {
@@ -102,6 +105,44 @@ class CourseControllerTest extends WebTestCase
             'GET',
             '/course/'.$course->getId().'/home.json'
         );
+        $this->assertResponseIsSuccessful();
+    }
+
+    public function testReorderToolsIsDeniedForStudent(): void
+    {
+        $client = static::createClient();
+        $course = $this->createCourse('course to reorder');
+
+        $student = $this->createUser('student');
+        $course->addUserAsStudent($student);
+
+        $em = $this->getEntityManager();
+        $em->persist($course);
+        $em->flush();
+
+        $client->loginUser($student);
+        $this->postToolOrder($client, $course, $this->getFirstToolId($course), 0);
+
+        // A student can read the course home, so the GET flow would let them
+        // through: reordering must be gated on its own, not on VIEW.
+        $this->assertResponseStatusCodeSame(403);
+    }
+
+    public function testReorderToolsIsAllowedForTeacher(): void
+    {
+        $client = static::createClient();
+        $course = $this->createCourse('course to reorder by teacher');
+
+        $teacher = $this->createUser('teacher');
+        $course->addUserAsTeacher($teacher);
+
+        $em = $this->getEntityManager();
+        $em->persist($course);
+        $em->flush();
+
+        $client->loginUser($teacher);
+        $this->postToolOrder($client, $course, $this->getFirstToolId($course), 0);
+
         $this->assertResponseIsSuccessful();
     }
 
@@ -219,5 +260,26 @@ class CourseControllerTest extends WebTestCase
         $client->request('GET', '/course/'.$course->getId().'/about');
         $this->assertResponseIsSuccessful();
         $this->assertStringContainsString('new course', $client->getResponse()->getContent());
+    }
+
+    private function getFirstToolId(Course $course): int
+    {
+        $tool = $course->getTools()->first();
+
+        $this->assertNotFalse($tool, 'The course was created without tools.');
+
+        return (int) $tool->getIid();
+    }
+
+    private function postToolOrder(KernelBrowser $client, Course $course, int $toolId, int $index): void
+    {
+        $client->request(
+            'POST',
+            '/course/'.$course->getId().'/home.json',
+            [],
+            [],
+            ['CONTENT_TYPE' => 'application/json'],
+            json_encode(['toolId' => $toolId, 'index' => $index], JSON_THROW_ON_ERROR)
+        );
     }
 }


### PR DESCRIPTION
## Problem

`CourseController::indexJson()` serves `/course/{cid}/home.json` for both GET and POST. The POST
branch handles the course home drag & drop reordering and **returns before the GET flow's access
check**, so `denyAccessUnlessGranted(CourseVoter::VIEW, $course)` is never reached for a POST.

The class carries no `#[IsGranted]`, so the only requirement was being authenticated. Any user who
knew a `cid` and a `toolId` could reorder that course's tools.

The permission check existed only in the client: `CourseHome.vue` renders the drag handle solely
when `useIsAllowedToEdit()` returns true.

## Fix

One check at the start of the POST branch, so the backend enforces what the UI already assumed:

```php
$this->denyAccessUnlessGranted(CourseVoter::EDIT, $course);
```

`EDIT` (admin, or `Course::hasUserAsTeacher()`) rather than `VIEW`, because `VIEW` would still let
any subscribed student reorder — and on an `OPEN_PLATFORM` course, any authenticated user at all.

## Tests

Two regression tests in `CourseControllerTest`:

- `testReorderToolsIsDeniedForStudent` — a student **subscribed** to the course gets 403. Subscribed
  on purpose: the point is that reordering needs its own gate, since `VIEW` would let this user
  through.
- `testReorderToolsIsAllowedForTeacher` — the course teacher still reorders successfully.

Verified that the first test fails without the fix (`200` instead of `403`), reproducing the
original report. `vendor/bin/ecs check` is clean on both files.

`testListSettings` in the same file fails on `master` already, unrelated to this change (it fails
the same way with only that filter applied).
