### PR TITLE
Drop three isset blocks in api_get_user_info_from_entity that assign a key to itself

### DIFF
--- a/public/main/inc/lib/api.lib.php
+++ b/public/main/inc/lib/api.lib.php
@@ -1755,17 +1755,10 @@ function api_get_user_info_from_entity(
     if (isset($result['user_is_online'])) {
         $result['user_is_online'] = true == $result['user_is_online'] ? 1 : 0;
     }
-    if (isset($result['user_is_online_in_chat'])) {
-        $result['user_is_online_in_chat'] = $result['user_is_online_in_chat'];
-    }
 
     $result['password'] = '';
     if ($showPassword) {
         $result['password'] = $user->getPassword();
-    }
-
-    if (isset($result['profile_completed'])) {
-        $result['profile_completed'] = $result['profile_completed'];
     }
 
     $result['profile_url'] = api_get_path(WEB_CODE_PATH).'social/profile.php?u='.$user_id;
@@ -1777,10 +1770,6 @@ function api_get_user_info_from_entity(
         $sendMessage,
         ['class' => 'ajax']
     );
-
-    if (isset($result['extra'])) {
-        $result['extra'] = $result['extra'];
-    }
 
     return $result;
 }


### PR DESCRIPTION
`api_get_user_info_from_entity` has three `if (isset($result[X])) { $result[X] = $result[X]; }` blocks. Each reads the key and writes the same value back, so the guard and the body together do nothing at all.

The one worth a second look is `user_is_online_in_chat`, because the block directly above it is the same shape for `user_is_online` and does normalise the value to `1`/`0`. If both keys are supposed to reach the caller in the same form, then what is missing there is the cast, not the block, and I would rather you make that call than guess it. `profile_completed` and `extra` have no such neighbour, they look like leftovers.

I dropped all three, which keeps the returned array exactly as it is today. There are a few more of these in the legacy tree, I left them alone since they sit in unrelated files.
