### PR TITLE
Security: Require course edit rights to read a document template status

### DIFF
--- a/src/CoreBundle/Controller/TemplateController.php
+++ b/src/CoreBundle/Controller/TemplateController.php
@@ -86,6 +86,20 @@ class TemplateController extends AbstractController
     #[Route('/document-templates/{documentId}/is-template', methods: ['GET'])]
     public function isDocumentTemplate(int $documentId, EntityManagerInterface $entityManager): Response
     {
+        // Same gate as creating and deleting the template: the answer is only for someone who
+        // may edit the document's course, never for anyone walking through document ids.
+        $document = $entityManager->getRepository(CDocument::class)->find($documentId);
+        if (!$document) {
+            return $this->json(['error' => 'Document not found.'], Response::HTTP_NOT_FOUND);
+        }
+
+        $course = $document->getFirstResourceLink()?->getCourse();
+        if (!$course instanceof Course) {
+            throw $this->createAccessDeniedException();
+        }
+
+        $this->denyAccessUnlessGranted(CourseVoter::EDIT, $course);
+
         $template = $entityManager->getRepository(Templates::class)->findOneBy(['refDoc' => $documentId]);
 
         return $this->json([


### PR DESCRIPTION
The is-template endpoint answered for any document id with no authorization at all, so document ids could be walked through anonymously to learn which ones are registered as templates. It now loads the document and applies the same CourseVoter::EDIT check its sibling create and delete endpoints already perform.

Verified against a running instance: before the change an anonymous GET returned 200 with the template status for any id; after it an anonymous caller and an unrelated student are turned away, and a user who may edit the document's course still gets the status.

Refs GHSA-r9gp-h2c9-5hm5