### PR TITLE
Security: sanitize chunk file name when finishing an exercise upload answer

### DIFF
--- a/public/main/inc/ajax/exercise.ajax.php
+++ b/public/main/inc/ajax/exercise.ajax.php
@@ -1201,7 +1201,10 @@ switch ($action) {
                 $tmpPath = $file['tmp_name'];
 
                 if (isset($_REQUEST['chunkAction']) && 'done' === $_REQUEST['chunkAction']) {
-                    $tmpPath = api_get_path(SYS_ARCHIVE_PATH).($file['name'] ?? $originalName);
+                    // Same sanitization as the "send" phase, so the path stays inside the
+                    // archive directory and still matches the chunk written there.
+                    $chunkName = disable_dangerous_file(api_replace_dangerous_char($file['name'] ?? $originalName));
+                    $tmpPath = api_get_path(SYS_ARCHIVE_PATH).$chunkName;
                 }
 
                 $uploadedFile = new UploadedFile(


### PR DESCRIPTION
The reported vector does not exist in 2.0: the `upload_answer` action no longer reads `curdirpath` nor builds a destination directory, it stores the file through the resource system instead. What remains is the same class of issue in the chunked-upload branch, where the temporary path was built from the client-supplied file name without the sanitization the "send" phase already applies. The name is now sanitized the same way, which also keeps the two phases pointing at the same file.