### PR TITLE
Security: Restrict SessionRelCourseRelUser API operations and scope its collection

### DIFF
--- a/src/CoreBundle/DataProvider/Extension/SessionRelCourseRelUserExtension.php
+++ b/src/CoreBundle/DataProvider/Extension/SessionRelCourseRelUserExtension.php
@@ -1,0 +1,85 @@
+<?php
+
+/* For licensing terms, see /license.txt */
+
+declare(strict_types=1);
+
+namespace Chamilo\CoreBundle\DataProvider\Extension;
+
+use ApiPlatform\Doctrine\Orm\Extension\QueryCollectionExtensionInterface;
+use ApiPlatform\Doctrine\Orm\Util\QueryNameGeneratorInterface;
+use ApiPlatform\Metadata\Operation;
+use Chamilo\CoreBundle\Entity\Session;
+use Chamilo\CoreBundle\Entity\SessionRelCourseRelUser;
+use Chamilo\CoreBundle\Entity\SessionRelUser;
+use Chamilo\CoreBundle\Entity\User;
+use Doctrine\ORM\QueryBuilder;
+use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\Security\Core\Exception\AccessDeniedException;
+
+/**
+ * Keeps the session course subscriptions collection to what the caller may see:
+ * their own subscriptions, plus the ones of the sessions they coach.
+ */
+final readonly class SessionRelCourseRelUserExtension implements QueryCollectionExtensionInterface
+{
+    public function __construct(
+        private Security $security,
+    ) {}
+
+    public function applyToCollection(
+        QueryBuilder $queryBuilder,
+        QueryNameGeneratorInterface $queryNameGenerator,
+        string $resourceClass,
+        ?Operation $operation = null,
+        array $context = []
+    ): void {
+        if (SessionRelCourseRelUser::class !== $resourceClass
+            || $this->security->isGranted('ROLE_ADMIN')
+        ) {
+            return;
+        }
+
+        /** @var User|null $user */
+        $user = $this->security->getUser();
+
+        if (null === $user) {
+            throw new AccessDeniedException('Access Denied.');
+        }
+
+        $alias = $queryBuilder->getRootAliases()[0];
+
+        $queryBuilder
+            ->andWhere(
+                $queryBuilder->expr()->orX(
+                    \sprintf('%s.user = :current_user', $alias),
+                    \sprintf(
+                        'EXISTS (
+                            SELECT 1 FROM %s course_coach
+                            WHERE course_coach.user = :current_user
+                                AND course_coach.session = %s.session
+                                AND course_coach.course = %s.course
+                                AND course_coach.status = :course_coach_status
+                        )',
+                        SessionRelCourseRelUser::class,
+                        $alias,
+                        $alias
+                    ),
+                    \sprintf(
+                        'EXISTS (
+                            SELECT 1 FROM %s general_coach
+                            WHERE general_coach.user = :current_user
+                                AND general_coach.session = %s.session
+                                AND general_coach.relationType = :general_coach_status
+                        )',
+                        SessionRelUser::class,
+                        $alias
+                    )
+                )
+            )
+            ->setParameter('current_user', (int) $user->getId())
+            ->setParameter('course_coach_status', Session::COURSE_COACH)
+            ->setParameter('general_coach_status', Session::GENERAL_COACH)
+        ;
+    }
+}

--- a/src/CoreBundle/DataProvider/Extension/SessionRelCourseRelUserExtension.php
+++ b/src/CoreBundle/DataProvider/Extension/SessionRelCourseRelUserExtension.php
@@ -9,6 +9,7 @@ namespace Chamilo\CoreBundle\DataProvider\Extension;
 use ApiPlatform\Doctrine\Orm\Extension\QueryCollectionExtensionInterface;
 use ApiPlatform\Doctrine\Orm\Util\QueryNameGeneratorInterface;
 use ApiPlatform\Metadata\Operation;
+use Chamilo\CoreBundle\Entity\CourseRelUser;
 use Chamilo\CoreBundle\Entity\Session;
 use Chamilo\CoreBundle\Entity\SessionRelCourseRelUser;
 use Chamilo\CoreBundle\Entity\SessionRelUser;
