### PR TITLE
Security: Onlyoffice: Take the callback document path only from the signed hash

### DIFF
--- a/public/plugin/Onlyoffice/callback.php
+++ b/public/plugin/Onlyoffice/callback.php
@@ -70,10 +70,9 @@ $sessionId = (int) getHashValue($hashData, 'sessionId', 0);
 $isExercisePreview = 1 === (int) getHashValue($hashData, 'exercisePreview', 0);
 $isReadOnly = 1 === (int) getHashValue($hashData, 'readOnly', 0);
 
-$docPathFromQuery = isset($_GET['docPath']) ? urldecode((string) $_GET['docPath']) : '';
-$docPath = '' !== $docPathFromQuery
-    ? $docPathFromQuery
-    : (string) getHashValue($hashData, 'docPath', '');
+// Only the signed value is trusted: a query parameter would let the caller
+// replace the document the hash was issued for.
+$docPath = (string) getHashValue($hashData, 'docPath', '');
 
 $courseInfo = [];
 $courseCode = '';
@@ -384,14 +383,42 @@ function emptyFile(): void
 }
 
 /**
+ * Resolve a course-relative document path to an existing file inside the course
+ * directory. Returns null when the file is missing or the path escapes that root.
+ */
+function resolveContainedCoursePath(string $docPath): ?string
+{
+    // SYS_COURSE_PATH is not declared by the 2.x core, so treat it as unresolvable
+    // rather than raising an undefined-constant error.
+    if (!\defined('SYS_COURSE_PATH')) {
+        return null;
+    }
+
+    $root = realpath(api_get_path(SYS_COURSE_PATH));
+
+    if (false === $root) {
+        return null;
+    }
+
+    $root = rtrim($root, '/').'/';
+    $realPath = realpath($root.ltrim(str_replace('\\', '/', $docPath), '/'));
+
+    if (false === $realPath || !str_starts_with($realPath, $root)) {
+        return null;
+    }
+
+    return $realPath;
+}
+
+/**
  * Resolve a document source in C2 first, then legacy.
  */
 function resolveDocumentSource(int $docId, int $resourceNodeId, string $courseCode, int $sessionId, string $docPath): ?array
 {
     if ('' !== $docPath) {
-        $filePath = api_get_path(SYS_COURSE_PATH).$docPath;
+        $filePath = resolveContainedCoursePath($docPath);
 
-        if (file_exists($filePath)) {
+        if (null !== $filePath) {
             onlyofficeLog('DEBUG', 'Resolved direct docPath', [
                 'docPath' => $docPath,
                 'filePath' => $filePath,
@@ -412,9 +439,8 @@ function resolveDocumentSource(int $docId, int $resourceNodeId, string $courseCo
             ];
         }
 
-        onlyofficeLog('WARNING', 'Direct docPath not found', [
+        onlyofficeLog('WARNING', 'Direct docPath not found inside the course directory', [
             'docPath' => $docPath,
-            'filePath' => $filePath,
         ]);
     }
 

--- a/public/plugin/Onlyoffice/editor.php
+++ b/public/plugin/Onlyoffice/editor.php
@@ -316,12 +316,12 @@ if (!empty($resourceNodeId)) {
     $trackHash = $jwtManager->getHash($trackPayload);
 
     $fileUrl = appendVersionTokenToUrl(
-        api_get_path(WEB_PLUGIN_PATH).'Onlyoffice/callback.php?hash='.$downloadHash.'&docPath='.urlencode($newDocPath),
+        api_get_path(WEB_PLUGIN_PATH).'Onlyoffice/callback.php?hash='.$downloadHash,
         $versionToken
     );
 
     $callbackUrl = appendVersionTokenToUrl(
-        api_get_path(WEB_PLUGIN_PATH).'Onlyoffice/callback.php?hash='.$trackHash.'&docPath='.urlencode($newDocPath),
+        api_get_path(WEB_PLUGIN_PATH).'Onlyoffice/callback.php?hash='.$trackHash,
         $versionToken
     );
 


### PR DESCRIPTION
The callback no longer reads the document path from the query string, so it can only act on the path the signed hash was issued for; the editor already puts that value inside the hash, so the query parameter was redundant and is now dropped when building callback URLs. The path is additionally resolved with realpath() and required to stay inside the course directory.

Two notes for the reviewer:

- That branch is currently inert on a stock 2.x install: it dereferences SYS_COURSE_PATH, which the 2.x core never declares (only the CStudio plugin does), so it raises an undefined-constant error before reaching any file operation. The fix therefore matters for installs where that constant does get declared, and it also turns the error into a clean 'not found'. Whether the exercise-editing feature that depends on this path is meant to work at all in 2.x looks like a separate functional question.
- Touches the same file as #8880; whichever merges second may need a trivial rebase.

Refs GHSA-g9q7-rjxg-2wp2