### PR TITLE
Fix IMS/LTI Deep Linking for multiple resources and cross-site returns

### DIFF
--- a/ImsLtiPlugin.php
+++ b/ImsLtiPlugin.php
@@ -1,0 +1,772 @@
+<?php
+
+/* For license terms, see /license.txt */
+
+use Chamilo\CoreBundle\Component\Http\SafeHttp;
+use Chamilo\CoreBundle\Entity\Course;
+use Chamilo\CoreBundle\Entity\Session;
+use Chamilo\CourseBundle\Entity\CTool;
+use Chamilo\PluginBundle\Entity\ImsLti\ImsLtiTool;
+use Chamilo\PluginBundle\Entity\ImsLti\LineItem;
+use Chamilo\PluginBundle\Entity\ImsLti\Platform;
+use Chamilo\PluginBundle\Entity\ImsLti\Token;
+use Chamilo\UserBundle\Entity\User;
+use Doctrine\ORM\Tools\SchemaTool;
+use Firebase\JWT\JWK;
+
+/**
+ * Description of MsiLti.
+ *
+ * @author Angel Fernando Quiroz Campos <angel.quiroz@beeznest.com>
+ */
+class ImsLtiPlugin extends Plugin
+{
+    const TABLE_TOOL = 'plugin_ims_lti_tool';
+    const TABLE_PLATFORM = 'plugin_ims_lti_platform';
+
+    public $isAdminPlugin = true;
+
+    protected function __construct()
+    {
+        $version = '1.9.0';
+        $author = 'Angel Fernando Quiroz Campos';
+
+        $message = Display::return_message($this->get_lang('GenerateKeyPairInfo'));
+        $settings = [
+            $message => 'html',
+            'enabled' => 'boolean',
+        ];
+
+        parent::__construct($version, $author, $settings);
+
+        $this->setCourseSettings();
+    }
+
+    /**
+     * Get the class instance.
+     *
+     * @staticvar MsiLtiPlugin $result
+     *
+     * @return ImsLtiPlugin
+     */
+    public static function create()
+    {
+        static $result = null;
+
+        return $result ?: $result = new self();
+    }
+
+    /**
+     * Get the plugin directory name.
+     */
+    public function get_name()
+    {
+        return 'ims_lti';
+    }
+
+    /**
+     * Install the plugin. Setup the database.
+     *
+     * @throws \Doctrine\ORM\Tools\ToolsException
+     */
+    public function install()
+    {
+        $this->createPluginTables();
+    }
+
+    /**
+     * Save configuration for plugin.
+     *
+     * Generate a new key pair for platform when enabling plugin.
+     *
+     * @throws \Doctrine\ORM\OptimisticLockException
+     *
+     * @return $this|Plugin
+     */
+    public function performActionsAfterConfigure()
+    {
+        $em = Database::getManager();
+
+        /** @var Platform $platform */
+        $platform = $em
+            ->getRepository('ChamiloPluginBundle:ImsLti\Platform')
+            ->findOneBy([]);
+
+        if ($this->get('enabled') === 'true') {
+            if (!$platform) {
+                $platform = new Platform();
+            }
+
+            $keyPair = self::generatePlatformKeys();
+
+            $platform->setKid($keyPair['kid']);
+            $platform->publicKey = $keyPair['public'];
+            $platform->setPrivateKey($keyPair['private']);
+
+            $em->persist($platform);
+        } else {
+            if ($platform) {
+                $em->remove($platform);
+            }
+        }
+
+        $em->flush();
+
+        return $this;
+    }
+
+    /**
+     * Unistall plugin. Clear the database.
+     */
+    public function uninstall()
+    {
+        try {
+            $this->dropPluginTables();
+            $this->removeTools();
+        } catch (Exception $e) {
+            error_log('Error while uninstalling IMS/LTI plugin: '.$e->getMessage());
+        }
+    }
+
+    /**
+     * @return CTool
+     */
+    public function findCourseToolByLink(Course $course, ImsLtiTool $ltiTool)
+    {
+        $em = Database::getManager();
+        $toolRepo = $em->getRepository('ChamiloCourseBundle:CTool');
+
+        /** @var CTool $cTool */
+        $cTool = $toolRepo->findOneBy(
+            [
+                'cId' => $course,
+                'link' => self::generateToolLink($ltiTool),
+            ]
+        );
+
+        return $cTool;
+    }
+
+    /**
+     * @throws \Doctrine\ORM\OptimisticLockException
+     */
+    public function updateCourseTool(CTool $courseTool, ImsLtiTool $ltiTool)
+    {
+        $em = Database::getManager();
+
+        $courseTool->setName($ltiTool->getName());
+
+        if ('iframe' !== $ltiTool->getDocumentTarget()) {
+            $courseTool->setTarget('_blank');
+        } else {
+            $courseTool->setTarget('_self');
+        }
+
+        $em->persist($courseTool);
+        $em->flush();
+    }
+
+    /**
+     * Add the course tool.
+     *
+     * @param bool $isVisible
+     *
+     * @throws \Doctrine\ORM\OptimisticLockException
+     */
+    public function addCourseTool(Course $course, ImsLtiTool $ltiTool, $isVisible = true)
+    {
+        $cTool = $this->createLinkToCourseTool(
+            $ltiTool->getName(),
+            $course->getId(),
+            null,
+            self::generateToolLink($ltiTool)
+        );
+        $cTool
+            ->setTarget(
+                $ltiTool->getDocumentTarget() === 'iframe' ? '_self' : '_blank'
+            )
+            ->setVisibility($isVisible);
+
+        $em = Database::getManager();
+        $em->persist($cTool);
+        $em->flush();
+    }
+
+    /**
+     * Add the course session tool.
+     *
+     * @param bool $isVisible
+     *
+     * @throws \Doctrine\ORM\OptimisticLockException
+     */
+    public function addCourseSessionTool(Course $course, Session $session, ImsLtiTool $ltiTool, $isVisible = true)
+    {
+        $cTool = $this->createLinkToCourseTool(
+            $ltiTool->getName(),
+            $course->getId(),
+            null,
+            self::generateToolLink($ltiTool),
+            $session->getId()
+        );
+        $cTool
+            ->setTarget(
+                $ltiTool->getDocumentTarget() === 'iframe' ? '_self' : '_blank'
+            )
+            ->setVisibility($isVisible);
+
+        $em = Database::getManager();
+        $em->persist($cTool);
+        $em->flush();
+    }
+
+    public static function isInstructor()
+    {
+        api_is_allowed_to_edit(false, true);
+    }
+
+    /**
+     * @return array
+     */
+    public static function getRoles(User $user)
+    {
+        $roles = ['http://purl.imsglobal.org/vocab/lis/v2/system/person#User'];
+
+        if (DRH === $user->getStatus()) {
+            $roles[] = 'http://purl.imsglobal.org/vocab/lis/v2/membership#Mentor';
+            $roles[] = 'http://purl.imsglobal.org/vocab/lis/v2/institution/person#Mentor';
+
+            return $roles;
+        }
+
+        if (!api_is_allowed_to_edit(false, true)) {
+            $roles[] = 'http://purl.imsglobal.org/vocab/lis/v2/membership#Learner';
+            $roles[] = 'http://purl.imsglobal.org/vocab/lis/v2/institution/person#Student';
+
+            if ($user->getStatus() === INVITEE) {
+                $roles[] = 'http://purl.imsglobal.org/vocab/lis/v2/institution/person#Guest';
+            }
+
+            return $roles;
+        }
+
+        $roles[] = 'http://purl.imsglobal.org/vocab/lis/v2/institution/person#Instructor';
+        $roles[] = 'http://purl.imsglobal.org/vocab/lis/v2/membership#Instructor';
+
+        if (api_is_platform_admin_by_id($user->getId())) {
+            $roles[] = 'http://purl.imsglobal.org/vocab/lis/v2/institution/person#Administrator';
+            $roles[] = 'http://purl.imsglobal.org/vocab/lis/v2/system/person#SysAdmin';
+            $roles[] = 'http://purl.imsglobal.org/vocab/lis/v2/system/person#Administrator';
+        }
+
+        return $roles;
+    }
+
+    /**
+     * @return string
+     */
+    public static function getUserRoles(User $user)
+    {
+        if (DRH === $user->getStatus()) {
+            return 'urn:lti:role:ims/lis/Mentor';
+        }
+
+        if ($user->getStatus() === INVITEE) {
+            return 'Learner,urn:lti:role:ims/lis/Learner/GuestLearner';
+        }
+
+        if (!api_is_allowed_to_edit(false, true)) {
+            return 'Learner';
+        }
+
+        $roles = ['Instructor'];
+
+        if (api_is_platform_admin_by_id($user->getId())) {
+            $roles[] = 'urn:lti:role:ims/lis/Administrator';
+        }
+
+        return implode(',', $roles);
+    }
+
+    /**
+     * @param int $userId
+     *
+     * @return string
+     */
+    public static function generateToolUserId($userId)
+    {
+        $siteName = api_get_setting('siteName');
+        $institution = api_get_setting('Institution');
+        $toolUserId = "$siteName - $institution - $userId";
+        $toolUserId = api_replace_dangerous_char($toolUserId);
+
+        return $toolUserId;
+    }
+
+    /**
+     * @return string
+     */
+    public static function getLaunchUserIdClaim(ImsLtiTool $tool, User $user)
+    {
+        if (null !== $tool->getParent()) {
+            $tool = $tool->getParent();
+        }
+
+        $replacement = $tool->getReplacementForUserId();
+
+        if (empty($replacement)) {
+            if ($tool->getVersion() === ImsLti::V_1P1) {
+                return self::generateToolUserId($user->getId());
+            }
+
+            return (string) $user->getId();
+        }
+
+        $replaced = str_replace(
+            ['$User.id', '$User.username'],
+            [$user->getId(), $user->getUsername()],
+            $replacement
+        );
+
+        return $replaced;
+    }
+
+    /**
+     * @return string
+     */
+    public static function getRoleScopeMentor(User $currentUser, ImsLtiTool $tool)
+    {
+        $scope = self::getRoleScopeMentorAsArray($currentUser, $tool, true);
+
+        return implode(',', $scope);
+    }
+
+    /**
+     * Tool User IDs which the user DRH can access as a mentor.
+     *
+     * @param bool $generateIdForTool. Optional. Set TRUE for LTI 1.x.
+     *
+     * @return array
+     */
+    public static function getRoleScopeMentorAsArray(User $user, ImsLtiTool $tool, $generateIdForTool = false)
+    {
+        if (DRH !== $user->getStatus()) {
+            return [];
+        }
+
+        $followedUsers = UserManager::get_users_followed_by_drh($user->getId(), 0, true);
+        $scope = [];
+        /** @var array $userInfo */
+        foreach ($followedUsers as $userInfo) {
+            if ($generateIdForTool) {
+                $followedUser = api_get_user_entity($userInfo['user_id']);
+
+                $scope[] = self::getLaunchUserIdClaim($tool, $followedUser);
+            } else {
+                $scope[] = (string) $userInfo['user_id'];
+            }
+        }
+
+        return $scope;
+    }
+
+    /**
+     * @throws \Doctrine\ORM\OptimisticLockException
+     */
+    public function saveItemAsLtiLink(array $contentItem, ImsLtiTool $baseLtiTool, Course $course)
+    {
+        $em = Database::getManager();
+
+        $url = empty($contentItem['url']) ? $baseLtiTool->getLaunchUrl() : $contentItem['url'];
+
+        // A Deep Linking selection represents a new LTI resource instance.
+        // Do not reuse an existing child tool solely because the launch URL is identical.
+        /** @var ImsLtiTool $newLtiTool */
+        $newLtiTool = new ImsLtiTool();
+        $newLtiTool
+            ->setLaunchUrl($url)
+            ->setParent(
+                $baseLtiTool
+            )
+            ->setPrivacy(
+                $baseLtiTool->isSharingName(),
+                $baseLtiTool->isSharingEmail(),
+                $baseLtiTool->isSharingPicture()
+            )
+            ->setCourse($course);
+
+        $newLtiTool
+            ->setName(
+                !empty($contentItem['title']) ? $contentItem['title'] : $baseLtiTool->getName()
+            )
+            ->setDescription(
+                !empty($contentItem['text']) ? $contentItem['text'] : null
+            );
+
+        if (!empty($contentItem['custom'])) {
+            $newLtiTool
+                ->setCustomParams(
+                    $newLtiTool->encodeCustomParams($contentItem['custom'])
+                );
+        }
+
+        $em->persist($newLtiTool);
+        $em->flush();
+
+        $courseTool = $this->findCourseToolByLink($course, $newLtiTool);
+
+        if ($courseTool) {
+            $this->updateCourseTool($courseTool, $newLtiTool);
+
+            return;
+        }
+
+        $this->addCourseTool($course, $newLtiTool);
+    }
+
+    /**
+     * @return ImsLtiServiceResponse|null
+     */
+    public function processServiceRequest()
+    {
+        $xml = $this->getRequestXmlElement();
+
+        if (empty($xml)) {
+            return null;
+        }
+
+        $request = ImsLtiServiceRequestFactory::create($xml);
+
+        return $request->process();
+    }
+
+    /**
+     * @param int $toolId
+     *
+     * @return bool
+     */
+    public static function existsToolInCourse($toolId, Course $course)
+    {
+        $em = Database::getManager();
+        $toolRepo = $em->getRepository('ChamiloPluginBundle:ImsLti\ImsLtiTool');
+
+        /** @var ImsLtiTool $tool */
+        $tool = $toolRepo->findOneBy(['id' => $toolId, 'course' => $course]);
+
+        return !empty($tool);
+    }
+
+    /**
+     * @param string $configUrl
+     *
+     * @throws Exception
+     *
+     * @return string
+     */
+    public function getLaunchUrlFromCartridge($configUrl)
+    {
+        // SSRF guard (CWE-918): only fetch public http(s) targets. Reject
+        // loopback/private/reserved/link-local hosts and the cloud metadata
+        // endpoint before issuing any request.
+        $safeIp = SafeHttp::resolveSafeIp($configUrl);
+
+        if (null === $safeIp) {
+            throw new Exception($this->get_lang('NoAccessToUrl'));
+        }
+
+        $options = [
+            CURLOPT_CUSTOMREQUEST => 'GET',
+            CURLOPT_POST => false,
+            CURLOPT_RETURNTRANSFER => true,
+            CURLOPT_HEADER => false,
+            CURLOPT_ENCODING => '',
+        ];
+        // Forbid redirects/non-HTTP schemes and pin the validated IP to defeat
+        // DNS rebinding; restore TLS verification.
+        $options += SafeHttp::secureCurlOptions($configUrl, $safeIp);
+
+        $ch = curl_init($configUrl);
+        curl_setopt_array($ch, $options);
+        $content = curl_exec($ch);
+        $errno = curl_errno($ch);
+        curl_close($ch);
+
+        if ($errno !== 0) {
+            throw new Exception($this->get_lang('NoAccessToUrl'));
+        }
+
+        libxml_use_internal_errors(true);
+        $xml = simplexml_load_string($content, SimpleXMLElement::class, LIBXML_NONET);
+
+        if ($xml === false) {
+            throw new Exception($this->get_lang('LaunchUrlNotFound'));
+        }
+
+        $result = $xml->xpath('blti:launch_url');
+
+        if (empty($result)) {
+            throw new Exception($this->get_lang('LaunchUrlNotFound'));
+        }
+
+        $launchUrl = $result[0];
+
+        return (string) $launchUrl;
+    }
+
+    public function trimParams(array &$params)
+    {
+        foreach ($params as $key => $value) {
+            $newValue = preg_replace('/\s+/', ' ', $value);
+            $params[$key] = trim($newValue);
+        }
+    }
+
+    /**
+     * @return array
+     */
+    public function removeUrlParamsFromLaunchParams(ImsLtiTool $tool, array &$params)
+    {
+        $urlQuery = parse_url($tool->getLaunchUrl(), PHP_URL_QUERY);
+
+        if (empty($urlQuery)) {
+            return $params;
+        }
+
+        $queryParams = [];
+        parse_str($urlQuery, $queryParams);
+        $queryKeys = array_keys($queryParams);
+
+        foreach ($queryKeys as $key) {
+            if (isset($params[$key])) {
+                unset($params[$key]);
+            }
+        }
+    }
+
+    /**
+     * Avoid conflict with foreign key when deleting a course.
+     *
+     * @param int $courseId
+     */
+    public function doWhenDeletingCourse($courseId)
+    {
+        $em = Database::getManager();
+        $q = $em
+            ->createQuery(
+                'DELETE FROM ChamiloPluginBundle:ImsLti\ImsLtiTool tool
+                    WHERE tool.course = :c_id and tool.parent IS NOT NULL'
+            );
+        $q->execute(['c_id' => (int) $courseId]);
+
+        $em->createQuery('DELETE FROM ChamiloPluginBundle:ImsLti\ImsLtiTool tool WHERE tool.course = :c_id')
+            ->execute(['c_id' => (int) $courseId]);
+    }
+
+    /**
+     * @return string
+     */
+    public static function getIssuerUrl()
+    {
+        $webPath = api_get_path(WEB_PATH);
+
+        return trim($webPath, " /");
+    }
+
+    public static function getCoursesForParentTool(ImsLtiTool $tool, Session $session = null)
+    {
+        if ($tool->getParent()) {
+            return [];
+        }
+
+        $children = $tool->getChildren();
+
+        if ($session) {
+            $children = $children->filter(function (ImsLtiTool $tool) use ($session) {
+                if (null === $tool->getSession()) {
+                    return false;
+                }
+
+                if ($tool->getSession()->getId() !== $session->getId()) {
+                    return false;
+                }
+
+                return true;
+            });
+        }
+
+        return $children->map(function (ImsLtiTool $tool) {
+            return $tool->getCourse();
+        });
+    }
+
+    /**
+     * It gets the public key from jwks or rsa keys.
+     *
+     * @param ImsLtiTool $tool
+     *
+     * @return mixed|string|null
+     */
+    public static function getToolPublicKey(ImsLtiTool $tool)
+    {
+        $publicKey = '';
+        if (!empty($tool->getJwksUrl())) {
+            $publicKeySet = json_decode(file_get_contents($tool->getJwksUrl()), true);
+            $pk = [];
+            foreach ($publicKeySet['keys'] as $key) {
+                $pk = openssl_pkey_get_details(
+                    JWK::parseKeySet(['keys' => [$key]])[$key['kid']]
+                );
+            }
+            if (!empty($pk)) {
+                $publicKey = $pk['key'];
+            }
+        } else {
+            $publicKey = $tool->publicKey;
+        };
+
+        return $publicKey;
+    }
+
+    /**
+     * @return string
+     */
+    protected function getConfigExtraText()
+    {
+        $text = $this->get_lang('ImsLtiDescription');
+        $text .= sprintf(
+            $this->get_lang('ManageToolButton'),
+            api_get_path(WEB_PLUGIN_PATH).'ims_lti/admin.php'
+        );
+
+        return $text;
+    }
+
+    /**
+     * Creates the plugin tables on database.
+     *
+     * @throws \Doctrine\ORM\Tools\ToolsException
+     */
+    private function createPluginTables()
+    {
+        $em = Database::getManager();
+
+        if ($em->getConnection()->getSchemaManager()->tablesExist([self::TABLE_TOOL])) {
+            return;
+        };
+
+        $schemaTool = new SchemaTool($em);
+        $schemaTool->createSchema(
+            [
+                $em->getClassMetadata(ImsLtiTool::class),
+                $em->getClassMetadata(LineItem::class),
+                $em->getClassMetadata(Platform::class),
+                $em->getClassMetadata(Token::class),
+            ]
+        );
+    }
+
+    /**
+     * Drops the plugin tables on database.
+     */
+    private function dropPluginTables()
+    {
+        $em = Database::getManager();
+
+        if (!$em->getConnection()->getSchemaManager()->tablesExist([self::TABLE_TOOL])) {
+            return;
+        };
+
+        $schemaTool = new SchemaTool($em);
+        $schemaTool->dropSchema(
+            [
+                $em->getClassMetadata(ImsLtiTool::class),
+                $em->getClassMetadata(LineItem::class),
+                $em->getClassMetadata(Platform::class),
+                $em->getClassMetadata(Token::class),
+            ]
+        );
+    }
+
+    private function removeTools()
+    {
+        $sql = "DELETE FROM c_tool WHERE link LIKE 'ims_lti/start.php%' AND category = 'plugin'";
+        Database::query($sql);
+    }
+
+    /**
+     * Set the course settings.
+     */
+    private function setCourseSettings()
+    {
+        $button = Display::toolbarButton(
+            $this->get_lang('ConfigureExternalTool'),
+            api_get_path(WEB_PLUGIN_PATH).'ims_lti/configure.php?'.api_get_cidreq(),
+            'cog',
+            'primary'
+        );
+
+        // This setting won't be saved in the database.
+        $this->course_settings = [
+            [
+                'name' => $this->get_lang('ImsLtiDescription').$button.'<hr>',
+                'type' => 'html',
+            ],
+        ];
+    }
+
+    /**
+     * @return string
+     */
+    private static function generateToolLink(ImsLtiTool $tool)
+    {
+        return 'ims_lti/start.php?id='.$tool->getId();
+    }
+
+    /**
+     * @return SimpleXMLElement|null
+     */
+    private function getRequestXmlElement()
+    {
+        $request = file_get_contents("php://input");
+
+        if (empty($request)) {
+            return null;
+        }
+
+        libxml_use_internal_errors(true);
+        $xml = simplexml_load_string($request, SimpleXMLElement::class, LIBXML_NONET);
+
+        return $xml !== false ? $xml : null;
+    }
+
+    /**
+     * Generate a key pair and key id for the platform.
+     *
+     * Rerturn a associative array like ['kid' => '...', 'private' => '...', 'public' => '...'].
+     *
+     * @return array
+     */
+    private static function generatePlatformKeys()
+    {
+        // Create the private and public key
+        $res = openssl_pkey_new(
+            [
+                'digest_alg' => 'sha256',
+                'private_key_bits' => 2048,
+                'private_key_type' => OPENSSL_KEYTYPE_RSA,
+            ]
+        );
+
+        // Extract the private key from $res to $privateKey
+        $privateKey = '';
+        openssl_pkey_export($res, $privateKey);
+
+        // Extract the public key from $res to $publicKey
+        $publicKey = openssl_pkey_get_details($res);
+
+        return [
+            'kid' => bin2hex(openssl_random_pseudo_bytes(10)),
+            'private' => $privateKey,
+            'public' => $publicKey["key"],
+        ];
+    }
+}