@@ -19,7 +20,9 @@ use Symfony\Component\Security\Core\Exception\AccessDeniedException;
 
 /**
  * Keeps the session course subscriptions collection to what the caller may see:
- * their own subscriptions, plus the ones of the sessions they coach.
+ * their own subscriptions, plus the ones of the courses they teach — as a coach
+ * of that session course, as a general coach of the session, or as a teacher of
+ * the base course.
  */
 final readonly class SessionRelCourseRelUserExtension implements QueryCollectionExtensionInterface
 {
@@ -74,12 +77,25 @@ final readonly class SessionRelCourseRelUserExtension implements QueryCollection
                         )',
                         SessionRelUser::class,
                         $alias
+                    ),
+                    // A teacher of the base course keeps managing it inside a session
+                    // even when nobody registered them as a coach of that session.
+                    \sprintf(
+                        'EXISTS (
+                            SELECT 1 FROM %s course_teacher
+                            WHERE course_teacher.user = :current_user
+                                AND course_teacher.course = %s.course
+                                AND course_teacher.status = :course_teacher_status
+                        )',
+                        CourseRelUser::class,
+                        $alias
                     )
                 )
             )
             ->setParameter('current_user', (int) $user->getId())
             ->setParameter('course_coach_status', Session::COURSE_COACH)
             ->setParameter('general_coach_status', Session::GENERAL_COACH)
+            ->setParameter('course_teacher_status', CourseRelUser::TEACHER)
         ;
     }
 }

--- a/src/CoreBundle/Entity/SessionRelCourseRelUser.php
+++ b/src/CoreBundle/Entity/SessionRelCourseRelUser.php
@@ -34,10 +34,10 @@ use Symfony\Component\Validator\Constraints as Assert;
         // The collection is narrowed down to the caller's own subscriptions and to the
         // sessions they coach by SessionRelCourseRelUserExtension.
         new GetCollection(),
-        // Self-subscription from the session catalogue is the only non-admin creation:
-        // enrolling somebody else, or granting oneself the coach status, is refused.
+        // Self-subscription from the session catalogue is the only non-admin creation;
+        // SessionRelCourseRelUserVoter also re-checks the setting that gates it.
         new Post(
-            securityPostDenormalize: "is_granted('ROLE_ADMIN') or (object.getUser().getId() == user.getId() and object.getStatus() == constant('Chamilo\\\\CoreBundle\\\\Entity\\\\Session::STUDENT'))"
+            securityPostDenormalize: "is_granted('CREATE', object)"
         ),
         new Put(security: "is_granted('ROLE_ADMIN')"),
         new Patch(security: "is_granted('ROLE_ADMIN')"),

--- a/src/CoreBundle/Entity/SessionRelCourseRelUser.php
+++ b/src/CoreBundle/Entity/SessionRelCourseRelUser.php
@@ -10,6 +10,12 @@ use ApiPlatform\Doctrine\Orm\Filter\DateFilter;
 use ApiPlatform\Doctrine\Orm\Filter\SearchFilter;
 use ApiPlatform\Metadata\ApiFilter;
 use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\Delete;
+use ApiPlatform\Metadata\Get;
+use ApiPlatform\Metadata\GetCollection;
+use ApiPlatform\Metadata\Patch;
+use ApiPlatform\Metadata\Post;
+use ApiPlatform\Metadata\Put;
 use Chamilo\CoreBundle\Repository\SessionRelCourseRelUserRepository;
 use Chamilo\CoreBundle\Traits\UserTrait;
 use Doctrine\ORM\Mapping as ORM;
@@ -21,6 +27,22 @@ use Symfony\Component\Validator\Constraints as Assert;
  * User subscriptions to a session course.
  */
 #[ApiResource(
