### PR TITLE
Security: Require the forum thread to belong to the course in the request

### DIFF
--- a/src/CoreBundle/State/Forum/ForumThreadPostsStateProvider.php
+++ b/src/CoreBundle/State/Forum/ForumThreadPostsStateProvider.php
@@ -140,6 +140,13 @@ final class ForumThreadPostsStateProvider implements ProviderInterface
         $user = $this->getCurrentUser();
         $canSubscribe = !$this->areForumPostNotificationsHidden($course);
 
+        // The thread comes from the URL and the rights below are computed for the course in the
+        // request, so the thread has to belong to that course — otherwise managing one course
+        // would read the threads of every other one.
+        if (!$this->threadBelongsToContext($thread, $course, $session, $group)) {
+            throw new NotFoundHttpException('Forum thread not found.');
+        }
+
         if (!$canManage) {
             $this->assertResourceIsVisible($thread->getResourceNode());
             $this->assertResourceIsVisible($forum->getResourceNode());
@@ -268,6 +275,27 @@ final class ForumThreadPostsStateProvider implements ProviderInterface
         if (null === $resourceNode || !$this->security->isGranted('VIEW', $resourceNode)) {
             throw new AccessDeniedHttpException('You are not allowed to access this resource.');
         }
+    }
+
+    /**
+     * A thread of the base course is reachable from a session of that course, hence the fallbacks.
+     */
+    private function threadBelongsToContext(
+        CForumThread $thread,
+        Course $course,
+        ?Session $session,
+        ?CGroup $group
+    ): bool {
+        $resourceNode = $thread->getResourceNode();
+        if (!$resourceNode instanceof ResourceNode) {
+            return false;
+        }
+
+        $link = $resourceNode->getResourceLinkByContext($course, $session, $group)
+            ?? $resourceNode->getResourceLinkByContext($course, $session)
+            ?? $resourceNode->getResourceLinkByContext($course);
+
+        return null !== $link;
     }
 
     private function getCurrentUser(): User


### PR DESCRIPTION
The thread came from the URL while the course, the session and the management rights came from the request's cid, and nothing tied the two together, so managing one course was enough to read the threads of any other. The provider now requires the thread to have a resource link in the course of the request before anything else, falling back from the group and session context to the plain course link so a base-course thread stays reachable from a session.

Verified against a running instance with a thread in a course the caller does not belong to. Before the change a teacher of another course reading it with their own cid got 200 and the full post text; after it they get 404, while a teacher of the thread's own course still gets the posts.

Refs GHSA-7226-96mv-x769