--- a/edit.php
+++ b/edit.php
@@ -1,0 +1,153 @@
+<?php
+/* For license terms, see /license.txt */
+
+use Chamilo\PluginBundle\Entity\ImsLti\ImsLtiTool;
+use Chamilo\PluginBundle\Form\FrmEdit;
+
+$cidReset = true;
+
+require_once __DIR__.'/../../main/inc/global.inc.php';
+
+api_protect_admin_script();
+
+if (!isset($_REQUEST['id'])) {
+    api_not_allowed(true);
+}
+
+$toolId = intval($_REQUEST['id']);
+
+$plugin = ImsLtiPlugin::create();
+$em = Database::getManager();
+
+/** @var ImsLtiTool $tool */
+$tool = $em->find('ChamiloPluginBundle:ImsLti\ImsLtiTool', $toolId);
+
+if (!$tool) {
+    Display::addFlash(
+        Display::return_message($plugin->get_lang('NoTool'), 'error')
+    );
+
+    header('Location: '.api_get_path(WEB_PLUGIN_PATH).'ims_lti/admin.php');
+    exit;
+}
+
+$form = new FrmEdit('ims_lti_edit_tool', [], $tool);
+$form->build();
+
+if ($form->validate()) {
+    $formValues = $form->exportValues();
+
+    $tool
+        ->setName($formValues['name'])
+        ->setDescription(
+            empty($formValues['description']) ? null : $formValues['description']
+        )
+        ->setCustomParams(
+            empty($formValues['custom_params']) ? null : $formValues['custom_params']
+        )
+        ->setDocumenTarget($formValues['document_target'])
+        ->setPrivacy(
+            !empty($formValues['share_name']),
+            !empty($formValues['share_email']),
+            !empty($formValues['share_picture'])
+        );
+
+    if (null === $tool->getParent()) {
+        $tool->setLaunchUrl($formValues['launch_url']);
+
+        if ($tool->getVersion() === ImsLti::V_1P1) {
+            $tool
+                ->setConsumerKey(
+                    empty($formValues['consumer_key']) ? null : $formValues['consumer_key']
+                )
+                ->setSharedSecret(
+                    empty($formValues['shared_secret']) ? null : $formValues['shared_secret']
+                );
+        } elseif ($tool->getVersion() === ImsLti::V_1P3) {
+            $tool
+                ->setLoginUrl($formValues['login_url'])
+                ->setRedirectUrl($formValues['redirect_url'])
+                ->setAdvantageServices(
+                    [
+                        'ags' => $formValues['1p3_ags'] ?? LtiAssignmentGradesService::AGS_NONE,
+                        'nrps' => $formValues['1p3_nrps'],
+                    ]
+                )
+                ->setJwksUrl($formValues['jwks_url'])
+                ->publicKey = $formValues['public_key'];
+        }
+
+        if (!empty($formValues['replacement_user_id'])) {
+            $tool->setReplacementForUserId($formValues['replacement_user_id']);
+        }
+    }
+
+    if (null === $tool->getParent() ||
+        (null !== $tool->getParent() && !$tool->getParent()->isActiveDeepLinking())
+    ) {
+        $tool->setActiveDeepLinking(!empty($formValues['deep_linking']));
+    }
+
+    if (null == $tool->getParent()) {
+        /** @var ImsLtiTool $child */
+        foreach ($tool->getChildren() as $child) {
+            $child
+                ->setLaunchUrl($tool->getLaunchUrl())
+                ->setLoginUrl($tool->getLoginUrl())
+                ->setRedirectUrl($tool->getRedirectUrl())
+                ->setAdvantageServices(
+                    $tool->getAdvantageServices()
+                )
+                ->setDocumenTarget($tool->getDocumentTarget())
+                ->publicKey = $tool->publicKey;
+
+            $em->persist($child);
+
+            $courseTool = $plugin->findCourseToolByLink(
+                $child->getCourse(),
+                $child
+            );
+
+            if ($courseTool) {
+                $plugin->updateCourseTool($courseTool, $child);
+            } else {
+                $plugin->addCourseTool($child->getCourse(), $child);
+            }
+        }
+    } else {
+        $courseTool = $plugin->findCourseToolByLink(
+            $tool->getCourse(),
+            $tool
+        );
+
+        if ($courseTool) {
+            $plugin->updateCourseTool($courseTool, $tool);
+        } else {
+            $plugin->addCourseTool($tool->getCourse(), $tool);
+        }
+    }
+
+    $em->persist($tool);
+    $em->flush();
+
+    Display::addFlash(
+        Display::return_message($plugin->get_lang('ToolEdited'), 'success')
+    );
+
+    header('Location: '.api_get_path(WEB_PLUGIN_PATH).'ims_lti/admin.php');
+    exit;
+} else {
+    $form->setDefaultValues();
+}
+
+$interbreadcrumb[] = ['url' => api_get_path(WEB_CODE_PATH).'admin/index.php', 'name' => get_lang('PlatformAdmin')];
+$interbreadcrumb[] = ['url' => api_get_path(WEB_PLUGIN_PATH).'ims_lti/admin.php', 'name' => $plugin->get_title()];
+
+$template = new Template($plugin->get_lang('EditExternalTool'));
+$template->assign('form', $form->returnForm());
+
+$content = $template->fetch('ims_lti/view/add.tpl');
+
+$template->assign('header', $plugin->get_title());
+$template->assign('content', $content);
+$template->display_one_col_template();

