### PR TITLE
Security: sanitize survey title in legacy survey list

### DIFF
--- a/public/main/survey/surveyUtil.class.php
+++ b/public/main/survey/surveyUtil.class.php
@@ -3384,7 +3384,7 @@ class SurveyUtil
         $array[0] = $surveyId;
         $type = $survey->getSurveyType();
 
-        $title = $survey->getTitle();
+        $title = Security::remove_XSS($survey->getTitle());
         if (self::checkHideEditionToolsByCode($survey->getCode())) {
             $array[1] = $title;
         } else {


### PR DESCRIPTION
The survey title reached the legacy survey list as raw HTML, both as the link label and as the plain cell used for DRH users. It now goes through `Security::remove_XSS()`, matching how the other title renderings in the same class already behave.

Note for reviewers: the sink named in the report (the Vue survey listing) turned out not to be exploitable — every survey view strips tags and interpolates the result, which escapes it. The legacy list above is the reachable sink for the same stored value, so that is what this fix addresses. The API still stores the title unfiltered, which is consistent with it being a rich-text field sanitized on output.

Refs GHSA-f42m-82xh-f88c