### PR TITLE
Security: Require edit permission on the resource node when adding a file variant

### DIFF
--- a/src/CoreBundle/Controller/AddVariantResourceFileAction.php
+++ b/src/CoreBundle/Controller/AddVariantResourceFileAction.php
@@ -43,7 +43,9 @@ class AddVariantResourceFileAction
             throw new NotFoundHttpException('ResourceNode not found');
         }
 
-        // Require edit permission on the owning resource node (admins pass via ROLE_ADMIN).
+        // The operation is already restricted to administrators, which is what the documents
+        // list requires to offer the action; edit permission on the target node is the
+        // object-level half of that same check.
         if (!$this->security->isGranted(ResourceNodeVoter::EDIT, $resourceNode)) {
             throw new AccessDeniedException('Unauthorised access to resource');
         }

--- a/src/CoreBundle/Controller/AddVariantResourceFileAction.php
+++ b/src/CoreBundle/Controller/AddVariantResourceFileAction.php
@@ -10,15 +10,22 @@ use Chamilo\CoreBundle\Entity\AccessUrl;
 use Chamilo\CoreBundle\Entity\Language;
 use Chamilo\CoreBundle\Entity\ResourceFile;
 use Chamilo\CoreBundle\Entity\ResourceNode;
+use Chamilo\CoreBundle\Security\Authorization\Voter\ResourceNodeVoter;
 use DateTime;
 use DateTimeImmutable;
 use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\Security\Core\Exception\AccessDeniedException;
 
 class AddVariantResourceFileAction
 {
+    public function __construct(
+        private readonly Security $security,
+    ) {}
+
     public function __invoke(Request $request, EntityManagerInterface $em): ResourceFile
     {
         $uploadedFile = $request->files->get('file');
@@ -34,6 +41,11 @@ class AddVariantResourceFileAction
         $resourceNode = $em->getRepository(ResourceNode::class)->find($resourceNodeId);
         if (!$resourceNode) {
             throw new NotFoundHttpException('ResourceNode not found');
+        }
+
+        // Require edit permission on the owning resource node (admins pass via ROLE_ADMIN).
+        if (!$this->security->isGranted(ResourceNodeVoter::EDIT, $resourceNode)) {
+            throw new AccessDeniedException('Unauthorised access to resource');
         }
 
         $accessUrlId = $request->request->get('accessUrlId');

--- a/src/CoreBundle/Entity/ResourceFile.php
+++ b/src/CoreBundle/Entity/ResourceFile.php
@@ -100,7 +100,7 @@ use Vich\UploaderBundle\Mapping\Attribute as Vich;
                     ]),
                 ),
             ),
-            security: 'is_granted(\'ROLE_USER\')',
+            security: 'is_granted(\'ROLE_ADMIN\')',
             deserialize: false,
             name: 'add_variant'
         ),


### PR DESCRIPTION
The add_variant endpoint attached or replaced a file on any resource node identified in the request, with no object-level check and open to any authenticated user. It now requires ROLE_ADMIN on the operation — matching what the documents list requires to offer the action — plus EDIT permission on the target resource node, the same object-level check the delete-variant endpoint already performs.

Refs GHSA-mjq6-9hj4-522f