### PR TITLE
Security: Restrict the session course notification to managers and the session own students

### DIFF
--- a/src/CoreBundle/Controller/SessionController.php
+++ b/src/CoreBundle/Controller/SessionController.php
@@ -37,11 +37,13 @@ use Graphp\GraphViz\GraphViz;
 use SessionManager;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\ExpressionLanguage\Expression;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
 use Symfony\Contracts\Translation\TranslatorInterface;
 use UserManager;
 
@@ -271,6 +273,7 @@ class SessionController extends AbstractController
     }
 
     #[Route('/{id}/send-course-notification', name: 'chamilo_core_session_send_course_notification', methods: ['POST'])]
+    #[IsGranted(new Expression("is_granted('ROLE_ADMIN') or is_granted('ROLE_SESSION_MANAGER')"))]
     public function sendCourseNotification(
         int $id,
         Request $request,
@@ -294,6 +297,12 @@ class SessionController extends AbstractController
         $user = $userRepo->find($studentId);
         if (!$user) {
             return $this->json(['error' => 'User not found'], Response::HTTP_NOT_FOUND);
+        }
+
+        // The notification is for a student of this session: activating an account and adding it
+        // to the portal below must never reach a user picked freely by id.
+        if (!$session->hasUserInSession($user, Session::STUDENT)) {
+            return $this->json(['error' => 'User is not a student of this session'], Response::HTTP_FORBIDDEN);
         }
 
         $email = $user->getEmail();


### PR DESCRIPTION
The send-course-notification endpoint declared no authorization at all, while it activates the target account and can add it to the current portal. It now requires ROLE_ADMIN or ROLE_SESSION_MANAGER — the roles the admin dashboard page that calls it already requires — and the target user must be a student of the session named in the URL, which is what the caller always does after enrolling them.

Verified against a running instance, with a note on reach: the unauthenticated call in the report did not reproduce here, an anonymous POST is redirected to the login page and nothing changes, and an authenticated student is redirected too, so something ahead of the controller already denies them. What is confirmed is the missing authorization on the action itself: an administrator could activate any account by id, which now returns 403 unless that user is a student of the session, while notifying an actual student of the session still returns 200 and activates them.

Refs GHSA-mfw3-hvv2-9x96