### PR TITLE
Security: Scope exercise results, tracking rows and user skills to their owner

### DIFF
--- a/public/main/exercise/exercise_result.php
+++ b/public/main/exercise/exercise_result.php
@@ -163,6 +163,20 @@ if (api_is_course_admin() && !in_array($origin, ['learnpath', 'embeddable'])) {
     );
 }
 $exercise_stat_info = $objExercise->get_stat_track_exercise_info_by_exe_id($exeId);
+
+// An attempt belongs to one course and is readable by its author and the course staff only:
+// exe_id is a sequential integer, so anything else would let it be walked.
+if (!empty($exercise_stat_info)) {
+    $attemptCourseId = (int) ($exercise_stat_info['c_id'] ?? 0);
+    $attemptUserId = (int) ($exercise_stat_info['exe_user_id'] ?? 0);
+
+    if ($attemptCourseId !== api_get_course_int_id()
+        || ($attemptUserId !== $currentUserId && !api_is_allowed_to_edit(true, true, true))
+    ) {
+        api_not_allowed(true);
+    }
+}
+
 $learnpath_id = (int) ($exercise_stat_info['orig_lp_id'] ?? $requestedLearnpathId);
 $learnpath_item_id = (int) ($exercise_stat_info['orig_lp_item_id'] ?? $requestedLearnpathItemId);
 $learnpath_item_view_id = (int) ($exercise_stat_info['orig_lp_item_view_id'] ?? $requestedLearnpathItemViewId);

--- a/src/CoreBundle/DataProvider/Extension/SocialPostExtension.php
+++ b/src/CoreBundle/DataProvider/Extension/SocialPostExtension.php
@@ -9,11 +9,29 @@ namespace Chamilo\CoreBundle\DataProvider\Extension;
 use ApiPlatform\Doctrine\Orm\Extension\QueryCollectionExtensionInterface;
 use ApiPlatform\Doctrine\Orm\Util\QueryNameGeneratorInterface;
 use ApiPlatform\Metadata\Operation;
+use Chamilo\CoreBundle\Entity\SocialPost;
+use Chamilo\CoreBundle\Entity\User;
+use Chamilo\CoreBundle\Entity\UsergroupRelUser;
+use Chamilo\CoreBundle\Entity\UserRelUser;
 use Doctrine\ORM\QueryBuilder;
+use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\Security\Core\Exception\AccessDeniedException;
 
-class SocialPostExtension implements QueryCollectionExtensionInterface
+/**
+ * Keeps the social posts collection to the ones the caller may read, which is
+ * the same rule SocialPostVoter applies to a single post: own posts, posts
+ * addressed to them, platform-wide promoted messages, wall content from their
+ * friends, and messages of the groups they belong to.
+ *
+ * SocialWallFilter narrows this further down to one wall, but only when the
+ * client asks for it, so it cannot be the only barrier. The social tool being
+ * off is already handled by SocialPostStateProvider for every operation.
+ */
+final readonly class SocialPostExtension implements QueryCollectionExtensionInterface
 {
-    public function __construct() {}
+    public function __construct(
+        private Security $security,
+    ) {}
 
     public function applyToCollection(
         QueryBuilder $queryBuilder,
@@ -22,6 +40,60 @@ class SocialPostExtension implements QueryCollectionExtensionInterface
         ?Operation $operation = null,
         array $context = []
     ): void {
-        // nothing to do here
+        if (SocialPost::class !== $resourceClass) {
+            return;
+        }
+
+        $alias = $queryBuilder->getRootAliases()[0];
+
+        /** @var User|null $user */
+        $user = $this->security->getUser();
+
+        if (null === $user) {
+            throw new AccessDeniedException('Access Denied.');
+        }
+
+        $expr = $queryBuilder->expr();
+
+        $queryBuilder
+            ->andWhere(
+                $expr->orX(
+                    $expr->eq("$alias.sender", ':current_user'),
+                    $expr->eq("$alias.userReceiver", ':current_user'),
+                    $expr->eq("$alias.type", ':promoted_type'),
+                    $expr->andX(
+                        $expr->in("$alias.type", ':wall_types'),
+                        $expr->exists(
+                            \sprintf(
+                                'SELECT 1 FROM %s friendship
+                                WHERE friendship.user = :current_user
+                                    AND friendship.friend = %s.sender
+                                    AND friendship.relationType = :friend_relation_type',
+                                UserRelUser::class,
+                                $alias
+                            )
+                        )
+                    ),
+                    $expr->andX(
+                        $expr->eq("$alias.type", ':group_type'),
+                        $expr->isNotNull("$alias.groupReceiver"),
+                        $expr->exists(
+                            \sprintf(
+                                'SELECT 1 FROM %s membership
+                                WHERE membership.user = :current_user
+                                    AND membership.usergroup = %s.groupReceiver',
+                                UsergroupRelUser::class,
+                                $alias
+                            )
+                        )
+                    )
+                )
+            )
+            ->setParameter('current_user', (int) $user->getId())
+            ->setParameter('promoted_type', SocialPost::TYPE_PROMOTED_MESSAGE)
+            ->setParameter('wall_types', [SocialPost::TYPE_WALL_POST, SocialPost::TYPE_WALL_COMMENT])
+            ->setParameter('friend_relation_type', UserRelUser::USER_RELATION_TYPE_FRIEND)
+            ->setParameter('group_type', SocialPost::TYPE_GROUP_MESSAGE)
+        ;
     }
 }

