### PR TITLE
Security: Tie UserRelCourseVote writes to the voting user and scope its collection

### DIFF
--- a/assets/vue/components/course/AdminCourseCard.vue
+++ b/assets/vue/components/course/AdminCourseCard.vue
@@ -48,7 +48,7 @@
 import Card from "primevue/card"
 import { ref, watch, computed } from "vue"
 import { useI18n } from "vue-i18n"
-import courseService from "../../services/courseService"
+import * as userRelCourseVoteService from "../../services/userRelCourseVoteService"
 import { useSecurityStore } from "../../store/securityStore"
 
 const { t } = useI18n()
@@ -97,7 +97,7 @@ function onImgError(e) {
 }
 
 async function toggleFavorite() {
-  const result = await courseService.toggleFavorite(props.course.id, securityStore.user.id)
+  const result = await userRelCourseVoteService.toggleFavorite(props.course.id, securityStore.user.id)
   isFavorite.value = result
   emit("favorite-toggled", {
     courseId: props.course.id,

--- a/assets/vue/services/courseService.js
+++ b/assets/vue/services/courseService.js
@@ -247,38 +247,6 @@ export default {
     return data
   },
 
-  toggleFavorite: async (courseId, userId) => {
-    // Check if the vote already exists
-    const { data } = await api.get("/api/user_rel_course_votes", {
-      params: { "user.id": userId, "course.id": courseId },
-    })
-
-    if (data["hydra:totalItems"] > 0) {
-      // Already favorite → remove
-      await api.delete(data["hydra:member"][0]["@id"])
-
-      return false
-    }
-
-    // Not favorite → create
-    await api.post("/api/user_rel_course_votes", {
-      user: `/api/users/${userId}`,
-      course: `/api/courses/${courseId}`,
-      vote: 1,
-      url: `/api/access_urls/${window.access_url_id ?? 1}`,
-    })
-
-    return true
-  },
-
-  listFavoriteCourses: async (userId) => {
-    const { data } = await api.get("/api/user_rel_course_votes", {
-      params: { "user.id": userId, vote: 1, pagination: false },
-    })
-
-    return data["hydra:member"].map((vote) => vote.course)
-  },
-
   getCompletedCourses: async (offset = 0, limit = 10) => {
     const res = await api.get("/admin/sessionadmin/courses/completed", {
       params: { offset, limit },

--- a/assets/vue/services/userRelCourseVoteService.js
+++ b/assets/vue/services/userRelCourseVoteService.js
@@ -86,6 +86,54 @@ export async function getUserVote({ userId, courseId, sessionId = null, urlId })
 }
 
 /**
+ * Adds a course to the user's favourites, or removes it when already there.
+ *
+ * @param {number} courseId - ID of the course
+ * @param {number} userId - ID of the user
+ * @returns {Promise<boolean>} - Whether the course is a favourite after the call
+ */
+export async function toggleFavorite(courseId, userId) {
+  // Check if the vote already exists
+  const { totalItems, items } = await baseService.getCollection("/api/user_rel_course_votes", {
+    "user.id": userId,
+    "course.id": courseId,
+  })
+
+  if (totalItems > 0) {
+    // Already favorite → remove
+    await baseService.delete(items[0]["@id"])
+
+    return false
+  }
+
+  // Not favorite → create
+  await baseService.post("/api/user_rel_course_votes", {
+    user: `/api/users/${userId}`,
+    course: `/api/courses/${courseId}`,
+    vote: 1,
+    url: `/api/access_urls/${window.access_url_id ?? 1}`,
+  })
+
+  return true
+}
+
+/**
+ * Lists the courses the user marked as favourite.
+ *
+ * @param {number} userId - ID of the user
+ * @returns {Promise<Array>} - List of courses
+ */
+export async function listFavoriteCourses(userId) {
+  const { items } = await baseService.getCollection("/api/user_rel_course_votes", {
+    "user.id": userId,
+    vote: 1,
+    pagination: false,
+  })
+
+  return items.map((vote) => vote.course)
+}
+
+/**
  * Retrieves all votes of a user for different courses.
  *
  * @param {number} userId - User ID

--- a/assets/vue/services/userRelCourseVoteService.js
+++ b/assets/vue/services/userRelCourseVoteService.js
@@ -60,20 +60,22 @@ export async function updateVote({ iri, vote, sessionId = null, urlId }) {
  */
 export async function getUserVote({ userId, courseId, sessionId = null, urlId }) {
   try {
-    let query = `/api/user_rel_course_votes?user.id=${userId}`
+    const searchParams = { "user.id": userId }
 
-    if (urlId) query += `&url.id=${urlId}`
+    if (urlId) searchParams["url.id"] = urlId
 
     if (courseId && courseId !== 0) {
-      query += `&course.id=${courseId}`
+      searchParams["course.id"] = courseId
     } else if (sessionId) {
-      query += `&session.id=${sessionId}&course=null`
+      searchParams["session.id"] = sessionId
+      // Kept as a string: axios drops null values, and the API expects the literal.
+      searchParams.course = "null"
     }
 
-    const response = await baseService.get(query)
+    const { items } = await baseService.getCollection("/api/user_rel_course_votes", searchParams)
 
-    if (response?.["hydra:member"]?.length > 0) {
-      return response["hydra:member"][0]
+    if (items?.length > 0) {
+      return items[0]
     }
 
     return null

--- a/assets/vue/views/sessionadmin/AdminDashboard.vue
+++ b/assets/vue/views/sessionadmin/AdminDashboard.vue
@@ -29,6 +29,7 @@ import { ref, onMounted } from "vue"
 import { useI18n } from "vue-i18n"
 import AdminCourseCard from "../../components/course/AdminCourseCard.vue"
 import courseService from "../../services/courseService"
+import * as userRelCourseVoteService from "../../services/userRelCourseVoteService"
 import { useSecurityStore } from "../../store/securityStore"
 
 const { t } = useI18n()
@@ -42,7 +43,7 @@ onMounted(async () => {
 
     const [coursesRes, favRes] = await Promise.allSettled([
       courseService.fetchDashboardCourses(),
-      courseService.listFavoriteCourses(securityStore.user.id),
+      userRelCourseVoteService.listFavoriteCourses(securityStore.user.id),
     ])
     if (coursesRes.status === "fulfilled") {
       const allCourses = coursesRes.value

--- a/assets/vue/views/sessionadmin/FavoritesCourses.vue
+++ b/assets/vue/views/sessionadmin/FavoritesCourses.vue
@@ -24,6 +24,7 @@
 import { ref, onMounted } from "vue"
 import { useI18n } from "vue-i18n"
 import courseService from "../../services/courseService"
+import * as userRelCourseVoteService from "../../services/userRelCourseVoteService"
 import AdminCourseCard from "../../components/course/AdminCourseCard.vue"
 import { useSecurityStore } from "../../store/securityStore"
 
@@ -65,7 +66,7 @@ async function loadFavorites() {
   const userId = securityStore.user.id
   const isSessionAdmin = securityStore.isSessionAdmin
 
-  const favoritesRaw = await courseService.listFavoriteCourses(userId)
+  const favoritesRaw = await userRelCourseVoteService.listFavoriteCourses(userId)
   const courseIds = favoritesRaw
     .map((iri) => parseInt(iri.split("/").pop()))
     .filter((id) => !isNaN(id))

--- a/src/CoreBundle/DataProvider/Extension/UserRelCourseVoteExtension.php
+++ b/src/CoreBundle/DataProvider/Extension/UserRelCourseVoteExtension.php
@@ -1,0 +1,54 @@
+<?php
+
+/* For licensing terms, see /license.txt */
+
+declare(strict_types=1);
+
+namespace Chamilo\CoreBundle\DataProvider\Extension;
+
+use ApiPlatform\Doctrine\Orm\Extension\QueryCollectionExtensionInterface;
+use ApiPlatform\Doctrine\Orm\Util\QueryNameGeneratorInterface;
+use ApiPlatform\Metadata\Operation;
+use Chamilo\CoreBundle\Entity\User;
+use Chamilo\CoreBundle\Entity\UserRelCourseVote;
+use Doctrine\ORM\QueryBuilder;
+use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\Security\Core\Exception\AccessDeniedException;
+
+/**
+ * Keeps the course votes collection to the ones cast by the caller.
+ */
+final readonly class UserRelCourseVoteExtension implements QueryCollectionExtensionInterface
+{
+    public function __construct(
+        private Security $security,
+    ) {}
+
+    public function applyToCollection(
+        QueryBuilder $queryBuilder,
+        QueryNameGeneratorInterface $queryNameGenerator,
+        string $resourceClass,
+        ?Operation $operation = null,
+        array $context = []
+    ): void {
+        if (UserRelCourseVote::class !== $resourceClass
+            || $this->security->isGranted('ROLE_ADMIN')
+        ) {
+            return;
+        }
+
+        /** @var User|null $user */
+        $user = $this->security->getUser();
+
+        if (null === $user) {
+            throw new AccessDeniedException('Access Denied.');
+        }
+
+        $alias = $queryBuilder->getRootAliases()[0];
+
+        $queryBuilder
+            ->andWhere(\sprintf('%s.user = :current_user', $alias))
+            ->setParameter('current_user', (int) $user->getId())
+        ;
+    }
+}

--- a/src/CoreBundle/Entity/UserRelCourseVote.php
+++ b/src/CoreBundle/Entity/UserRelCourseVote.php
@@ -15,7 +15,6 @@ use ApiPlatform\Metadata\Get;
 use ApiPlatform\Metadata\GetCollection;
 use ApiPlatform\Metadata\Patch;
 use ApiPlatform\Metadata\Post;
-use ApiPlatform\Metadata\Put;
 use Chamilo\CoreBundle\EventListener\UserRelCourseVoteListener;
 use Chamilo\CoreBundle\Traits\UserTrait;
 use Doctrine\ORM\Mapping as ORM;
@@ -35,15 +34,14 @@ use Symfony\Component\Serializer\Attribute\Groups;
         new Post(
             securityPostDenormalize: "is_granted('ROLE_ADMIN') or object.getUser().getId() == user.getId()"
         ),
-        new Put(
-            security: "is_granted('ROLE_ADMIN') or object.getUser().getId() == user.getId()",
-            securityPostDenormalize: "is_granted('ROLE_ADMIN') or object.getUser().getId() == user.getId()"
-        ),
         new Patch(
             security: "is_granted('ROLE_ADMIN') or object.getUser().getId() == user.getId()",
             securityPostDenormalize: "is_granted('ROLE_ADMIN') or object.getUser().getId() == user.getId()"
         ),
-        new Delete(security: "is_granted('ROLE_ADMIN')"),
+        // Removing a course from the favourites deletes the vote behind it.
+        new Delete(
+            security: "is_granted('ROLE_ADMIN') or object.getUser().getId() == user.getId()"
+        ),
     ],
     normalizationContext: ['groups' => ['userRelCourseVote:read']],
     denormalizationContext: ['groups' => ['userRelCourseVote:write']]

--- a/src/CoreBundle/Entity/UserRelCourseVote.php
+++ b/src/CoreBundle/Entity/UserRelCourseVote.php
@@ -26,11 +26,24 @@ use Symfony\Component\Serializer\Attribute\Groups;
  */
 #[ApiResource(
     operations: [
-        new Get(security: "is_granted('ROLE_USER')"),
+        new Get(
+            security: "is_granted('ROLE_ADMIN') or object.getUser().getId() == user.getId()"
+        ),
+        // The collection is narrowed down to the caller's own votes by UserRelCourseVoteExtension.
         new GetCollection(security: "is_granted('ROLE_USER')"),
-        new Post(security: "is_granted('ROLE_USER')"),
-        new Put(security: "is_granted('ROLE_USER')"),
-        new Patch(security: "is_granted('ROLE_USER')"), new Delete(security: "is_granted('ROLE_ADMIN')"),
+        // A vote always belongs to the user casting it: the posted user cannot be somebody else.
+        new Post(
+            securityPostDenormalize: "is_granted('ROLE_ADMIN') or object.getUser().getId() == user.getId()"
+        ),
+        new Put(
+            security: "is_granted('ROLE_ADMIN') or object.getUser().getId() == user.getId()",
+            securityPostDenormalize: "is_granted('ROLE_ADMIN') or object.getUser().getId() == user.getId()"
+        ),
+        new Patch(
+            security: "is_granted('ROLE_ADMIN') or object.getUser().getId() == user.getId()",
+            securityPostDenormalize: "is_granted('ROLE_ADMIN') or object.getUser().getId() == user.getId()"
+        ),
+        new Delete(security: "is_granted('ROLE_ADMIN')"),
     ],
     normalizationContext: ['groups' => ['userRelCourseVote:read']],
     denormalizationContext: ['groups' => ['userRelCourseVote:write']]


### PR DESCRIPTION
Replaces the blanket `ROLE_USER` on `UserRelCourseVote` with per-operation checks so a vote can only be read, created, modified or removed by the user it belongs to, and adds a collection extension limiting the listing to the caller's own votes.

The operation set now matches what the catalogue actually calls: `Put` is gone (no caller), and `Delete` — which the favourite toggle uses to unstar a course — is no longer admin-only, so that flow works for regular users again.

Note for the reviewer: `getUserVote()` passes `session.id` and `course=null` as filters, but neither is declared in the resource's `SearchFilter` (only `user.id`, `course.id` and `url.id` are), so API Platform silently drops them and a session vote lookup can return the wrong row. Pre-existing and unrelated to this fix, but worth a separate issue.

Refs GHSA-fr7r-jpw5-8qh5