### PR TITLE
Security: Gate social post attachment reads on the parent post permission

### DIFF
--- a/src/CoreBundle/Entity/SocialPostAttachment.php
+++ b/src/CoreBundle/Entity/SocialPostAttachment.php
@@ -22,7 +22,12 @@ use Stringable;
 #[ApiResource(
     types: ['http://schema.org/MediaObject'],
     operations: [
-        new Get(security: "object.getSocialPost() != null and is_granted('VIEW', object.getSocialPost())"),
+        // SocialPostVoter has no administrator bypass, so ROLE_ADMIN is spelled out here to keep
+        // the access administrators already had on this resource.
+        new Get(
+            security: "is_granted('ROLE_ADMIN')
+                or (object.getSocialPost() != null and is_granted('VIEW', object.getSocialPost()))"
+        ),
         new GetCollection(security: "is_granted('ROLE_ADMIN')"),
         new Post(
             controller: CreateSocialPostAttachmentAction::class,

--- a/src/CoreBundle/Entity/SocialPostAttachment.php
+++ b/src/CoreBundle/Entity/SocialPostAttachment.php
@@ -8,7 +8,6 @@ namespace Chamilo\CoreBundle\Entity;
 
 use ApiPlatform\Metadata\ApiResource;
 use ApiPlatform\Metadata\Get;
-use ApiPlatform\Metadata\GetCollection;
 use ApiPlatform\Metadata\Post;
 use ApiPlatform\OpenApi\Model\Operation;
 use ApiPlatform\OpenApi\Model\RequestBody;
@@ -22,13 +21,9 @@ use Stringable;
 #[ApiResource(
     types: ['http://schema.org/MediaObject'],
     operations: [
-        // SocialPostVoter has no administrator bypass, so ROLE_ADMIN is spelled out here to keep
-        // the access administrators already had on this resource.
-        new Get(
-            security: "is_granted('ROLE_ADMIN')
-                or (object.getSocialPost() != null and is_granted('VIEW', object.getSocialPost()))"
-        ),
-        new GetCollection(security: "is_granted('ROLE_ADMIN')"),
+        // Kept because API Platform needs an item operation to build this resource's IRI; reading
+        // the attachments of a post goes through /social_posts/{id}/attachments.
+        new Get(security: "object.getSocialPost() != null and is_granted('VIEW', object.getSocialPost())"),
         new Post(
             controller: CreateSocialPostAttachmentAction::class,
             openapi: new Operation(

--- a/src/CoreBundle/Entity/SocialPostAttachment.php
+++ b/src/CoreBundle/Entity/SocialPostAttachment.php
@@ -22,8 +22,8 @@ use Stringable;
 #[ApiResource(
     types: ['http://schema.org/MediaObject'],
     operations: [
-        new Get(security: "is_granted('ROLE_USER')"),
-        new GetCollection(security: "is_granted('ROLE_USER')"),
+        new Get(security: "object.getSocialPost() != null and is_granted('VIEW', object.getSocialPost())"),
+        new GetCollection(security: "is_granted('ROLE_ADMIN')"),
         new Post(
             controller: CreateSocialPostAttachmentAction::class,
             openapi: new Operation(


### PR DESCRIPTION
Reading a social post attachment only required an authenticated account, so attachment metadata and URLs of posts the social voter hides were readable by anyone. The item operation now delegates to the parent post's VIEW check, matching MessageAttachment, and the collection operation is removed: nothing consumed it, and listing the attachments of a post is what /social_posts/{id}/attachments already does, with the same VIEW check. The item operation stays because API Platform needs one to build the resource IRI the POST returns.

Verified against a running instance with two unrelated students. Before: the non-author read the attachment (200, exposing originalName, mimeType, size and the /r/ view and download URLs) and saw it listed in the collection, while the nested route already returned 403 for them. After: the item returns 403 for them, the collection route only answers POST, the author still reads their own attachment and the nested route, and creating an attachment still returns its IRI. Administrators get 403 on the item, which is what the nested route already returned for them.

Refs GHSA-94mr-8v6c-gxxh