### PR TITLE
Security: Plugins: Validate the plugin name before using it to build a file path

### DIFF
--- a/public/main/admin/configure_plugin.php
+++ b/public/main/admin/configure_plugin.php
@@ -470,6 +470,12 @@ function plugin_remove_toggle_fields_from_form_html(string $html): string
 
 $pluginRepo = Container::getPluginRepository();
 $pluginName = isset($_GET['plugin']) ? (string) $_GET['plugin'] : '';
+
+// The plugin name must be validated before it is used to build any file path.
+if (!AppPlugin::isValidPluginName($pluginName)) {
+    api_not_allowed(true);
+}
+
 $plugin = $pluginRepo->getInstalledByName($pluginName);
 
 if (!$plugin || !$plugin->isInstalled()) {

--- a/public/main/inc/ajax/plugin.ajax.php
+++ b/public/main/inc/ajax/plugin.ajax.php
@@ -282,10 +282,17 @@ try {
         exit;
     }
 
-    $pluginTitle = $_POST['plugin'] ?? '';
+    $pluginTitle = is_string($_POST['plugin'] ?? null) ? $_POST['plugin'] : '';
     if ($pluginTitle === '') {
         http_response_code(400);
         echo json_encode(['success' => false, 'error' => 'Missing plugin parameter']);
+        exit;
+    }
+
+    // The plugin name must be validated before it is used to build any file path.
+    if (!AppPlugin::isValidPluginName($pluginTitle)) {
+        http_response_code(400);
+        echo json_encode(['success' => false, 'error' => 'Invalid plugin parameter']);
         exit;
     }
 

--- a/public/main/inc/lib/plugin.lib.php
+++ b/public/main/inc/lib/plugin.lib.php
@@ -58,6 +58,22 @@ class AppPlugin
     }
 
     /**
+     * Checks that a plugin name matches an existing directory inside the plugin
+     * directory, so it can never be used to escape from it when building a file
+     * path. The directory list is read only once per request.
+     */
+    public static function isValidPluginName(string $pluginName): bool
+    {
+        static $availablePlugins = null;
+
+        if (null === $availablePlugins) {
+            $availablePlugins = self::getInstance()->read_plugins_from_path();
+        }
+
+        return in_array($pluginName, $availablePlugins, true);
+    }
+
+    /**
      * Read plugin from path.
      */
     public function read_plugins_from_path(): array
@@ -432,6 +448,11 @@ class AppPlugin
         $plugin_file = null;
 
         foreach ($posibleName as $dir) {
+            // The name is used to build a file path, so it must match a plugin directory.
+            if (!self::isValidPluginName($dir)) {
+                continue;
+            }
+
             $path = $pluginPath."$dir/plugin.php";
             if (is_file($path)) {
                 $plugin_file = $path;


### PR DESCRIPTION
Validates the plugin name against the list of directories inside `plugin/` before it is used to build a file path.

- `AppPlugin::isValidPluginName()`: new helper that checks a name against `read_plugins_from_path()`. The directory list is read only once per request.
- `AppPlugin::getPluginInfo()`: candidate directory names that are not in that list are skipped, so the case-insensitive fallback keeps working (`BBB` still resolves to the `Bbb` directory).
- `main/inc/ajax/plugin.ajax.php`: the name is checked right after it is read, before any path is built. Also reads it as a string, so an array parameter returns 400 instead of 500.
- `main/admin/configure_plugin.php`: the name is now checked before it is used, not after.

The 56 plugin directories currently shipped are accepted unchanged. Verified on a local install that the plugin list, the configuration page and the install / enable / disable / uninstall actions all behave as before.
