### PR TITLE
Security: Make the personal file ownership filter a conjunction

### DIFF
--- a/src/CoreBundle/DataProvider/Extension/PersonalFileExtension.php
+++ b/src/CoreBundle/DataProvider/Extension/PersonalFileExtension.php
@@ -79,7 +79,7 @@ final class PersonalFileExtension implements QueryCollectionExtensionInterface
                 ->setParameter('userLink', $user->getId())
             ;
         } else {
-            $queryBuilder->orWhere('node.creator = :current');
+            $queryBuilder->andWhere('node.creator = :current');
             $queryBuilder->setParameter('current', $user->getId());
         }
     }


### PR DESCRIPTION
The personal files collection filtered by owner with orWhere, so the ownership predicate would stop being mandatory as soon as any earlier WHERE existed on the query. It now uses andWhere, like the shared branch of the same extension and the sibling message tag extension.

Verified against a running instance. As the reporter states, there is no observable leak with the current extension order: a second student sees totalItems=0 on the collection, plain, filtered by title and filtered by resourceNode.parent, gets 403 on the item and is redirected away from the download, both before and after the change; the owner keeps seeing their file in all of those. The operator itself is what is wrong — building the same query with a WHERE already present yields 'WHERE title LIKE ? OR creator_id = ?' with orWhere against 'WHERE title LIKE ? AND creator_id = ?' with andWhere. debug:container confirms why it is dormant today: every Chamilo collection extension runs unprioritised while FilterExtension sits at -16, so this predicate is currently always the first WHERE.

Refs GHSA-8g72-66mc-3c4j