### PR TITLE
Security: Require teacher rights to reach the course settings form

### DIFF
--- a/src/CoreBundle/Controller/CourseController.php
+++ b/src/CoreBundle/Controller/CourseController.php
@@ -903,21 +903,21 @@ class CourseController extends ToolBaseController
         SettingsCourseManager $manager,
         SettingsFormFactory $formFactory
     ): Response {
-        $this->denyAccessUnlessGranted(CourseVoter::VIEW, $course);
+        // Course settings are teacher material: VIEW would let any enrolled student in.
+        $user = $this->userHelper->getCurrent();
+        $canManageSettings = $this->isGranted('ROLE_ADMIN')
+            || ($user instanceof User && (
+                $course->hasUserAsTeacher($user)
+                || $this->isGranted('ROLE_CURRENT_COURSE_TEACHER')
+            ));
+
+        if (!$canManageSettings) {
+            throw $this->createAccessDeniedException('You are not allowed to manage the course settings.');
+        }
+
         $manager->setCourse($course);
 
         if ('wiki' === $namespace) {
-            $user = $this->userHelper->getCurrent();
-            $canManageWikiSettings = $this->isGranted('ROLE_ADMIN')
-                || ($user instanceof User && (
-                    $course->hasUserAsTeacher($user)
-                    || $this->isGranted('ROLE_CURRENT_COURSE_TEACHER')
-                ));
-
-            if (!$canManageWikiSettings) {
-                throw $this->createAccessDeniedException('You are not allowed to manage Wiki settings.');
-            }
-
             if ($request->isMethod(Request::METHOD_GET)) {
                 $nodeId = $course->getResourceNode()?->getId();
                 if (null !== $nodeId) {


### PR DESCRIPTION
`CourseController::updateSettings()` gated every namespace with `CourseVoter::VIEW`, which any enrolled student satisfies. It now applies the teacher check that until today only the `wiki` namespace had (admin, course teacher, or current-course teacher) to all namespaces, so the wiki branch keeps just its GET redirect.

Note for the reviewer: the check accepts `ROLE_CURRENT_COURSE_TEACHER` in addition to `CourseVoter::EDIT`'s course-teacher rule, to keep session coaches working as the wiki branch already did.

Refs GHSA-mc26-9gww-95mc