### PR TITLE
Security: check gradebook category write access against its own course

### DIFF
--- a/src/CoreBundle/Entity/GradebookCategory.php
+++ b/src/CoreBundle/Entity/GradebookCategory.php
@@ -32,9 +32,10 @@ use Symfony\Component\Validator\Constraints as Assert;
         new Get(security: "is_granted('ROLE_USER')"),
         new GetCollection(security: "is_granted('ROLE_USER')"),
         new Post(security: "is_granted('ROLE_ADMIN') or is_granted('ROLE_CURRENT_COURSE_TEACHER')"),
-        new Put(security: "is_granted('ROLE_ADMIN') or is_granted('ROLE_CURRENT_COURSE_TEACHER')"),
-        new Patch(security: "is_granted('ROLE_ADMIN') or is_granted('ROLE_CURRENT_COURSE_TEACHER')"),
-        new Delete(security: "is_granted('ROLE_ADMIN') or is_granted('ROLE_CURRENT_COURSE_TEACHER')"),
+        // Checked against the category's own course, not the request-context one.
+        new Put(security: "is_granted('EDIT', object.getCourse())"),
+        new Patch(security: "is_granted('EDIT', object.getCourse())"),
+        new Delete(security: "is_granted('DELETE', object.getCourse())"),
     ],
     normalizationContext: [
         'groups' => ['gradebookCategory:read'],

--- a/src/CoreBundle/Entity/GradebookCategory.php
+++ b/src/CoreBundle/Entity/GradebookCategory.php
@@ -31,11 +31,11 @@ use Symfony\Component\Validator\Constraints as Assert;
     operations: [
         new Get(security: "is_granted('ROLE_USER')"),
         new GetCollection(security: "is_granted('ROLE_USER')"),
-        new Post(security: "is_granted('ROLE_ADMIN') or is_granted('ROLE_CURRENT_COURSE_TEACHER')"),
-        // Checked against the category's own course, not the request-context one.
-        new Put(security: "is_granted('EDIT', object.getCourse())"),
-        new Patch(security: "is_granted('EDIT', object.getCourse())"),
-        new Delete(security: "is_granted('DELETE', object.getCourse())"),
+        new Post(security: "is_granted('ROLE_CURRENT_COURSE_TEACHER') or is_granted('ROLE_CURRENT_COURSE_SESSION_TEACHER')"),
+        // Checked against the category's own course and session, not the request-context ones.
+        new Put(security: "is_granted('EDIT', object)"),
+        new Patch(security: "is_granted('EDIT', object)"),
+        new Delete(security: "is_granted('DELETE', object)"),
     ],
     normalizationContext: [
         'groups' => ['gradebookCategory:read'],

--- a/src/CoreBundle/Security/Authorization/Voter/GradebookCategoryVoter.php
+++ b/src/CoreBundle/Security/Authorization/Voter/GradebookCategoryVoter.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+/* For licensing terms, see /license.txt */
+
+namespace Chamilo\CoreBundle\Security\Authorization\Voter;
+
+use Chamilo\CoreBundle\Entity\GradebookCategory;
+use Chamilo\CoreBundle\Entity\User;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Authorization\AccessDecisionManagerInterface;
+use Symfony\Component\Security\Core\Authorization\Voter\Vote;
+use Symfony\Component\Security\Core\Authorization\Voter\Voter;
+
+/**
+ * Grants write access to a gradebook category based on the course and session
+ * the category itself belongs to, not on the ones carried by the request.
+ *
+ * @extends Voter<'EDIT'|'DELETE', GradebookCategory>
+ */
+class GradebookCategoryVoter extends Voter
+{
+    public const string EDIT = 'EDIT';
+    public const string DELETE = 'DELETE';
+
+    public function __construct(
+        private readonly AccessDecisionManagerInterface $accessDecisionManager,
+    ) {}
+
+    protected function supports(string $attribute, $subject): bool
+    {
+        $allowed = [
+            self::EDIT,
+            self::DELETE,
+        ];
+
+        return $subject instanceof GradebookCategory && \in_array($attribute, $allowed, true);
+    }
+
+    protected function voteOnAttribute(string $attribute, $subject, TokenInterface $token, ?Vote $vote = null): bool
+    {
+        $user = $token->getUser();
+
+        if (!$user instanceof User) {
+            return false;
+        }
+
+        if ($this->accessDecisionManager->decide($token, ['ROLE_ADMIN'])) {
+            return true;
+        }
+
+        /** @var GradebookCategory $category */
+        $category = $subject;
+        $course = $category->getCourse();
+
+        // Teacher of the base course the category belongs to.
+        if ($course->hasUserAsTeacher($user)) {
+            return true;
+        }
+
+        // Coach of the session the category belongs to.
+        $session = $category->getSession();
+
+        return null !== $session
+            && ($session->hasUserAsGeneralCoach($user) || $session->hasCourseCoachInCourse($user, $course));
+    }
+}


### PR DESCRIPTION
The write operations on the `GradebookCategory` API resource relied on contextual roles derived from the request's `cid`, so the check described the course the caller asked for rather than the one the target category belongs to.

`Put`/`Patch`/`Delete` now go through a dedicated `GradebookCategoryVoter` that resolves access from the category's own `course` and `session` properties: a teacher of the base course, or a general/course coach of the session the category belongs to. `Post` keeps contextual roles — there is no object yet on create — but gains `ROLE_CURRENT_COURSE_SESSION_TEACHER`, which was missing. Admins pass through in both cases.

Note for reviewers: `Get` and `GetCollection` remain gated by `ROLE_USER`, so gradebook categories from other courses are still readable and enumerable. Restricting reads needs a collection extension and would change what students and session coaches can list, so it is left out of this fix.

Refs GHSA-6vqw-jgc8-g7g3