### PR TITLE
Security: sanitize forum post body in legacy thread view

### DIFF
--- a/public/main/forum/viewthread.php
+++ b/public/main/forum/viewthread.php
@@ -693,7 +693,11 @@ foreach ($posts as $post) {
     $post['post_title'] .= Display::tag('div', $titlePost, ['class' => 'post-header']);
 
     // Body
-    $post['post_data'] = Display::tag('div', $post['post_text'], ['class' => 'post-body']);
+    $post['post_data'] = Display::tag(
+        'div',
+        Security::remove_XSS($post['post_text'], STUDENT),
+        ['class' => 'post-body']
+    );
 
     // Attachments
     $post['post_attachments'] = '';


### PR DESCRIPTION
The forum post body was the only rendering path in the module printing stored post text as raw HTML — the post title right above it, and the three other views of the same field, already filter it. It now goes through `Security::remove_XSS(..., STUDENT)` like the rest.

Refs GHSA-gjcf-95hx-382f