--- a/src/CoreBundle/DataProvider/Extension/TrackEExerciseExtension.php
+++ b/src/CoreBundle/DataProvider/Extension/TrackEExerciseExtension.php
@@ -32,10 +32,6 @@ final class TrackEExerciseExtension implements QueryCollectionExtensionInterface
             return;
         }
 
-        if ('get' !== $operation->getName()) {
-            return;
-        }
-
         if ($this->security->isGranted('ROLE_ADMIN')) {
             return;
         }

--- a/src/CoreBundle/Entity/User.php
+++ b/src/CoreBundle/Entity/User.php
@@ -72,6 +72,7 @@ use UserManager;
             uriTemplate: '/users/{id}/skills',
             controller: UserSkillsController::class,
             normalizationContext: ['groups' => ['user_skills:read']],
+            security: "is_granted('ROLE_ADMIN') or user.getId() == request.attributes.get('id')",
             name: 'get_user_skills'
         ),
     ],


### PR DESCRIPTION
This advisory groups six findings. Four of them are fixed here, one commit each:

- the legacy exercise result page now requires the attempt to belong to the current course and to the caller, or the caller to be course staff;
- the user skills endpoint is limited to the account owner and admins;
- the TrackEExercise collection extension was a no-op because it compared the operation name against `get`, which never matches the generated collection name — removed, so student rows are scoped again;
- `SocialPostExtension::applyToCollection()` was empty and now applies the same rule `SocialPostVoter` enforces on a single post (own posts, posts addressed to the caller, promoted messages, wall content from friends, messages of their groups). `SocialWallFilter` still refines by wall on top, but it only runs when the client sends `socialwall_wallOwner`, so it could not be the only barrier.

A fifth finding, the unscoped `resource_nodes` collection, needs no change: `ResourceNodeExtension` already scopes it on master.

⚠ The sixth finding is NOT fixed: the student publication download. `ResourceController::download()` does check `ResourceNodeVoter::VIEW`, but inside the voter two shortcuts open it up — when the request carries no `cid` the voter adopts the course of the resource itself and then matches its own link, and a course with OPEN_WORLD visibility returns true outright. Closing only those two still leaves the reported vector alive, because the `student_publications` branch accepts `ROLE_CURRENT_COURSE_STUDENT`, which any authenticated user gets on an open course: a user with no enrollment at all can still download by adding `?cid=<course of the resource>`. A real fix has to require actual membership of the resource's course instead of a context role, which changes who may read submissions in open courses and touches corrections, group and session flows — better done in its own PR with proper assignment fixtures.

Refs GHSA-rw37-h59f-48w9