### PR TITLE
Security: Plugins: Validate the plugin name before using it to build a file path in configure_plugin.php

### DIFF
--- a/main/admin/configure_plugin.php
+++ b/main/admin/configure_plugin.php
@@ -11,12 +11,18 @@ require_once __DIR__.'/../inc/global.inc.php';
 
 api_protect_admin_script();
 
-$pluginName = $_GET['name'];
+$pluginName = $_GET['name'] ?? '';
 $appPlugin = new AppPlugin();
 $installedPlugins = $appPlugin->getInstalledPlugins();
+
+// The plugin name must be validated before it is used to build any file path.
+if (!AppPlugin::isValidPluginName($pluginName) || !in_array($pluginName, $installedPlugins, true)) {
+    api_not_allowed(true);
+}
+
 $pluginInfo = $appPlugin->getPluginInfo($pluginName, true);
 
-if (!in_array($pluginName, $installedPlugins) || empty($pluginInfo)) {
+if (empty($pluginInfo)) {
     api_not_allowed(true);
 }
 

--- a/main/inc/lib/plugin.lib.php
+++ b/main/inc/lib/plugin.lib.php
@@ -54,6 +54,26 @@ class AppPlugin
     }
 
     /**
+     * Checks that a plugin name matches an existing directory inside the plugin
+     * directory, so it can never be used to escape from it when building a file
+     * path. The directory list is read only once per request.
+     *
+     * @param string $pluginName
+     *
+     * @return bool
+     */
+    public static function isValidPluginName($pluginName)
+    {
+        static $availablePlugins = null;
+
+        if (null === $availablePlugins) {
+            $availablePlugins = self::getInstance()->read_plugins_from_path();
+        }
+
+        return is_string($pluginName) && in_array($pluginName, $availablePlugins, true);
+    }
+
+    /**
      * Read plugin from path.
      *
      * @return array
@@ -552,6 +572,10 @@ class AppPlugin
      */
     public function getPluginInfo($plugin_name, $forced = false)
     {
+        if (!self::isValidPluginName($plugin_name)) {
+            return [];
+        }
+
         $pluginData = Session::read('plugin_data');
         if (isset($pluginData[$plugin_name]) && $forced == false) {
             return $pluginData[$plugin_name];


### PR DESCRIPTION
Validates the plugin name against the list of directories inside `plugin/` before it is used to build a file path.

- `AppPlugin::isValidPluginName()`: new helper that checks a name against `read_plugins_from_path()`. The directory list is read only once per request.
- `AppPlugin::getPluginInfo()`: returns an empty array for names that are not in that list.
- `main/admin/configure_plugin.php`: the name is now checked before it is used, not after.

The 80 plugin directories currently shipped are accepted unchanged, so no existing plugin configuration page is affected.