--- a/form.php
+++ b/form.php
@@ -1,0 +1,166 @@
+<?php
+/* For license terms, see /license.txt */
+
+use Chamilo\PluginBundle\Entity\ImsLti\ImsLtiTool;
+
+require_once __DIR__.'/../../main/inc/global.inc.php';
+
+api_protect_course_script();
+api_block_anonymous_users(false);
+
+$em = Database::getManager();
+
+/** @var ImsLtiTool $tool */
+$tool = isset($_GET['id'])
+    ? $em->find('ChamiloPluginBundle:ImsLti\ImsLtiTool', (int) $_GET['id'])
+    : null;
+
+if (!$tool) {
+    api_not_allowed(true);
+}
+
+$imsLtiPlugin = ImsLtiPlugin::create();
+$session = api_get_session_entity();
+$course = api_get_course_entity();
+$user = api_get_user_entity(api_get_user_id());
+
+$pluginPath = api_get_path(WEB_PLUGIN_PATH).'ims_lti/';
+$toolUserId = ImsLtiPlugin::getLaunchUserIdClaim($tool, $user);
+$platformDomain = str_replace(['https://', 'http://'], '', api_get_setting('InstitutionUrl'));
+
+$params = [];
+$params['lti_version'] = 'LTI-1p0';
+
+if ($tool->isActiveDeepLinking()) {
+    $params['lti_message_type'] = 'ContentItemSelectionRequest';
+
+    // Keep the Chamilo course/session context in the Deep Linking return URL.
+    // This is important when the tool returns with a cross-site POST and the
+    // browser does not attach the Chamilo session cookie to that first POST.
+    $returnUrl = $pluginPath.'item_return.php';
+    $cidReq = api_get_cidreq();
+
+    if (!empty($cidReq)) {
+        $returnUrl .= '?'.$cidReq;
+    }
+
+    $params['content_item_return_url'] = $returnUrl;
+    $params['accept_media_types'] = 'application/vnd.ims.lti.v1.ltilink';
+    $params['accept_presentation_document_targets'] = 'frame,iframe,window';
+    $params['accept_unsigned'] = 'false';
+    $params['accept_multiple'] = 'true';
+    $params['auto_create'] = 'false';
+    $params['title'] = $tool->getName();
+    $params['text'] = $tool->getDescription();
+    $params['data'] = 'tool:'.$tool->getId();
+} else {
+    $params['lti_message_type'] = 'basic-lti-launch-request';
+    $params['resource_link_id'] = $tool->getId();
+    $params['resource_link_title'] = $tool->getName();
+    $params['resource_link_description'] = $tool->getDescription();
+
+    $toolEval = $tool->getGradebookEval();
+
+    if (!empty($toolEval)) {
+        $params['lis_result_sourcedid'] = json_encode(
+            ['e' => $toolEval->getId(), 'u' => $user->getId(), 'l' => uniqid(), 'lt' => time()]
+        );
+        $params['lis_outcome_service_url'] = api_get_path(WEB_PATH).'lti/os';
+        $params['lis_person_sourcedid'] = "$platformDomain:$toolUserId";
+        $params['lis_course_section_sourcedid'] = ImsLti::getCourseSectionSourcedId($platformDomain, $course, $session);
+    }
+}
+
+$params['user_id'] = $toolUserId;
+
+if ($tool->isSharingPicture()) {
+    $params['user_image'] = UserManager::getUserPicture($user->getId());
+}
+
+$params['roles'] = ImsLtiPlugin::getUserRoles($user);
+
+if ($tool->isSharingName()) {
+    $params['lis_person_name_given'] = $user->getFirstname();
+    $params['lis_person_name_family'] = $user->getLastname();
+    $params['lis_person_name_full'] = $user->getFirstname().' '.$user->getLastname();
+}
+
+if ($tool->isSharingEmail()) {
+    $params['lis_person_contact_email_primary'] = $user->getEmail();
+}
+
+if (DRH === $user->getStatus()) {
+    $scopeMentor = ImsLtiPlugin::getRoleScopeMentor($user, $tool);
+
+    if (!empty($scopeMentor)) {
+        $params['role_scope_mentor'] = $scopeMentor;
+    }
+}
+
+$params['context_id'] = $course->getId();
+$params['context_type'] = 'CourseSection';
+$params['context_label'] = $course->getCode();
+$params['context_title'] = $course->getTitle();
+$params['launch_presentation_locale'] = api_get_language_isocode();
+$params['launch_presentation_document_target'] = $tool->getDocumentTarget();
+$params['tool_consumer_info_product_family_code'] = 'Chamilo LMS';
+$params['tool_consumer_info_version'] = api_get_version();
+$params['tool_consumer_instance_guid'] = $platformDomain;
+$params['tool_consumer_instance_name'] = api_get_setting('siteName');
+$params['tool_consumer_instance_url'] = api_get_path(WEB_PATH);
+$params['tool_consumer_instance_contact_email'] = api_get_setting('emailAdministrator');
+$params['oauth_callback'] = 'about:blank';
+
+$customParams = $tool->parseCustomParams();
+$imsLtiPlugin->trimParams($customParams);
+
+$params += ImsLti::substituteVariablesInCustomParams(
+    $params,
+    $customParams,
+    $user,
+    $course,
+    $session,
+    $platformDomain,
+    ImsLti::V_1P1,
+    $tool
+);
+
+$imsLtiPlugin->trimParams($params);
+
+if (!empty($tool->getConsumerKey()) && !empty($tool->getSharedSecret())) {
+    $consumer = new OAuthConsumer(
+        $tool->getConsumerKey(),
+        $tool->getSharedSecret(),
+        null
+    );
+    $hmacMethod = new OAuthSignatureMethod_HMAC_SHA1();
+
+    $request = OAuthRequest::from_consumer_and_token(
+        $consumer,
+        '',
+        'POST',
+        $tool->getLaunchUrl(),
+        $params
+    );
+    $request->sign_request($hmacMethod, $consumer, '');
+
+    $params = $request->get_parameters();
+}
+
+$imsLtiPlugin->removeUrlParamsFromLaunchParams($tool, $params);
+?>
+<!DOCTYPE html>
+<html>
+<head>
+    <title>title</title>
+</head>
+<body>
+<form action="<?php echo $tool->getLaunchUrl(); ?>" name="ltiLaunchForm" method="post"
+      encType="application/x-www-form-urlencoded">
+    <?php foreach ($params as $key => $value) { ?>
+        <input type="hidden" name="<?php echo $key; ?>" value="<?php echo htmlspecialchars($value); ?>">
+    <?php } ?>
+</form>
+<script>document.ltiLaunchForm.submit();</script>
+</body>
+</html>

