### PR TITLE
Security: Restrict session subscription creation to self-service student enrolment

### DIFF
--- a/src/CoreBundle/Entity/SessionRelUser.php
+++ b/src/CoreBundle/Entity/SessionRelUser.php
@@ -30,11 +30,19 @@ use Symfony\Component\Validator\Constraints as Assert;
     operations: [
         new Get(security: "is_granted('ROLE_ADMIN') or object.user == user"),
         new GetCollection(security: "is_granted('ROLE_USER')"),
-        new Post(security: "is_granted('ROLE_ADMIN') or is_granted('ROLE_USER')"),
+        new Post(
+            security: "is_granted('ROLE_USER')",
+            securityPostDenormalize: "is_granted('CREATE', object)"
+        ),
     ],
     normalizationContext: [
         'groups' => [
             'session_rel_user:read',
+        ],
+    ],
+    denormalizationContext: [
+        'groups' => [
+            'session_rel_user:write',
         ],
     ],
     security: "is_granted('ROLE_USER')"
@@ -71,18 +79,24 @@ class SessionRelUser
     protected ?int $id = null;
 
     #[Assert\NotNull]
-    #[Groups(['session_rel_user:read'])]
+    #[Groups(['session_rel_user:read', 'session_rel_user:write'])]
     #[ORM\ManyToOne(targetEntity: Session::class, cascade: ['persist'], inversedBy: 'users')]
     #[ORM\JoinColumn(name: 'session_id', referencedColumnName: 'id')]
     protected ?Session $session = null;
 
     #[Assert\NotNull]
-    #[Groups(['session_rel_user:read', 'session:item:read', 'user_subscriptions:sessions', 'session:basic'])]
+    #[Groups([
+        'session_rel_user:read',
+        'session_rel_user:write',
+        'session:item:read',
+        'user_subscriptions:sessions',
+        'session:basic',
+    ])]
     #[ORM\ManyToOne(targetEntity: User::class, cascade: ['persist'], inversedBy: 'sessionsRelUser')]
     #[ORM\JoinColumn(name: 'user_id', referencedColumnName: 'id', onDelete: 'CASCADE')]
     protected User $user;
 
-    #[Groups(['session_rel_user:read', 'session:item:read', 'user_subscriptions:sessions'])]
+    #[Groups(['session_rel_user:read', 'session_rel_user:write', 'session:item:read', 'user_subscriptions:sessions'])]
     #[Assert\Choice(callback: [Session::class, 'getRelationTypeList'], message: 'Choose a valid relation type.')]
     #[ORM\Column(name: 'relation_type', type: 'integer')]
     protected int $relationType;

--- a/src/CoreBundle/Security/Authorization/Voter/SessionRelUserVoter.php
+++ b/src/CoreBundle/Security/Authorization/Voter/SessionRelUserVoter.php
@@ -1,0 +1,69 @@
+<?php
+
+/* For licensing terms, see /license.txt */
+
+declare(strict_types=1);
+
+namespace Chamilo\CoreBundle\Security\Authorization\Voter;
+
+use Chamilo\CoreBundle\Entity\Session;
+use Chamilo\CoreBundle\Entity\SessionRelUser;
+use Chamilo\CoreBundle\Entity\User;
+use Chamilo\CoreBundle\Settings\SettingsManager;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Authorization\AccessDecisionManagerInterface;
+use Symfony\Component\Security\Core\Authorization\Voter\Vote;
+use Symfony\Component\Security\Core\Authorization\Voter\Voter;
+
+/**
+ * Creation rules for a session subscription.
+ *
+ * Outside of administration, the only legitimate creation is a user subscribing
+ * themselves as a student from the session catalogue, which the platform has to
+ * allow: the catalogue hides its button when the setting is off, and that
+ * decision cannot be left to the browser.
+ *
+ * @extends Voter<'CREATE', SessionRelUser>
+ */
+class SessionRelUserVoter extends Voter
+{
+    public const string CREATE = 'CREATE';
+
+    public function __construct(
+        private AccessDecisionManagerInterface $accessDecisionManager,
+        private SettingsManager $settingsManager
+    ) {}
+
+    protected function supports(string $attribute, $subject): bool
+    {
+        return self::CREATE === $attribute && $subject instanceof SessionRelUser;
+    }
+
+    protected function voteOnAttribute(string $attribute, $subject, TokenInterface $token, ?Vote $vote = null): bool
+    {
+        if ($this->accessDecisionManager->decide($token, ['ROLE_ADMIN'])) {
+            return true;
+        }
+
+        $currentUser = $token->getUser();
+
+        if (!$currentUser instanceof User) {
+            return false;
+        }
+
+        if (!$this->isAutoSubscriptionAllowed()) {
+            return false;
+        }
+
+        /** @var SessionRelUser $subject */
+        return $subject->getUser()->getId() === $currentUser->getId()
+            && Session::STUDENT === $subject->getRelationType();
+    }
+
+    private function isAutoSubscriptionAllowed(): bool
+    {
+        $setting = $this->settingsManager->getSetting('catalog.allow_session_auto_subscription', true);
+
+        return 'true' === strtolower((string) $setting);
+    }
+}


### PR DESCRIPTION
POST /api/session_rel_users accepted an arbitrary user and relation type from the request body, so any authenticated user could subscribe anyone to any session with coach-level rights. Creation now goes through a dedicated voter (admins, or self-enrolment as a student when the catalogue setting allows it) and the write payload is limited to session, user and relation type.

Refs GHSA-p9rc-p9g3-6hv5