### PR TITLE
Security: Stop exposing the user current portal as a writable API field

### DIFF
--- a/src/CoreBundle/Entity/User.php
+++ b/src/CoreBundle/Entity/User.php
@@ -676,7 +676,8 @@ class User implements UserInterface, EquatableInterface, ResourceInterface, Reso
     protected ?string $theme = null;
     #[ORM\Column(name: 'hr_dept_id', type: 'smallint', unique: false, nullable: true)]
     protected ?int $hrDeptId = null;
-    #[Groups(['user:write'])]
+    // Not writable through the API: its setter creates the AccessUrlRelUser row, which would let
+    // anyone editing their own account join any portal. UserListener sets it on creation instead.
     protected ?AccessUrl $currentUrl = null;
 
     /**


### PR DESCRIPTION
User::$currentUrl was in the user:write group, and its setter builds an AccessUrlRelUser that Doctrine cascade-persists, so a user editing their own account could join any portal — the very thing the admin-only guard on AccessUrlRelUser prevents. The property is no longer writable through the API; UserListener sets it when an account is created, and adding a user to another portal keeps its own operation, POST /access_urls/{id}/user, restricted to administrators and session managers.

Verified against a running instance with a second access URL, one row per operation:

- PATCH /api/users/{own_id} with currentUrl, as a student: before, 200 and the portals went from 1 to 1,3; after, 200 and the portals stay at 1. This is the exploitable path — Put and Patch are the operations gated by is_granted('EDIT', object).
- PUT with the same body: 422 both before and after, the operation wants the full resource, so it is not a practical vector.
- POST /api/users as a student: 403 both before and after, that operation already requires ROLE_ADMIN.
- POST /api/users as an administrator with currentUrl pointing at the second portal: before, the account was created directly on that portal (prePersist only assigns one when the collection is empty, and the setter had already filled it); after, it is created on the current portal instead, so the portal is decided by the server rather than by the body.
- POST /api/access_urls/{id}/user as an administrator: 201, the account is created with both portals, unchanged by this patch.

Refs GHSA-8fpc-3w6p-477j