--- a/item_return.php
+++ b/item_return.php
@@ -1,0 +1,154 @@
+<?php
+/* For license terms, see /license.txt */
+
+use Chamilo\CoreBundle\Entity\Course;
+use Chamilo\PluginBundle\Entity\ImsLti\ImsLtiTool;
+
+require_once __DIR__.'/../../main/inc/global.inc.php';
+
+// Deep Linking returns from the external tool with a cross-site POST.
+// With SameSite cookie restrictions, the first POST may arrive without the
+// existing Chamilo session cookie. Re-post the exact LTI response once from
+// a Chamilo page so that the browser sends the first-party session cookie.
+if (!api_get_user_id() && empty($_POST['repost'])) {
+    header_remove('Set-Cookie');
+    $repostAction = htmlspecialchars($_SERVER['REQUEST_URI'], ENT_QUOTES, 'UTF-8');
+    ?>
+    <!DOCTYPE html>
+    <html>
+    <head>
+        <meta charset="UTF-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        <title>LTI Deep Linking</title>
+    </head>
+    <body>
+        <form id="ltiRepostForm" method="post" action="<?php echo $repostAction; ?>">
+            <?php foreach ($_POST as $name => $value) { ?>
+                <?php if (is_scalar($value)) { ?>
+                    <input type="hidden"
+                           name="<?php echo htmlspecialchars((string) $name, ENT_QUOTES, 'UTF-8'); ?>"
+                           value="<?php echo htmlspecialchars((string) $value, ENT_QUOTES, 'UTF-8'); ?>">
+                <?php } ?>
+            <?php } ?>
+            <input type="hidden" name="repost" value="1">
+            <noscript><button type="submit">Continue</button></noscript>
+        </form>
+        <script>document.getElementById('ltiRepostForm').submit();</script>
+    </body>
+    </html>
+    <?php
+    exit;
+}
+
+// The helper flag is not part of the signed LTI response.
+if (!empty($_POST['repost'])) {
+    unset($_POST['repost'], $_REQUEST['repost']);
+}
+
+api_protect_course_script(false);
+api_block_anonymous_users(false);
+
+if (empty($_POST['content_items']) || empty($_POST['data'])) {
+    api_not_allowed(false);
+}
+
+$toolId = str_replace('tool:', '', $_POST['data']);
+
+$plugin = ImsLtiPlugin::create();
+$em = Database::getManager();
+/** @var Course $course */
+$course = $em->find('ChamiloCoreBundle:Course', api_get_course_int_id());
+/** @var ImsLtiTool|null $ltiTool */
+$ltiTool = $em->find('ChamiloPluginBundle:ImsLti\ImsLtiTool', $toolId);
+
+if (!$ltiTool) {
+    api_not_allowed();
+}
+
+$consumer = new OAuthConsumer(
+    $_POST['oauth_consumer_key'],
+    $ltiTool->getSharedSecret()
+);
+$hmacMethod = new OAuthSignatureMethod_HMAC_SHA1();
+
+// Build the OAuth request from the original signed LTI parameters only.
+// The local `repost` helper must never become part of the OAuth signature.
+// Query parameters in the Deep Linking return URL (for example cidReq)
+// are part of the OAuth parameter set and therefore must be included.
+$oauthParameters = array_merge($_GET, $_POST);
+unset($oauthParameters['repost']);
+
+$request = OAuthRequest::from_request(
+    'POST',
+    api_get_path(WEB_PLUGIN_PATH).'ims_lti/item_return.php',
+    $oauthParameters
+);
+$request->sign_request($hmacMethod, $consumer, '');
+$signature = $request->get_parameter('oauth_signature');
+$receivedSignature = isset($_POST['oauth_signature']) ? (string) $_POST['oauth_signature'] : '';
+
+if (empty($receivedSignature) || !hash_equals((string) $signature, $receivedSignature)) {
+    api_not_allowed();
+}
+
+$contentItems = json_decode($_POST['content_items'], true);
+$contentItems = $contentItems['@graph'];
+
+foreach ($contentItems as $contentItem) {
+    if ('LtiLinkItem' === $contentItem['@type']) {
+        if ('application/vnd.ims.lti.v1.ltilink' === $contentItem['mediaType']) {
+            $plugin->saveItemAsLtiLink($contentItem, $ltiTool, $course);
+
+            Display::addFlash(
+                Display::return_message($plugin->get_lang('ToolAdded'), 'success')
+            );
+        }
+    }
+}
+
+$courseUrl = api_get_course_url();
+?>
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport"
+          content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0">
+    <meta http-equiv="X-UA-Compatible" content="ie=edge">
+    <title>Document</title>
+</head>
+<body>
+    <script>
+        (function () {
+            var courseUrl = <?php echo json_encode($courseUrl); ?>;
+
+            // Deep Linking opened in a new window: refresh the original
+            // Chamilo course and close the selection window.
+            if (window.opener && !window.opener.closed) {
+                try {
+                    window.opener.location.href = courseUrl;
+                } catch (e) {
+                    // Fall through to a redirect in this window.
+                }
+
+                window.close();
+
+                if (!window.closed) {
+                    window.location.href = courseUrl;
+                }
+
+                return;
+            }
+
+            // Deep Linking opened in an iframe.
+            if (window.parent && window.parent !== window) {
+                window.parent.location.href = courseUrl;
+                return;
+            }
+
+            // Fallback for a normal top-level window.
+            window.location.href = courseUrl;
+        }());
+    </script>
+</body>
+</html>

