### PR TITLE
Security: whitelist ORDER BY direction in MySpace session overview export

### DIFF
--- a/public/main/inc/lib/myspace.lib.php
+++ b/public/main/inc/lib/myspace.lib.php
@@ -1950,7 +1950,8 @@ class MySpace
     ) {
         $from = (int) $from;
         $numberItems = (int) $numberItems;
-        $direction = Database::escape_string($direction);
+        // ORDER BY is an identifier context: escaping is not enough, only a whitelist is safe.
+        $direction = 'DESC' === strtoupper((string) $direction) ? 'DESC' : 'ASC';
         $columnName = 'name';
         if (1 === $column) {
             $columnName = 'id';


### PR DESCRIPTION
The sort direction taken from the request in `MySpace::get_session_data_tracking_overview()` was only passed through `Database::escape_string()` before being concatenated into an `ORDER BY` clause. Escaping does not protect an unquoted identifier context, so the value is now restricted to a validated `ASC`/`DESC` token, matching what the interactive SortableTable path already does.

Note for reviewers: the same method still orders by the `name` column, which was renamed to `title` in 2.0. That is a pre-existing functional bug in this export and is left untouched here to keep the change limited to the security fix.

Refs GHSA-2jjf-95rh-4q2p, GHSA-2hp3-qmmq-624r