### PR TITLE
Plugins: fix PHP 8.2 dynamic property deprecations

### DIFF
--- a/public/plugin/BuyCourses/src/list.php
+++ b/public/plugin/BuyCourses/src/list.php
@@ -39,13 +39,11 @@ $qb = $plugin->getCourses($first, $pageSize);
 $query = $qb->getQuery();
 $courses = new Paginator($query, $fetchJoinCollection = true);
 
+$courseBuyData = [];
+
 foreach ($courses as $course) {
     $item = $plugin->getItemByProduct($course->getId(), BuyCoursesPlugin::PRODUCT_TYPE_COURSE);
-    $course->buyCourseData = [];
-
-    if ($item) {
-        $course->buyCourseData = $item;
-    }
+    $courseBuyData[$course->getId()] = $item ?: [];
 }
 
 $totalItems = count($courses);
@@ -84,6 +82,9 @@ $tpl->assign('showing_services', false);
 
 $tpl->assign('sessions', []);
 $tpl->assign('services', []);
+
+$tpl->assign('course_buy_data', $courseBuyData);
+$tpl->assign('session_buy_data', []);
 
 $tpl->assign('course_current_page', $currentPage);
 $tpl->assign('course_pages_count', $pagesCount);

--- a/public/plugin/BuyCourses/src/list_session.php
+++ b/public/plugin/BuyCourses/src/list_session.php
@@ -57,13 +57,11 @@ $query = CoursesAndSessionsCatalog::browseSessions(
 
 $sessions = new Paginator($query, $fetchJoinCollection = true);
 
+$sessionBuyData = [];
+
 foreach ($sessions as $session) {
     $item = $plugin->getItemByProduct($session->getId(), BuyCoursesPlugin::PRODUCT_TYPE_SESSION);
-    $session->buyCourseData = [];
-
-    if ($item) {
-        $session->buyCourseData = $item;
-    }
+    $sessionBuyData[$session->getId()] = $item ?: [];
 }
 
 $totalItems = count($sessions);
@@ -90,6 +88,9 @@ $tpl->assign('tax_enable', $taxEnable);
 $tpl->assign('courses', []);
 $tpl->assign('sessions', $sessions);
 $tpl->assign('services', []);
+
+$tpl->assign('course_buy_data', []);
+$tpl->assign('session_buy_data', $sessionBuyData);
 
 $tpl->assign('course_pagination', '');
 $tpl->assign('session_pagination', '');

--- a/public/plugin/BuyCourses/src/subscriptions_courses.php
+++ b/public/plugin/BuyCourses/src/subscriptions_courses.php
@@ -35,13 +35,11 @@ $qb = $plugin->getCourses($first, $pageSize);
 $query = $qb->getQuery();
 $courses = new Paginator($query, $fetchJoinCollection = true);
 
+$courseBuyData = [];
+
 foreach ($courses as $course) {
     $item = $plugin->getSubscriptionItemByProduct($course->getId(), BuyCoursesPlugin::PRODUCT_TYPE_COURSE);
-    $course->buyCourseData = [];
-
-    if (false !== $item) {
-        $course->buyCourseData = $item;
-    }
+    $courseBuyData[$course->getId()] = false !== $item ? $item : [];
 }
 
 $totalItems = count($courses);
@@ -73,6 +71,9 @@ $tpl->assign('product_type_session', BuyCoursesPlugin::PRODUCT_TYPE_SESSION);
 
 $tpl->assign('courses', $courses);
 $tpl->assign('sessions', []);
+
+$tpl->assign('course_buy_data', $courseBuyData);
+$tpl->assign('session_buy_data', []);
 
 $tpl->assign('course_current_page', $currentPage);
 $tpl->assign('course_pages_count', $pagesCount);

--- a/public/plugin/BuyCourses/src/subscriptions_sessions.php
+++ b/public/plugin/BuyCourses/src/subscriptions_sessions.php
@@ -53,17 +53,15 @@ $query = CoursesAndSessionsCatalog::browseSessions(
 
 $sessions = new Paginator($query, $fetchJoinCollection = true);
 
+$sessionBuyData = [];
+
 foreach ($sessions as $session) {
     $item = $plugin->getSubscriptionItemByProduct(
         $session->getId(),
         BuyCoursesPlugin::PRODUCT_TYPE_SESSION
     );
 
-    $session->buyCourseData = [];
-
-    if (false !== $item) {
-        $session->buyCourseData = $item;
-    }
+    $sessionBuyData[$session->getId()] = false !== $item ? $item : [];
 }
 
 $totalItems = count($sessions);
@@ -88,6 +86,9 @@ $tpl->assign('tax_enable', $taxEnable);
 
 $tpl->assign('courses', []);
 $tpl->assign('sessions', $sessions);
+
+$tpl->assign('course_buy_data', []);
+$tpl->assign('session_buy_data', $sessionBuyData);
 
 $tpl->assign('course_total_items', 0);
 $tpl->assign('course_current_page', 1);

--- a/public/plugin/BuyCourses/view/list.tpl
+++ b/public/plugin/BuyCourses/view/list.tpl
@@ -97,6 +97,7 @@
                 </thead>
                 <tbody class="divide-y divide-gray-25 bg-white">
                 {% for item in courses %}
+                {% set buy_data = course_buy_data[item.id]|default([]) %}
                 <tr data-item="{{ item.id }}" data-type="course" class="align-middle transition hover:bg-support-2">
                     <td class="px-6 py-4">
                         <div class="flex min-w-[20rem] items-center gap-3">
@@ -161,7 +162,7 @@
                     </td>
 
                     <td class="px-6 py-4 text-center">
-                        {% if item.buyCourseData %}
+                        {% if buy_data %}
                         <span class="inline-flex items-center gap-2 rounded-full bg-success/10 px-3 py-1 text-xs font-semibold text-success">
                                             <em class="mdi mdi-check"></em>
                                             {{ 'Yes'|get_lang }}
@@ -175,8 +176,8 @@
                     </td>
 
                     <td class="px-6 py-4 text-right text-sm font-semibold text-gray-90">
-                        {% if item.buyCourseData and item.buyCourseData.price_formatted %}
-                        <span class="whitespace-nowrap">{{ item.buyCourseData.price_formatted }}</span>
+                        {% if buy_data and buy_data.price_formatted %}
+                        <span class="whitespace-nowrap">{{ buy_data.price_formatted }}</span>
                         {% else %}
                         <span class="text-gray-50">—</span>
                         {% endif %}
@@ -184,8 +185,8 @@
 
                     {% if tax_enable and (tax_applies_to == 1 or tax_applies_to == 2) %}
                     <td class="px-6 py-4 text-center text-sm text-gray-90">
-                        {% if item.buyCourseData and item.buyCourseData.tax_perc_show is defined %}
-                        {{ item.buyCourseData.tax_perc_show }} %
+                        {% if buy_data and buy_data.tax_perc_show is defined %}
+                        {{ buy_data.tax_perc_show }} %
                         {% else %}
                         <span class="text-gray-50">—</span>
                         {% endif %}
@@ -343,6 +344,7 @@
                 </thead>
                 <tbody class="divide-y divide-gray-25 bg-white">
                 {% for item in sessions %}
+                {% set buy_data = session_buy_data[item.id]|default([]) %}
                 <tr data-item="{{ item.id }}" data-type="session" class="align-middle transition hover:bg-support-2">
                     <td class="px-6 py-4">
                         <a
@@ -362,7 +364,7 @@
                     </td>
 
                     <td class="px-6 py-4 text-center">
-                        {% if item.buyCourseData %}
+                        {% if buy_data %}
                         <span class="inline-flex items-center gap-2 rounded-full bg-success/10 px-3 py-1 text-xs font-semibold text-success">
                                             <em class="mdi mdi-check"></em>
                                             {{ 'Yes'|get_lang }}
@@ -376,8 +378,8 @@
                     </td>
 
                     <td class="px-6 py-4 text-right text-sm font-semibold text-gray-90">
-                        {% if item.buyCourseData and item.buyCourseData.price_formatted is defined %}
-                        <span class="whitespace-nowrap">{{ item.buyCourseData.price_formatted }}</span>
+                        {% if buy_data and buy_data.price_formatted is defined %}
+                        <span class="whitespace-nowrap">{{ buy_data.price_formatted }}</span>
                         {% else %}
                         <span class="text-gray-50">—</span>
                         {% endif %}
@@ -385,8 +387,8 @@
 
                     {% if tax_enable and (tax_applies_to == 1 or tax_applies_to == 3) %}
                     <td class="px-6 py-4 text-center text-sm text-gray-90">
-                        {% if item.buyCourseData and item.buyCourseData.tax_perc_show is defined %}
-                        {{ item.buyCourseData.tax_perc_show }} %
+                        {% if buy_data and buy_data.tax_perc_show is defined %}
+                        {{ buy_data.tax_perc_show }} %
                         {% else %}
                         <span class="text-gray-50">—</span>
                         {% endif %}

--- a/public/plugin/BuyCourses/view/subscriptions.tpl
+++ b/public/plugin/BuyCourses/view/subscriptions.tpl
@@ -107,6 +107,7 @@
 
                 <tbody class="divide-y divide-gray-25 bg-white">
                 {% for item in courses %}
+                {% set buy_data = course_buy_data[item.id]|default([]) %}
                 <tr data-item="{{ item.id }}" data-type="course" class="align-middle transition hover:bg-support-2">
                     <td class="px-6 py-4">
                         <div class="flex min-w-[20rem] items-center gap-3">
@@ -171,7 +172,7 @@
                     </td>
 
                     <td class="px-6 py-4 text-center">
-                        {% if item.buyCourseData %}
+                        {% if buy_data %}
                         <span class="inline-flex items-center gap-2 rounded-full bg-success/10 px-3 py-1 text-xs font-semibold text-success">
                                             <em class="mdi mdi-check"></em>
                                             {{ 'Yes'|get_lang }}
@@ -186,8 +187,8 @@
 
                     {% if tax_enable and (tax_applies_to == 1 or tax_applies_to == 2) %}
                     <td class="px-6 py-4 text-center text-sm text-gray-90">
-                        {% if item.buyCourseData and item.buyCourseData.tax_perc_show is defined %}
-                        {{ item.buyCourseData.tax_perc_show }} %
+                        {% if buy_data and buy_data.tax_perc_show is defined %}
+                        {{ buy_data.tax_perc_show }} %
                         {% else %}
                         <span class="text-gray-50">—</span>
                         {% endif %}
@@ -195,7 +196,7 @@
                     {% endif %}
 
                     <td class="px-6 py-4 text-right">
-                        {% if item.buyCourseData %}
+                        {% if buy_data %}
                         <a
                                 href="{{ url('index') ~ 'plugin/BuyCourses/src/configure_subscription.php?' ~ {'id': item.id, 'type': product_type_course}|url_encode }}"
                                 class="inline-flex items-center justify-center gap-2 rounded-xl bg-info px-4 py-2.5 text-sm font-semibold text-white shadow-sm transition hover:opacity-90 focus:outline-none focus:ring-2 focus:ring-info/30 focus:ring-offset-2"
@@ -359,6 +360,7 @@
 
                 <tbody class="divide-y divide-gray-25 bg-white">
                 {% for item in sessions %}
+                {% set buy_data = session_buy_data[item.id]|default([]) %}
                 <tr data-item="{{ item.id }}" data-type="session" class="align-middle transition hover:bg-support-2">
                     <td class="px-6 py-4">
                         <a
@@ -378,7 +380,7 @@
                     </td>
 
                     <td class="px-6 py-4 text-center">
-                        {% if item.buyCourseData %}
+                        {% if buy_data %}
                         <span class="inline-flex items-center gap-2 rounded-full bg-success/10 px-3 py-1 text-xs font-semibold text-success">
                                             <em class="mdi mdi-check"></em>
                                             {{ 'Yes'|get_lang }}
@@ -393,8 +395,8 @@
 
                     {% if tax_enable and (tax_applies_to == 1 or tax_applies_to == 3) %}
                     <td class="px-6 py-4 text-center text-sm text-gray-90">
-                        {% if item.buyCourseData and item.buyCourseData.tax_perc_show is defined %}
-                        {{ item.buyCourseData.tax_perc_show }} %
+                        {% if buy_data and buy_data.tax_perc_show is defined %}
+                        {{ buy_data.tax_perc_show }} %
                         {% else %}
                         <span class="text-gray-50">—</span>
                         {% endif %}
@@ -402,7 +404,7 @@
                     {% endif %}
 
                     <td class="px-6 py-4 text-right">
-                        {% if item.buyCourseData %}
+                        {% if buy_data %}
                         <a
                                 href="{{ url('index') ~ 'plugin/BuyCourses/src/configure_subscription.php?' ~ {'id': item.id, 'type': product_type_session}|url_encode }}"
                                 class="inline-flex items-center justify-center gap-2 rounded-xl bg-info px-4 py-2.5 text-sm font-semibold text-white shadow-sm transition hover:opacity-90 focus:outline-none focus:ring-2 focus:ring-info/30 focus:ring-offset-2"

--- a/public/plugin/Dashboard/block_evaluation_graph/block_evaluation_graph.class.php
+++ b/public/plugin/Dashboard/block_evaluation_graph/block_evaluation_graph.class.php
@@ -25,6 +25,8 @@ class BlockEvaluationGraph extends Block
     private $courses;
     private $sessions;
     private $permission = [DRH, SESSIONADMIN];
+    private $bg_width;
+    private $bg_height;
 
     /**
      * Constructor.

--- a/public/plugin/Onlyoffice/lib/onlyofficeCallbackService.php
+++ b/public/plugin/Onlyoffice/lib/onlyofficeCallbackService.php
@@ -19,6 +19,7 @@ use Onlyoffice\DocsIntegrationSdk\Service\Callback\CallbackService;
 class OnlyofficeCallbackService extends CallbackService
 {
     private $docData;
+    private $trackResult;
 
     public function __construct($settingsManager, $jwtManager, $docData = [])
     {

--- a/public/plugin/TopLinks/plugin.php
+++ b/public/plugin/TopLinks/plugin.php
@@ -3,3 +3,5 @@
 /* For license terms, see /license.txt */
 
 $plugin_info = TopLinksPlugin::create()->get_info();
+$plugin_info['source'] = 'official';
+$plugin_info['commercial_model'] = 'free';

--- a/public/plugin/TopLinks/src/TopLinksPlugin.php
+++ b/public/plugin/TopLinks/src/TopLinksPlugin.php
@@ -29,8 +29,6 @@ class TopLinksPlugin extends Plugin
         $this->isAdminPlugin = true;
         $this->isCoursePlugin = false;
         $this->addCourseTool = false;
-        $this->source = 'official';
-        $this->type = 'free';
     }
 
     public static function create(): TopLinksPlugin


### PR DESCRIPTION
Fixes `Creation of dynamic property X is deprecated` (PHP 8.2) in four plugins. In every case the assigned property is declared neither in the class itself nor anywhere in its inheritance chain.

## Cases

**TopLinks** — `TopLinksPlugin::__construct()` assigned `$this->source` and `$this->type`; the base `Plugin` class declares neither. They were also ineffective: `Plugin::get_info()` never copies them into `$plugin_info`. Moved to `plugin.php` as `source` and `commercial_model`, which is what `settings.lib.php` actually reads — same convention as `HelloWorld` and `MaintenanceMode`.

**Dashboard** — `BlockEvaluationGraph` assigned `$bg_width` and `$bg_height`; the parent `Block` only declares `$path`. Both are read only inside the class, so they are declared `private`.

**Onlyoffice** — `OnlyofficeCallbackService` assigned `$trackResult`; the SDK's `CallbackService` only declares `$settingsManager` and `$jwtManager`. Read only inside the class, so it is declared `private`.

**BuyCourses** — the course and session listings attached a `buyCourseData` property to the `Course` and `Session` Doctrine entities. Replaced with a plain map indexed by entity id, handed to the templates as `course_buy_data` / `session_buy_data`, so no plugin-specific property is bolted onto core entities. Two separate maps because `list.tpl` and `subscriptions.tpl` render the course block and the session block in the same file, and course ids can collide with session ids.

## How these were found

AST scan over the 56 plugins (3,556 files) resolving the full inheritance chain — parents, traits, promoted constructor properties, `__set`, `#[AllowDynamicProperties]` — plus a second textual pass for external `$obj->prop =` assignments, which the first pass does not cover.

Other candidates were verified one by one against their base class and turned out to be properly declared upstream, so they are left untouched: `PENSException::$message`, `OnlyofficeFormatsManager::$formatsList`, `$settingsManager->newSettings`, all of Zoom (`BaseMeetingTrait`, `MeetingInfo`, `MeetingRegistrant`, `RecordingMeeting`), MigrationMoodle (`Exercise`, `Question`, `TestCategory`), `SortableTable::$headers`, CpChart's `$Antialias`, ImsLti's `$publicKey` / `$target`, and H5pImport's `$asset` (a `stdClass`).

## Testing

- `php -l` on the 6 modified PHP files
- `bin/console lint:twig` on the 2 modified templates — valid
- The BuyCourses refactor keeps each script's original truthiness check (`if ($item)` in the listings, `false !== $item` in the subscriptions), so behaviour is unchanged

Not verified in the browser: none of these plugins is installed in my local environment, and installing BuyCourses creates its tables.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