--- a/item_return2.php
+++ b/item_return2.php
@@ -1,0 +1,151 @@
+<?php
+/* For licensing terms, see /license.txt */
+
+use Chamilo\PluginBundle\Entity\ImsLti\ImsLtiTool;
+use Firebase\JWT\JWT;
+
+require_once __DIR__.'/../../main/inc/global.inc.php';
+
+// LTI 1.3 Deep Linking also returns with a cross-site POST. Re-post once
+// from the Chamilo origin when the browser did not send the session cookie.
+if (!api_get_user_id() && empty($_POST['repost'])) {
+    header_remove('Set-Cookie');
+    $repostAction = htmlspecialchars($_SERVER['REQUEST_URI'], ENT_QUOTES, 'UTF-8');
+    ?>
+    <!DOCTYPE html>
+    <html>
+    <head>
+        <meta charset="UTF-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        <title>LTI Deep Linking</title>
+    </head>
+    <body>
+        <form id="ltiRepostForm" method="post" action="<?php echo $repostAction; ?>">
+            <?php foreach ($_POST as $name => $value) { ?>
+                <?php if (is_scalar($value)) { ?>
+                    <input type="hidden"
+                           name="<?php echo htmlspecialchars((string) $name, ENT_QUOTES, 'UTF-8'); ?>"
+                           value="<?php echo htmlspecialchars((string) $value, ENT_QUOTES, 'UTF-8'); ?>">
+                <?php } ?>
+            <?php } ?>
+            <input type="hidden" name="repost" value="1">
+            <noscript><button type="submit">Continue</button></noscript>
+        </form>
+        <script>document.getElementById('ltiRepostForm').submit();</script>
+    </body>
+    </html>
+    <?php
+    exit;
+}
+
+if (!empty($_POST['repost'])) {
+    unset($_POST['repost'], $_REQUEST['repost']);
+}
+
+api_protect_course_script();
+api_block_anonymous_users(false);
+
+$jwt = empty($_REQUEST['JWT']) ? '' : $_REQUEST['JWT'];
+
+$em = Database::getManager();
+$course = api_get_course_entity(api_get_course_int_id());
+
+try {
+    if (empty($jwt)) {
+        throw new Exception('Token is missing');
+    }
+
+    $jwtParts = explode('.', $jwt, 3);
+    $payloadStr = JWT::urlsafeB64Decode($jwtParts[1]);
+    $payload = json_decode($payloadStr, true);
+
+    if (empty($payload)) {
+        throw new Exception('Token payload is empty');
+    }
+
+    if (empty($payload['https://purl.imsglobal.org/spec/lti-dl/claim/data'])) {
+        throw new Exception('Data claim is missing');
+    }
+
+    if ($payload['aud'] !== ImsLtiPlugin::getIssuerUrl()) {
+        throw new Exception('Audience not valid');
+    }
+
+    $toolId = str_replace('tool:', '', $payload['https://purl.imsglobal.org/spec/lti-dl/claim/data']);
+    /** @var ImsLtiTool $ltiTool */
+    $ltiTool = $em->find('ChamiloPluginBundle:ImsLti\ImsLtiTool', $toolId);
+
+    if (empty($ltiTool)) {
+        throw new Exception('LTI tool not found');
+    }
+
+    if ($payload['iss'] !== $ltiTool->getClientId()) {
+        throw new Exception('Consumer not valid');
+    }
+
+    $decodedJwt = JWT::decode($jwt, $ltiTool->publicKey, ['RS256']);
+
+    if (empty($decodedJwt->{'https://purl.imsglobal.org/spec/lti-dl/claim/content_items'})) {
+        throw new Exception('Content items are missing');
+    }
+
+    foreach ($decodedJwt->{'https://purl.imsglobal.org/spec/lti-dl/claim/content_items'} as $contentItemClaim) {
+        /** @var LtiContentItemType|null $contentItem */
+        $contentItem = null;
+
+        switch ($contentItemClaim->type) {
+            case 'ltiResourceLink':
+                $contentItem = new LtiResourceLink($contentItemClaim);
+                break;
+            default:
+                break;
+        }
+
+        if (null !== $contentItem) {
+            $contentItem->save($ltiTool, $course);
+        }
+    }
+} catch (Exception $exception) {
+    $message = Display::return_message($exception->getMessage(), 'error');
+
+    api_not_allowed(true, $message);
+}
+
+$plugin = ImsLtiPlugin::create();
+
+Display::addFlash(
+    Display::return_message($plugin->get_lang('ToolAdded'), 'success')
+);
+$courseUrl = api_get_course_url();
+?>
+<!DOCTYPE html>
+<body>
+<script>
+    (function () {
+        var courseUrl = <?php echo json_encode($courseUrl); ?>;
+
+        if (window.opener && !window.opener.closed) {
+            try {
+                window.opener.location.href = courseUrl;
+            } catch (e) {
+                // Fall through to a redirect in this window.
+            }
+
+            window.close();
+
+            if (!window.closed) {
+                window.location.href = courseUrl;
+            }
+
+            return;
+        }
+
+        if (window.parent && window.parent !== window) {
+            window.parent.location.href = courseUrl;
+            return;
+        }
+
+        window.location.href = courseUrl;
+    }());
+</script>
+</body>