+    operations: [
+        new Get(
+            security: "is_granted('ROLE_ADMIN') or object.getUser().getId() == user.getId()"
+        ),
+        // The collection is narrowed down to the caller's own subscriptions and to the
+        // sessions they coach by SessionRelCourseRelUserExtension.
+        new GetCollection(),
+        // Self-subscription from the session catalogue is the only non-admin creation:
+        // enrolling somebody else, or granting oneself the coach status, is refused.
+        new Post(
+            securityPostDenormalize: "is_granted('ROLE_ADMIN') or (object.getUser().getId() == user.getId() and object.getStatus() == constant('Chamilo\\\\CoreBundle\\\\Entity\\\\Session::STUDENT'))"
+        ),
+        new Put(security: "is_granted('ROLE_ADMIN')"),
+        new Patch(security: "is_granted('ROLE_ADMIN')"),
+        new Delete(security: "is_granted('ROLE_ADMIN')"),
+    ],
     normalizationContext: [
         'groups' => [
             'user:read',

--- a/src/CoreBundle/Entity/SessionRelCourseRelUser.php
+++ b/src/CoreBundle/Entity/SessionRelCourseRelUser.php
@@ -15,7 +15,6 @@ use ApiPlatform\Metadata\Get;
 use ApiPlatform\Metadata\GetCollection;
 use ApiPlatform\Metadata\Patch;
 use ApiPlatform\Metadata\Post;
-use ApiPlatform\Metadata\Put;
 use Chamilo\CoreBundle\Repository\SessionRelCourseRelUserRepository;
 use Chamilo\CoreBundle\Traits\UserTrait;
 use Doctrine\ORM\Mapping as ORM;
@@ -39,7 +38,6 @@ use Symfony\Component\Validator\Constraints as Assert;
         new Post(
             securityPostDenormalize: "is_granted('CREATE', object)"
         ),
-        new Put(security: "is_granted('ROLE_ADMIN')"),
         new Patch(security: "is_granted('ROLE_ADMIN')"),
         new Delete(security: "is_granted('ROLE_ADMIN')"),
     ],

--- a/src/CoreBundle/Security/Authorization/Voter/SessionRelCourseRelUserVoter.php
+++ b/src/CoreBundle/Security/Authorization/Voter/SessionRelCourseRelUserVoter.php
@@ -1,0 +1,69 @@
+<?php
+
+/* For licensing terms, see /license.txt */
+
+declare(strict_types=1);
+
+namespace Chamilo\CoreBundle\Security\Authorization\Voter;
+
+use Chamilo\CoreBundle\Entity\Session;
+use Chamilo\CoreBundle\Entity\SessionRelCourseRelUser;
+use Chamilo\CoreBundle\Entity\User;
+use Chamilo\CoreBundle\Settings\SettingsManager;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Authorization\AccessDecisionManagerInterface;
+use Symfony\Component\Security\Core\Authorization\Voter\Vote;
+use Symfony\Component\Security\Core\Authorization\Voter\Voter;
+
+/**
+ * Creation rules for a session course subscription.
+ *
+ * Outside of administration, the only legitimate creation is a user subscribing
+ * themselves from the session catalogue, which the platform has to allow: the
+ * catalogue hides its button when the setting is off, and that decision cannot
+ * be left to the browser.
+ *
+ * @extends Voter<'CREATE', SessionRelCourseRelUser>
+ */
+class SessionRelCourseRelUserVoter extends Voter
+{
+    public const string CREATE = 'CREATE';
+
+    public function __construct(
+        private AccessDecisionManagerInterface $accessDecisionManager,
+        private SettingsManager $settingsManager
+    ) {}
+
+    protected function supports(string $attribute, $subject): bool
+    {
+        return self::CREATE === $attribute && $subject instanceof SessionRelCourseRelUser;
+    }
+
+    protected function voteOnAttribute(string $attribute, $subject, TokenInterface $token, ?Vote $vote = null): bool
+    {
+        if ($this->accessDecisionManager->decide($token, ['ROLE_ADMIN'])) {
+            return true;
+        }
+
+        $currentUser = $token->getUser();
+
+        if (!$currentUser instanceof User) {
+            return false;
+        }
+
+        if (!$this->isAutoSubscriptionAllowed()) {
+            return false;
+        }
+
+        /** @var SessionRelCourseRelUser $subject */
+        return $subject->getUser()->getId() === $currentUser->getId()
+            && Session::STUDENT === $subject->getStatus();
+    }
+
+    private function isAutoSubscriptionAllowed(): bool
+    {
+        $setting = $this->settingsManager->getSetting('catalog.allow_session_auto_subscription', true);
+
+        return 'true' === strtolower((string) $setting);
+    }
+}


### PR DESCRIPTION
Gives each `SessionRelCourseRelUser` API operation its own security expression instead of the resource-wide `ROLE_USER`, so writes are limited to admins and to a user subscribing themselves as a student, and adds a collection extension that narrows the listing to the caller's own subscriptions plus the sessions they coach.

Creation goes through a voter rather than an inline expression, because self-subscription is only legitimate while `catalog.allow_session_auto_subscription` is on — the catalogue card hides its button when it is off, and that decision cannot be left to the browser. The setting defaults to `false`.

Note for the reviewer: item `Get` is now admin-or-owner, so a coach can no longer fetch a single subscription of one of their learners; no current Vue caller does that, but it is a behaviour change worth confirming.

Refs GHSA-fc9v-jqhv-c88c