### PR TITLE
Security: Require course membership for auto-generated survey invitations

### DIFF
--- a/src/CoreBundle/ApiResource/Survey/SurveyAnswer.php
+++ b/src/CoreBundle/ApiResource/Survey/SurveyAnswer.php
@@ -36,10 +36,11 @@ use Symfony\Component\Serializer\Attribute\Groups;
             name: 'get_survey_answer',
             provider: SurveyAnswerProvider::class,
             parameters: [
+                // Not required: an invitee answering from a link has no course context, and the
+                // provider then resolves the course from the survey itself, as the Post does.
                 'cid' => new QueryParameter(
                     schema: ['type' => 'integer'],
-                    description: 'Course identifier',
-                    required: true,
+                    description: 'Course identifier; falls back to publicCid or to the survey own course',
                 ),
                 'sid' => new QueryParameter(
                     schema: ['type' => 'integer'],

--- a/src/CoreBundle/Helpers/UserHelper.php
+++ b/src/CoreBundle/Helpers/UserHelper.php
@@ -38,4 +38,16 @@ readonly class UserHelper
         return $this->security->isGranted('ROLE_CURRENT_COURSE_TEACHER')
             || $this->security->isGranted('ROLE_CURRENT_COURSE_SESSION_TEACHER');
     }
+
+    /**
+     * Whether the current user belongs to the current course context, base course or session.
+     *
+     * Only the student roles are named because the role hierarchy has each teacher role imply
+     * its student one, and ROLE_ADMIN imply all of them.
+     */
+    public function isMemberOfCurrentCourse(): bool
+    {
+        return $this->security->isGranted('ROLE_CURRENT_COURSE_STUDENT')
+            || $this->security->isGranted('ROLE_CURRENT_COURSE_SESSION_STUDENT');
+    }
 }

--- a/src/CoreBundle/State/Survey/SurveyAnswerProvider.php
+++ b/src/CoreBundle/State/Survey/SurveyAnswerProvider.php
@@ -14,6 +14,7 @@ use Chamilo\CoreBundle\Entity\Session;
 use Chamilo\CoreBundle\Entity\User;
 use Chamilo\CoreBundle\Helpers\CidReqHelper;
 use Chamilo\CoreBundle\Helpers\SurveyHelper;
+use Chamilo\CoreBundle\Helpers\UserHelper;
 use Chamilo\CoreBundle\Settings\SettingsManager;
 use Chamilo\CourseBundle\Entity\CSurvey;
 use Chamilo\CourseBundle\Entity\CSurveyAnswer;
@@ -65,6 +66,7 @@ final readonly class SurveyAnswerProvider implements ProviderInterface
         private Security $security,
         private SettingsManager $settingsManager,
         private SurveyHelper $surveyHelper,
+        private UserHelper $userHelper,
     ) {}
 
     /**
@@ -231,7 +233,7 @@ final readonly class SurveyAnswerProvider implements ProviderInterface
 
             // The auto code mints an invitation on the spot. Outside the anonymous link, which
             // exists to be shared, only members of the course context may obtain one.
-            if ('1' !== (string) $survey->getAnonymous() && !$this->belongsToCurrentCourseContext()) {
+            if ('1' !== (string) $survey->getAnonymous() && !$this->userHelper->isMemberOfCurrentCourse()) {
                 throw new AccessDeniedHttpException('You are not allowed to answer this survey.');
             }
 
@@ -549,15 +551,6 @@ final readonly class SurveyAnswerProvider implements ProviderInterface
     private function getInvitationCode(Request $request): string
     {
         return trim((string) ($request->query->get('invitationCode') ?? $request->query->get('invitationcode') ?? ''));
-    }
-
-    /**
-     * Teachers, coaches and administrators reach this through the student roles they imply.
-     */
-    private function belongsToCurrentCourseContext(): bool
-    {
-        return $this->security->isGranted('ROLE_CURRENT_COURSE_STUDENT')
-            || $this->security->isGranted('ROLE_CURRENT_COURSE_SESSION_STUDENT');
     }
 
     private function getOrCreateAnonymousAutoInvitation(CSurvey $survey, Course $course, ?Session $session, Request $request): CSurveyInvitation

--- a/src/CoreBundle/State/Survey/SurveyAnswerProvider.php
+++ b/src/CoreBundle/State/Survey/SurveyAnswerProvider.php
@@ -229,6 +229,12 @@ final readonly class SurveyAnswerProvider implements ProviderInterface
                 throw new AccessDeniedHttpException('A valid user is required.');
             }
 
+            // The auto code mints an invitation on the spot. Outside the anonymous link, which
+            // exists to be shared, only members of the course context may obtain one.
+            if ('1' !== (string) $survey->getAnonymous() && !$this->belongsToCurrentCourseContext()) {
+                throw new AccessDeniedHttpException('You are not allowed to answer this survey.');
+            }
+
             return $this->getOrCreateAutoInvitation($survey, $course, $session, $user);
         }
 
@@ -543,6 +549,15 @@ final readonly class SurveyAnswerProvider implements ProviderInterface
     private function getInvitationCode(Request $request): string
     {
         return trim((string) ($request->query->get('invitationCode') ?? $request->query->get('invitationcode') ?? ''));
+    }
+
+    /**
+     * Teachers, coaches and administrators reach this through the student roles they imply.
+     */
+    private function belongsToCurrentCourseContext(): bool
+    {
+        return $this->security->isGranted('ROLE_CURRENT_COURSE_STUDENT')
+            || $this->security->isGranted('ROLE_CURRENT_COURSE_SESSION_STUDENT');
     }
 
     private function getOrCreateAnonymousAutoInvitation(CSurvey $survey, Course $course, ?Session $session, Request $request): CSurveyInvitation