### PR DESCRIPTION
**Summary**
This PR fixes several issues in the IMS/LTI 1.9.0 plugin affecting LTI 1.1 Deep Linking, particularly when an LTI provider exposes several resources through the same launch URL.
The issues were identified and tested with Chamilo 1.11.40 and Edupool / Schulmediathek Hamburg, using LTI 1.1 with Deep Linking.
Before these changes, the plugin could effectively handle only one resource from a provider using a common launch URL: adding another video replaced the previous one. Additional issues in the Deep Linking workflow could also cause fatal errors, lost sessions, access-denied responses, and incorrect return behaviour.
After these changes, multiple resources from the same LTI provider can be added independently to the same course.

**Problems identified**
****1**. New LTI resources with the same launch URL overwrite previous resources**
saveItemAsLtiLink() searches for an existing child tool using:
    • launch URL
    • parent LTI tool
    • course
If the provider uses the same launch URL for several resources, Chamilo therefore treats each newly selected resource as the existing one and overwrites its title, description and custom parameters.
This affects LTI providers such as Edupool, where different videos can share the same launch endpoint.
**2.** **Fatal error when enabling or editing Deep Linking**
When editing a parent LTI tool, edit.php can try to update the corresponding course tool without first checking whether a CTool actually exists.
This can result in:
Argument 1 passed to ImsLtiPlugin::updateCourseTool()
must be an instance of Chamilo\CourseBundle\Entity\CTool, null given
The code now checks whether the course tool exists. If it does not, it creates it instead of calling updateCourseTool() with null.
**3.** **Incomplete LTI 1.1 Deep Linking request parameters**
The LTI 1.1 Deep Linking request did not fully describe the expected behaviour for multiple returned resources.
The request is now explicitly configured with:
accept_multiple = true
accept_unsigned = false
auto_create = false
The return URL also preserves the Chamilo course context required to process the returned resource correctly.
**4.** **Session loss during the cross-site Deep Linking return**
The Deep Linking response is sent back to Chamilo through a cross-site POST.
Depending on browser cookie handling, Chamilo may receive this POST without the active Chamilo session. The request is then rejected or the user is redirected to the Chamilo login page.
The return handling has therefore been made more robust by preserving the original Deep Linking POST and replaying it from the Chamilo context before processing the returned content.
**5.** **OAuth validation during the internal repost**
The cross-site session recovery mechanism uses an internal marker to distinguish a replayed request from the original POST.
This internal parameter must not participate in OAuth signature validation because it was not part of the request originally signed by the LTI provider.
The internal repost marker is therefore removed before OAuth verification so that the signature is calculated only from the original LTI parameters.
**6.** **Incorrect behaviour after successful resource selection**
After saving a returned resource, the previous implementation redirected back to:
ims_lti/start.php?id=...
This launches the LTI provider again and can make the provider page appear to reload immediately after a resource has been selected.
The return process now sends the user back to the Chamilo course and correctly handles the case where the LTI provider was opened in a separate window.
**7.** **LTI 1.3 Deep Linking return handling**
The corresponding LTI 1.3 return code has also received defensive improvements, including safer handling of unsupported or missing content-item objects.
These LTI 1.3 changes were syntax-checked but were not functionally tested with the Edupool integration, which uses LTI 1.1.

