### PR TITLE
Security: cast session id to integer in user export query

### DIFF
--- a/public/main/user/user_export.php
+++ b/public/main/user/user_export.php
@@ -46,9 +46,9 @@ if (!empty($export['session'])) {
 
 if (is_array($courseSessionValue) && isset($courseSessionValue[1])) {
     $courseSessionCode = $courseSessionValue[0];
-    $sessionId = $courseSessionValue[1];
+    $sessionId = (int) $courseSessionValue[1];
     $courseSessionInfo = api_get_course_info($courseSessionCode);
-    $courseSessionId = $courseSessionInfo['real_id'];
+    $courseSessionId = (int) $courseSessionInfo['real_id'];
     $sessionInfo = api_get_session_info($sessionId);
 }
 


### PR DESCRIPTION
The session id taken from the `course_session` request parameter was interpolated into the export query as-is, even though the sink only ever needs an integer. It is now cast before use, together with the course id resolved next to it.

Refs GHSA-vhxh-3r5f-64r5