### PR TITLE
Security: Require course membership to read a student publication resource

### DIFF
--- a/src/CoreBundle/Security/Authorization/Voter/ResourceNodeVoter.php
+++ b/src/CoreBundle/Security/Authorization/Voter/ResourceNodeVoter.php
@@ -11,6 +11,7 @@ use Chamilo\CoreBundle\Entity\ResourceLink;
 use Chamilo\CoreBundle\Entity\ResourceNode;
 use Chamilo\CoreBundle\Entity\ResourceRight;
 use Chamilo\CoreBundle\Entity\Session;
+use Chamilo\CoreBundle\Entity\User;
 use Chamilo\CoreBundle\Helpers\CourseFromRequestHelper;
 use Chamilo\CoreBundle\Helpers\PageHelper;
 use Chamilo\CoreBundle\Helpers\ResourceAclHelper;
@@ -200,13 +201,12 @@ class ResourceNodeVoter extends Voter
                 return true;
             }
 
-            if ($this->hasContextRole('ROLE_CURRENT_COURSE_STUDENT')
-                || $this->hasContextRole('ROLE_CURRENT_COURSE_TEACHER')
-                || $this->hasContextRole('ROLE_CURRENT_COURSE_SESSION_STUDENT')
-                || $this->hasContextRole('ROLE_CURRENT_COURSE_SESSION_TEACHER')
-            ) {
-                return true;
-            }
+            // The context roles are handed out on open courses to any authenticated
+            // visitor, and they describe the course of the request rather than the one
+            // the submission belongs to. Neither is good enough to hand over somebody
+            // else's work, so membership of the submission's own course is required.
+            return $user instanceof User
+                && $this->belongsToResourceCourse($resourceNode, $user);
         }
 
         if ('files' === $resourceNode->getResourceType()->getTitle()) {
@@ -689,6 +689,44 @@ class ResourceNodeVoter extends Voter
 
             $headerHost = $scheme.'://'.$host.(null !== $port ? ':'.$port : '');
             if ($headerHost !== $currentHost) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Whether the user takes part in one of the courses the resource is linked to,
+     * as a real subscription rather than as a visitor of an open course.
+     */
+    private function belongsToResourceCourse(ResourceNode $resourceNode, User $user): bool
+    {
+        foreach ($resourceNode->getResourceLinks() as $link) {
+            // Corrections and feedback are linked to the student they were sent to.
+            $linkUser = $link->getUser();
+            if ($linkUser instanceof User && $linkUser->getId() === $user->getId()) {
+                return true;
+            }
+
+            $linkCourse = $link->getCourse();
+            if (!$linkCourse instanceof Course) {
+                continue;
+            }
+
+            $linkSession = $link->getSession();
+            if ($linkSession instanceof Session) {
+                if ($linkSession->hasUserAsGeneralCoach($user)
+                    || $linkSession->hasCourseCoachInCourse($user, $linkCourse)
+                    || $linkSession->hasUserInCourse($user, $linkCourse, Session::STUDENT)
+                ) {
+                    return true;
+                }
+
+                continue;
+            }
+
+            if ($linkCourse->hasUserAsTeacher($user) || $linkCourse->hasSubscriptionByUser($user)) {
                 return true;
             }
         }


### PR DESCRIPTION
Completes the last finding of GHSA-rw37-h59f-48w9, left out of #8875.

`ResourceNodeVoter` granted VIEW on `student_publications`, `student_publications_corrections` and `student_publications_comments` to anyone holding a course context role. Those roles are handed out to any authenticated visitor of an open course (`CourseAccessResolver::courseRolesForAccessibleCourse()`) and describe the course of the request, not the one the submission belongs to — so a user with no enrollment could download another student's work by knowing its uuid and adding `?cid=<course>`. The branch now requires the user to actually take part in one of the courses the resource is linked to: subscribed or teacher of the base course, coach or student of the session, or the recipient of the link when a correction was sent to them personally.

Only those three resource types are affected; every other resource keeps the previous behaviour.

Refs GHSA-rw37-h59f-48w9