**Changes**
The following files are modified:
plugin/ims_lti/ImsLtiPlugin.php
plugin/ims_lti/edit.php
plugin/ims_lti/form.php
plugin/ims_lti/item_return.php
plugin/ims_lti/item_return2.php

**ImsLtiPlugin.php**
A Deep Linking selection now creates a new LTI resource instance instead of reusing an existing instance solely because the launch URL is identical.
This allows multiple resources from the same provider to coexist:
Same LTI provider
    ├── Resource A
    ├── Resource B
    ├── Resource C
    └── ...
even when all resources use the same launch URL.

**edit.php**
Checks whether the corresponding course tool exists before calling updateCourseTool().
If it does not exist, the course tool is created instead.

**form.php**
Improves the LTI 1.1 Deep Linking request by adding multiple-resource support and preserving the required Chamilo return context.

**item_return.php**
Improves LTI 1.1 Deep Linking return handling, cross-site session recovery, OAuth verification, and the final return to the Chamilo course.

**item_return2.php**
Applies corresponding defensive improvements to the LTI 1.3 Deep Linking return path.

**Reproduction before the fix**
    1. Configure an LTI 1.1 provider with Deep Linking.
    2. Add the provider to a course.
    3. Select a first video or resource.
    4. The resource appears as an LTI course tool.
    5. Open the provider again.
    6. Select a second video or resource using the same launch URL.