--- a/src/CoreBundle/State/Survey/SurveyMeetingProvider.php
+++ b/src/CoreBundle/State/Survey/SurveyMeetingProvider.php
@@ -196,6 +196,11 @@ final readonly class SurveyMeetingProvider implements ProviderInterface
     {
         $invitationCode = $this->getInvitationCode($request);
         if ('auto' === $invitationCode) {
+            // The auto code mints an invitation on the spot, so it has to stay inside the course.
+            if (!$this->belongsToCurrentCourseContext()) {
+                throw new AccessDeniedHttpException('You are not allowed to answer this meeting poll.');
+            }
+
             return $this->getOrCreateAutoInvitation($survey, $course, $session, $user);
         }
 
@@ -438,6 +443,15 @@ final readonly class SurveyMeetingProvider implements ProviderInterface
     private function getInvitationCode(Request $request): string
     {
         return trim((string) ($request->query->get('invitationCode') ?? $request->query->get('invitationcode') ?? ''));
+    }
+
+    /**
+     * Teachers, coaches and administrators reach this through the student roles they imply.
+     */
+    private function belongsToCurrentCourseContext(): bool
+    {
+        return $this->security->isGranted('ROLE_CURRENT_COURSE_STUDENT')
+            || $this->security->isGranted('ROLE_CURRENT_COURSE_SESSION_STUDENT');
     }
 
     private function getOrCreateAutoInvitation(CSurvey $survey, Course $course, ?Session $session, User $user): CSurveyInvitation

--- a/src/CoreBundle/State/Survey/SurveyMeetingProvider.php
+++ b/src/CoreBundle/State/Survey/SurveyMeetingProvider.php
@@ -14,6 +14,7 @@ use Chamilo\CoreBundle\Entity\Session;
 use Chamilo\CoreBundle\Entity\User;
 use Chamilo\CoreBundle\Helpers\CidReqHelper;
 use Chamilo\CoreBundle\Helpers\SurveyHelper;
+use Chamilo\CoreBundle\Helpers\UserHelper;
 use Chamilo\CoreBundle\Settings\SettingsManager;
 use Chamilo\CourseBundle\Entity\CSurvey;
 use Chamilo\CourseBundle\Entity\CSurveyAnswer;
@@ -45,6 +46,7 @@ final readonly class SurveyMeetingProvider implements ProviderInterface
         private Security $security,
         private SettingsManager $settingsManager,
         private SurveyHelper $surveyHelper,
+        private UserHelper $userHelper,
     ) {}
 
     /**
@@ -197,7 +199,7 @@ final readonly class SurveyMeetingProvider implements ProviderInterface
         $invitationCode = $this->getInvitationCode($request);
         if ('auto' === $invitationCode) {
             // The auto code mints an invitation on the spot, so it has to stay inside the course.
-            if (!$this->belongsToCurrentCourseContext()) {
+            if (!$this->userHelper->isMemberOfCurrentCourse()) {
                 throw new AccessDeniedHttpException('You are not allowed to answer this meeting poll.');
             }
 
@@ -443,15 +445,6 @@ final readonly class SurveyMeetingProvider implements ProviderInterface
     private function getInvitationCode(Request $request): string
     {
         return trim((string) ($request->query->get('invitationCode') ?? $request->query->get('invitationcode') ?? ''));
-    }
-
-    /**
-     * Teachers, coaches and administrators reach this through the student roles they imply.
-     */
-    private function belongsToCurrentCourseContext(): bool
-    {
-        return $this->security->isGranted('ROLE_CURRENT_COURSE_STUDENT')
-            || $this->security->isGranted('ROLE_CURRENT_COURSE_SESSION_STUDENT');
     }
 
     private function getOrCreateAutoInvitation(CSurvey $survey, Course $course, ?Session $session, User $user): CSurveyInvitation


### PR DESCRIPTION
Answering a survey with invitationCode=auto created an invitation for the current user without checking that they belong to the course. Membership of the course or session context is now required, through a new UserHelper::isMemberOfCurrentCourse() that both survey providers call. A last commit also drops the required flag on the Get operation's cid, which is what made surveys unusable outside a course context.

Verified against a running instance, and the exploitable path is narrower than the report suggests. With cid in the query the course context listener already answers first: an unenrolled student gets 403 on a course whose visibility is REGISTERED, and on an OPEN_PLATFORM course they hold the course student role by design, before and after this change. What was genuinely unprotected is the POST, where cid is optional and the course falls back to the survey's own course, so no context check ran: an unenrolled student could POST /api/survey/answer/{id}?invitationCode=auto with no cid against a closed course and get 201, answer and invitation persisted. That now returns 403 with nothing written, while an enrolled student answering with cid still gets 201.

The cid change fixes a separate, pre-existing bug the same tests surfaced: an invitee holding a real invitation code could not read the survey at all on a closed course — without cid the Get died in parameter validation (422), and with cid the context listener denied the course (403), leaving only a blind POST. With cid optional the provider resolves the course from the survey, as the Post already documented, and the invitation is what authorises the read. Checked on a closed course with an unenrolled invitee: their own code returns the questions with or without cid, another user's code returns 403, no code and no invitation returns 403, invitationCode=auto returns 403 through the new guard, preview stays teacher-only, and an enrolled member with cid is unaffected.

One point for review: the anonymous link keeps working as before, since that flow exists to be shared outside the course. The same unguarded auto branch in SurveyMeetingProvider is fixed here as well.

Refs GHSA-3c47-mrf9-6w4f