**Actual behaviour**
The second resource replaces the first one.
Depending on the Deep Linking workflow, additional problems may also occur:
    • fatal error when enabling or editing Deep Linking;
    • expired-session/login screen during the return;
    • access denied after selecting a resource;
    • provider page being launched again instead of returning to the course.

**Expected behaviour**
Every newly selected Deep Linking resource should create an independent LTI resource instance, even when several resources share the same launch URL.

**Tested behaviour after the fix**
Tested with:
Chamilo: 1.11.40
IMS/LTI plugin: 1.9.0
LTI version: 1.1
Deep Linking: enabled
Provider: Edupool / Schulmediathek Hamburg
Verified:
    • the LTI provider opens successfully;
    • resources can be selected through Deep Linking;
    • the return to Chamilo works;
    • multiple videos can be added successively;
    • previously added videos are no longer overwritten;
    • each video receives its own LTI course-tool instance;
    • no fatal error occurs when Deep Linking is enabled;
    • OAuth validation succeeds;
    • the user is returned to the Chamilo course after resource selection.
The server was configured according to the plugin README regarding cross-site cookies (SameSite=None; Secure).

**Relation to Moodle**
Moodle's LTI implementation was used as a functional reference for understanding the expected Deep Linking workflow, particularly:
    • treating separate Deep Linking selections as separate activity instances;
    • supporting multiple returned resources;
    • preserving context during the Deep Linking return;
    • handling cross-site POST/session behaviour.
The implementation in this PR was written for and adapted to Chamilo's own plugin architecture.

**Note regarding Chamilo 2**
The same underlying multiple-resource issue should also be reviewed in Chamilo 2.x.
Chamilo 2.0.3 uses a reorganized IMS/LTI plugin, but its resource-saving logic also searches existing LTI tools by launchUrl and course context. Providers using a common launch URL for several distinct resources may therefore be affected by the same underlying issue.
This PR targets Chamilo 1.11.40 / IMS-LTI 1.9.0 only. The changes should not be applied directly to Chamilo 2.x because the plugin architecture has changed. The corresponding logic should be reviewed and, where applicable, adapted separately for Chamilo 2.