### PR TITLE
AI tutor: add platform support mode

### DIFF
--- a/assets/vue/components/chat/DockedChat.vue
+++ b/assets/vue/components/chat/DockedChat.vue
@@ -62,9 +62,9 @@
               </button>
             </div>
 
-            <!-- AI Tutor quick entry (only when course context is available) -->
+            <!-- AI Tutor quick entry (course tutor or global Chamilo support) -->
             <div
-              v-if="inCourse && tutorCtx.enabled && !contactsHasAiTutor"
+              v-if="tutorCtx.enabled && !contactsHasAiTutor"
               class="chd-ai"
             >
               <button
@@ -158,7 +158,7 @@
                   >
                     <div
                       class="chd-bubble__content"
-                      v-html="renderMessage(msg.message)"
+                      v-html="renderMessage(msg)"
                     />
                     <div class="chd-bubble__meta">
                       <span class="chd-bubble__date">{{ formatTs(msg.date) }}</span>
@@ -459,10 +459,11 @@ const scrollBox = ref(null)
 /** Tutor context (backend-authoritative) */
 const tutorCtx = reactive({
   loaded: false,
-  enabled: false, // TRUE only when backend says enabled (course-aware)
+  enabled: false, // TRUE only when backend says enabled for the current context
   inTest: false,
   course: null, // { id, title, language }
   provider: "", // default provider key
+  mode: null, // "course" or "global"
 })
 
 /** Unread tracking */
@@ -531,7 +532,7 @@ function normalizeContactsHtmlForAiTutor(html) {
     )
     .forEach((n) => n.remove())
 
-  const shouldShowAi = !!tutorCtx.enabled && !!inCourse.value && !tutorCtx.inTest
+  const shouldShowAi = !!tutorCtx.enabled && !tutorCtx.inTest
 
   if (shouldShowAi) {
     const row = document.createElement("div")
@@ -622,11 +623,172 @@ function linkify(raw) {
 }
 
 /**
- * Render chat message safely for v-html.
- * Allow only <a> and <br> tags (chat messages are treated as plain text).
+ * Decode the HTML entities/line breaks produced by legacy chat storage back
+ * into plain text. The result is always escaped again before being rendered.
  */
-function renderMessage(rawMessage) {
-  const html = linkify(rawMessage)
+function normalizeStoredChatText(rawMessage) {
+  let text = String(rawMessage ?? "")
+
+  // Chat::sanitize() stores line breaks as <br>. Some AI providers can also
+  // escape the tag, so accept an optional leading backslash.
+  text = text.replace(/\\?<br\s*\/?>/gi, "\n")
+
+  // Messages coming from the legacy chat table have already passed through
+  // htmlspecialchars(). Decode once, then escape again in the renderer below.
+  const decoder = document.createElement("textarea")
+  decoder.innerHTML = text
+
+  return decoder.value
+}
+
+function safeHttpUrl(rawUrl) {
+  try {
+    const url = new URL(String(rawUrl || ""))
+    if (!/^https?:$/i.test(url.protocol)) return ""
+    return url.toString()
+  } catch {
+    return ""
+  }
+}
+
+/**
+ * Render the limited Markdown normally returned by AI providers.
+ * Raw HTML is never trusted: content is escaped first and DOMPurify remains
+ * the final safety boundary.
+ */
+function renderAiInlineMarkdown(rawText) {
+  let text = String(rawText ?? "")
+
+  // Providers occasionally escape Markdown punctuation (\*\*, \[, ...).
+  // Unescape it only for assistant messages so normal user chat stays literal.
+  text = text.replace(/\\([\\`*_[\]{}()#+\-.!>])/g, "$1")
+
+  const tokens = []
+  const token = (html) => {
+    const key = `\uE000${tokens.length}\uE001`
+    tokens.push(html)
+    return key
+  }
+
+  // Markdown links first so the URL is not picked up again by bare-link logic.
+  text = text.replace(/\[([^\]\n]+)\]\((https?:\/\/[^\s)]+)\)/g, (match, label, rawUrl) => {
+    const href = safeHttpUrl(rawUrl)
+    if (!href) return match
+
+    return token(
+      `<a href="${escapeForHtml(href)}" target="_blank" rel="noopener noreferrer">${escapeForHtml(label)}</a>`,
+    )
+  })
+
+  // Inline code.
+  text = text.replace(/`([^`\n]+)`/g, (match, code) => token(`<code>${escapeForHtml(code)}</code>`))
+
+  // Bare HTTP(S) URLs.
+  text = text.replace(/https?:\/\/[^\s<>"']+/g, (rawUrl) => {
+    const href = safeHttpUrl(rawUrl)
+    if (!href) return rawUrl
+
+    return token(
+      `<a href="${escapeForHtml(href)}" target="_blank" rel="noopener noreferrer">${escapeForHtml(rawUrl)}</a>`,
+    )
+  })
+
+  let html = escapeForHtml(text)
+
+  // Limited emphasis support. Keep this intentionally small and predictable.
+  html = html.replace(/\*\*([^*\n]+)\*\*/g, "<strong>$1</strong>")
+  html = html.replace(/__([^_\n]+)__/g, "<strong>$1</strong>")
+  html = html.replace(/(^|[^*])\*([^*\n]+)\*(?!\*)/g, "$1<em>$2</em>")
+  html = html.replace(/(^|[^_])_([^_\n]+)_(?!_)/g, "$1<em>$2</em>")
+
+  tokens.forEach((value, index) => {
+    html = html.replaceAll(`\uE000${index}\uE001`, value)
+  })
+
+  return html
+}
+
+function renderAiMarkdown(rawMessage) {
+  const text = normalizeStoredChatText(rawMessage)
+  const lines = text.split(/\n/)
+  const out = []
+  let listType = ""
+
+  const closeList = () => {
+    if (!listType) return
+    out.push(`</${listType}>`)
+    listType = ""
+  }
+
+  const openList = (type) => {
+    if (listType === type) return
+    closeList()
+    listType = type
+    out.push(`<${type}>`)
+  }
+
+  for (const rawLine of lines) {
+    const line = rawLine.trimEnd()
+
+    if (!line.trim()) {
+      closeList()
+      out.push("<br>")
+      continue
+    }
+
+    const heading = line.match(/^#{1,6}\s+(.+)$/)
+    if (heading) {
+      closeList()
+      out.push(`<strong>${renderAiInlineMarkdown(heading[1])}</strong><br>`)
+      continue
+    }
+
+    if (/^\s*---+\s*$/.test(line)) {
+      closeList()
+      out.push("<br>")
+      continue
+    }
+
+    const bullet = line.match(/^\s*[-*]\s+(.+)$/)
+    if (bullet) {
+      openList("ul")
+      out.push(`<li>${renderAiInlineMarkdown(bullet[1])}</li>`)
+      continue
+    }
+
+    const numbered = line.match(/^\s*\d+[.)]\s+(.+)$/)
+    if (numbered) {
+      openList("ol")
+      out.push(`<li>${renderAiInlineMarkdown(numbered[1])}</li>`)
+      continue
+    }
+
+    closeList()
+    out.push(`${renderAiInlineMarkdown(line)}<br>`)
+  }
+
+  closeList()
+
+  return DOMPurify.sanitize(out.join(""), {
+    ALLOWED_TAGS: ["a", "br", "strong", "em", "code", "ul", "ol", "li"],
+    ALLOWED_ATTR: ["href", "target", "rel"],
+    ADD_ATTR: ["target", "rel"],
+  })
+}
+
+/**
+ * Render chat messages safely for v-html.
+ * - Normal chat stays plain text with safe clickable links.
+ * - AI assistant messages get a small, sanitized Markdown renderer.
+ */
+function renderMessage(message) {
+  const fromId = Number(message?.from_user_info?.id ?? message?.f ?? 0)
+
+  if (fromId === AI_PEER_ID) {
+    return renderAiMarkdown(message?.message)
+  }
+
+  const html = linkify(normalizeStoredChatText(message?.message))
   return DOMPurify.sanitize(html, {
     ALLOWED_TAGS: ["a", "br"],
     ALLOWED_ATTR: ["href", "target", "rel"],
@@ -911,8 +1073,8 @@ function collectVisibleContactIds() {
   const root = document.querySelector(".chd .chd-contacts .chd-contacts-html")
   const ids = new Set()
 
-  // Only include AI Tutor when backend says it is enabled (course-aware).
-  if (tutorCtx.enabled && inCourse.value) ids.add(AI_PEER_ID)
+  // Include AI Tutor whenever the backend enables it for the current context.
+  if (tutorCtx.enabled) ids.add(AI_PEER_ID)
 
   if (root) {
     root
@@ -955,6 +1117,7 @@ async function loadTutorContext() {
   tutorCtx.inTest = false
   tutorCtx.course = null
   tutorCtx.provider = ""
+  tutorCtx.mode = null
 
   try {
     const r = await getJSON(API.tutor_context)
@@ -962,11 +1125,13 @@ async function loadTutorContext() {
     tutorCtx.inTest = !!r?.in_test
     tutorCtx.course = r?.course || null
     tutorCtx.provider = typeof r?.provider === "string" ? r.provider : ""
+    tutorCtx.mode = typeof r?.mode === "string" ? r.mode : null
   } catch {
     tutorCtx.enabled = false
     tutorCtx.inTest = false
     tutorCtx.course = null
     tutorCtx.provider = ""
+    tutorCtx.mode = null
   } finally {
     tutorCtx.loaded = true
   }
@@ -1080,8 +1245,8 @@ function resetAiThreadCache() {
 async function openConversation(peer) {
   const pid = Number(peer.id)
 
-  // Guard: AI Tutor must be course-only and enabled by backend.
-  if (pid === AI_PEER_ID && (!tutorCtx.enabled || !inCourse.value || tutorCtx.inTest)) return
+  // Backend decides whether the AI Tutor is available in course or global support mode.
+  if (pid === AI_PEER_ID && (!tutorCtx.enabled || tutorCtx.inTest)) return
 
   activePeer.value = {
     id: pid,
@@ -1377,7 +1542,7 @@ const sendDisabled = computed(() => {
   if (sending.value) return true
   if (userStatus.value !== 1) return true
   if (isAiThread.value && tutorCtx.inTest) return true
-  if (isAiThread.value && (!tutorCtx.enabled || !inCourse.value)) return true
+  if (isAiThread.value && !tutorCtx.enabled) return true
   return false
 })
 
@@ -1705,7 +1870,7 @@ async function send() {
 
   if (pid === AI_PEER_ID) {
     if (tutorCtx.inTest) return
-    if (!tutorCtx.enabled || !inCourse.value) return
+    if (!tutorCtx.enabled) return
   }
 
   const nowSec = Math.floor(Date.now() / 1000)
@@ -1774,7 +1939,7 @@ async function clearConversation() {
     const pid = activePeer.value.id
 
     if (Number(pid) === AI_PEER_ID) {
-      // Server reset for AI tutor (course-only)
+      // Server reset for the current AI tutor context.
       await post(API.tutor_reset, { ai_provider: tutorCtx.provider || "" })
       resetAiThreadCache()
       await getPreviousMessages()
@@ -1923,7 +2088,7 @@ async function onNavigationChanged() {
   }
 
   if (aiActive) {
-    if (!tutorCtx.enabled || !inCourse.value || tutorCtx.inTest) {
+    if (!tutorCtx.enabled || tutorCtx.inTest) {
       activePeer.value = null
       resetAiThreadCache()
       return

--- a/src/CoreBundle/AiProvider/AiTutorChatService.php
+++ b/src/CoreBundle/AiProvider/AiTutorChatService.php
@@ -12,6 +12,7 @@ use Chamilo\CoreBundle\Entity\Course;
 use Chamilo\CoreBundle\Entity\Session;
 use Chamilo\CoreBundle\Entity\User;
 use Chamilo\CoreBundle\Repository\AiTutorConversationRepository;
+use Chamilo\CourseBundle\Repository\CCourseDescriptionRepository;
 use DateTime;
 use Doctrine\ORM\EntityManagerInterface;
 use InvalidArgumentException;
@@ -36,12 +37,14 @@ final class AiTutorChatService
 
     private const string DEFAULT_PROVIDER = 'openai';
     private const string ACTIVE_PROVIDER_SESSION_PREFIX = 'ai_tutor_active_provider_';
+    public const string OFFICIAL_DOCUMENTATION_URL = 'https://docs.chamilo.org';
 
     public function __construct(
         private readonly RequestStack $requestStack,
         private readonly AiProviderFactory $aiProviderFactory,
         private readonly EntityManagerInterface $em,
         private readonly AiTutorConversationRepository $conversationRepo,
+        private readonly CCourseDescriptionRepository $courseDescriptionRepository,
         private readonly AiChatCompletionClientInterface $client,
         private readonly LoggerInterface $logger
     ) {}
@@ -195,7 +198,7 @@ final class AiTutorChatService
         string $newUserMessage,
         string $selectedTextContext = ''
     ): array {
-        $system = $this->buildSystemPrompt($course);
+        $system = $this->buildContextSystemPrompt($course);
 
         $providerMessages = [];
         $providerMessages[] = ['role' => 'system', 'content' => $system];
@@ -598,20 +601,70 @@ final class AiTutorChatService
             // ignore
         }
 
-        return "You are a digital tutor and mentor inside Chamilo. Answer in the user's language.";
+        return $this->buildContextSystemPrompt(null, $uiLang);
     }
 
-    private function buildSystemPrompt(Course $course, string $courseLanguage = ''): string
+    /**
+     * Build the AI Tutor system prompt for course and global support modes.
+     *
+     * The wording is provided by the product owner. Course mode also appends the
+     * course description sections as plain-text context.
+     */
+    public function buildContextSystemPrompt(?Course $course, string $courseLanguage = ''): string
     {
-        $title = (string) ($course->getTitle() ?: 'this course');
         $lang = trim($courseLanguage);
+        $documentationUrl = self::OFFICIAL_DOCUMENTATION_URL.'/';
 
-        return "You are a digital tutor and mentor. You help me understand topics related to my courses, in this case '{$title}'. "
-            .($lang ? "The course is in '{$lang}' but just answer me in whatever language I talk to you. " : 'Just answer me in whatever language I talk to you. ')
+        if ($course instanceof Course) {
+            if ('' === $lang && method_exists($course, 'getCourseLanguage')) {
+                $lang = trim((string) ($course->getCourseLanguage() ?? ''));
+            }
+
+            $title = (string) ($course->getTitle() ?: 'this course');
+            $description = $this->buildCourseDescriptionContext($course);
+
+            return "You are a digital tutor and mentor. You help me understand topics related to my course titled <title>'{$title}'</title> with the following description: <description>{$description}</description>. "
+                ."The course is in '{$lang}' but just answer me in whatever language I talk to you. "
+                .'This is an educational use, so content that would not be appropriate for children (or minors under any law) is not acceptable. '
+                ."You are not available to me when I'm taking an exam, just in case I forget and I ask why you weren't there. "
+                .'You must mention the course title when greeting or when the user asks what you are. '
+                .'If the user asks something unrelated to the course topic or the use of the platform, politely redirect to course-related or platform-related help. '
+                ."For information about the use of the platform, use the documentation at {$documentationUrl}. "
+                ."If you don't know, say so, don't halucinate on topics you don't know. "
+                .'Provide references to the documentation if useful (for illustrations, for example).';
+        }
+
+        return 'You are a patient technical support assistant specialised in the use of Chamilo as an e-learning platform. '
+            .'Answer questions the user might have about the user of the platform. '
+            ."For information about the use of the platform, use the documentation at {$documentationUrl}. "
             .'This is an educational use, so content that would not be appropriate for children (or minors under any law) is not acceptable. '
-            ."You are not available to me when I'm taking an exam, just in case I forget and I ask why you weren't there. "
-            .'You must mention the course title when greeting or when the user asks what you are. '
-            .'If the user asks something unrelated to the course topic, politely redirect to course-related help.';
+            ."If you don't know, say so, don't halucinate on topics you don't know. "
+            .'Provide references to the documentation if useful (for illustrations, for example). '
+            .'If the user asks something unrelated to the topic of use of the platform, politely redirect to platform-related help.';
+    }
+
+    private function buildCourseDescriptionContext(Course $course): string
+    {
+        $sections = $this->courseDescriptionRepository->findAllInCourse($course);
+        $parts = [];
+
+        foreach ($sections as $section) {
+            $title = trim(strip_tags((string) $section->getTitle()));
+            $content = trim(strip_tags((string) $section->getContent()));
+
+            if ('' === $title && '' === $content) {
+                continue;
+            }
+
+            $text = '' !== $title && '' !== $content
+                ? $title.': '.$content
+                : ($title ?: $content);
+
+            $text = preg_replace('/\s+/u', ' ', $text) ?? $text;
+            $parts[] = trim($text);
+        }
+
+        return implode(' | ', $parts);
     }
 
     private function renderEmptyState(): string

--- a/src/CoreBundle/Controller/ChatController.php
+++ b/src/CoreBundle/Controller/ChatController.php
@@ -8,6 +8,7 @@ namespace Chamilo\CoreBundle\Controller;
 
 use Chamilo\CoreBundle\AiProvider\AiProviderFactory;
 use Chamilo\CoreBundle\AiProvider\AiTutorChatService;
+use Chamilo\CoreBundle\Entity\Chat as ChatEntity;
 use Chamilo\CoreBundle\Entity\Course;
 use Chamilo\CoreBundle\Helpers\AiFeatureAccessHelper;
 use Chamilo\CoreBundle\Helpers\CidReqHelper;
@@ -27,6 +28,7 @@ use Chat;
 use CourseChatUtils;
 use DateTimeImmutable;
 use DateTimeZone;
+use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\Persistence\ManagerRegistry;
 use Event;
 use Security;
@@ -457,8 +459,15 @@ final class ChatController extends AbstractController
 
         if (AiTutorChatService::FRIEND_AI === $peerId) {
             $course = $this->resolveCourseFromRequest($req, $doctrine);
+
             if (null === $course) {
-                return new JsonResponse([]);
+                if (!$this->aiFeatureAccessHelper->isFeatureEnabledAtPlatform('tutor_chatbot')) {
+                    return new JsonResponse([]);
+                }
+
+                return new JsonResponse(
+                    $this->getGlobalAiChatMessagesSince($doctrine, (int) $me, max(0, $sinceId), 80)
+                );
             }
 
             $courseSettingsManager->setCourse($course);
@@ -487,25 +496,9 @@ final class ChatController extends AbstractController
                     'recd' => 2,
                     'from_user_info' => ('user' === $role)
                         ? api_get_user_info((int) $me, true)
-                        : [
-                            'id' => AiTutorChatService::FRIEND_AI,
-                            'user_id' => AiTutorChatService::FRIEND_AI,
-                            'complete_name' => 'AI Tutor',
-                            'user_is_online_in_chat' => 1,
-                            'user_is_online' => 1,
-                            'online' => 1,
-                            'avatar_small' => '',
-                        ],
+                        : $this->getAiTutorUserInfo(),
                     'to_user_info' => ('user' === $role)
-                        ? [
-                            'id' => AiTutorChatService::FRIEND_AI,
-                            'user_id' => AiTutorChatService::FRIEND_AI,
-                            'complete_name' => 'AI Tutor',
-                            'user_is_online_in_chat' => 1,
-                            'user_is_online' => 1,
-                            'online' => 1,
-                            'avatar_small' => '',
-                        ]
+                        ? $this->getAiTutorUserInfo()
                         : api_get_user_info((int) $me, true),
                     'f' => $fromId,
                 ];
@@ -539,8 +532,7 @@ final class ChatController extends AbstractController
         LanguageHelper $languageHelper,
         AiProviderFactory $aiProviderFactory,
         ChatRepository $chatRepository,
-        ManagerRegistry $doctrine,
-        SettingsCourseManager $courseSettingsManager
+        ManagerRegistry $doctrine
     ): JsonResponse {
         $me = $this->getCurrentUserIdOrNull();
         if (null === $me) {
@@ -571,53 +563,56 @@ final class ChatController extends AbstractController
                 (string) $req->request->get('selected_text', '')
             );
 
-            // AI tutor must be available only inside a course.
             $course = $this->resolveCourseFromRequest($req, $doctrine);
+            $mode = null === $course ? 'global' : 'course';
+
             if (null === $course) {
+                if (!$this->aiFeatureAccessHelper->isFeatureEnabledAtPlatform('tutor_chatbot')) {
+                    return new JsonResponse([
+                        'error' => 'ai_not_enabled_at_platform',
+                        'message' => 'AI tutor is not enabled at platform level.',
+                    ], 403);
+                }
+            } elseif (!$this->aiFeatureAccessHelper->isFeatureEnabledForCourse(
+                'tutor_chatbot',
+                (int) $course->getId()
+            )) {
                 return new JsonResponse([
-                    'error' => 'ai_requires_course_context',
-                    'message' => 'AI tutor is only available inside a course.',
-                ], 403);
-            }
-
-            // Check course setting (teacher can disable it per course).
-            $courseSettingsManager->setCourse($course);
-            $courseSettingValue = (string) $courseSettingsManager->getCourseSettingValue('tutor_chatbot');
-
-            if (!$this->aiFeatureAccessHelper->isFeatureEnabledForCourse('tutor_chatbot', (int) $course->getId())) {
-                return new JsonResponse([
-                    'error' => 'disabled_by_course_setting',
+                    'error' => 'ai_disabled_for_course',
                     'message' => 'AI tutor is disabled for this course.',
                 ], 403);
             }
 
             $uiLang = $languageHelper->getInterfaceIso();
-            $courseTitle = (string) $course->getTitle();
-            $courseLang = $uiLang ?: 'en';
-
-            $tmpLang = '';
-            if (method_exists($course, 'getCourseLanguage')) {
-                $tmpLang = (string) ($course->getCourseLanguage() ?? '');
-            }
-            if ('' === $tmpLang && method_exists($course, 'getLanguage')) {
-                $tmpLang = (string) ($course->getLanguage() ?? '');
-            }
-            if ('' !== $tmpLang) {
-                $courseLang = $tmpLang;
-            }
-
+            $contextLanguage = $uiLang ?: 'en';
             $ctx = [
-                'mode' => 'course',
-                'course_id' => (int) ($course->getId() ?? 0),
-                'title' => $courseTitle,
-                'lang' => $courseLang ?: 'en',
+                'mode' => $mode,
+                'course_id' => 0,
+                'title' => 'Chamilo',
+                'lang' => $contextLanguage,
             ];
 
-            // Store context + strict system prompt in session for the AI layer.
+            if ($course instanceof Course) {
+                $courseLanguage = $this->resolveCourseLanguage($course);
+                if ('' !== $courseLanguage) {
+                    $contextLanguage = $courseLanguage;
+                }
+
+                $ctx = [
+                    'mode' => 'course',
+                    'course_id' => (int) $course->getId(),
+                    'title' => (string) $course->getTitle(),
+                    'lang' => $contextLanguage ?: 'en',
+                ];
+            }
+
             try {
                 if ($req->hasSession()) {
                     $req->getSession()->set('ai_tutor_context', $ctx);
-                    $req->getSession()->set('ai_tutor_system_prompt', $this->buildAiTutorSystemPrompt($ctx));
+                    $req->getSession()->set(
+                        'ai_tutor_system_prompt',
+                        $aiTutorChatService->buildContextSystemPrompt($course, (string) $ctx['lang'])
+                    );
                 }
             } catch (Throwable) {
                 // Best effort: ignore session storage failures.
@@ -656,7 +651,8 @@ final class ChatController extends AbstractController
                     $chatRepository,
                     (int) $me,
                     (int) $userMsgId,
-                    $nowTs
+                    $nowTs,
+                    $mode
                 );
             }
 
@@ -692,7 +688,8 @@ final class ChatController extends AbstractController
                     $chatRepository,
                     (int) $me,
                     (int) $userMsgId,
-                    $nowTs
+                    $nowTs,
+                    $mode
                 );
             }
 
@@ -705,7 +702,8 @@ final class ChatController extends AbstractController
                     $chatRepository,
                     (int) $me,
                     (int) $userMsgId,
-                    $nowTs
+                    $nowTs,
+                    $mode
                 );
             }
 
@@ -718,7 +716,8 @@ final class ChatController extends AbstractController
                     $chatRepository,
                     (int) $me,
                     (int) $userMsgId,
-                    $nowTs
+                    $nowTs,
+                    $mode
                 );
             }
 
@@ -750,7 +749,7 @@ final class ChatController extends AbstractController
                     ],
                     'to_user_info' => api_get_user_info((int) $me, true),
                 ],
-                'mode' => 'course',
+                'mode' => $mode,
             ]);
         }
 
@@ -797,13 +796,19 @@ final class ChatController extends AbstractController
 
         $course = $this->resolveCourseFromRequest($req, $doctrine);
         if (null === $course) {
-            return new JsonResponse(['error' => 'not_in_course'], 403);
+            if (!$this->aiFeatureAccessHelper->isFeatureEnabledAtPlatform('tutor_chatbot')) {
+                return new JsonResponse(['error' => 'ai_not_enabled_at_platform'], 403);
+            }
+
+            $deleted = $this->clearGlobalAiChatConversation($doctrine, (int) $me);
+
+            return new JsonResponse(['ok' => true, 'deleted' => $deleted, 'mode' => 'global']);
         }
 
         $courseSettingsManager->setCourse($course);
         $courseSettingValue = (string) $courseSettingsManager->getCourseSettingValue('tutor_chatbot');
         if (!$this->aiFeatureAccessHelper->isFeatureEnabledForCourse('tutor_chatbot', (int) $course->getId())) {
-            return new JsonResponse(['error' => 'disabled_by_course_setting'], 403);
+            return new JsonResponse(['error' => 'ai_disabled_for_course'], 403);
         }
 
         $requestedProvider = trim((string) $req->request->get('ai_provider', ''));
@@ -815,7 +820,7 @@ final class ChatController extends AbstractController
 
         $aiTutorChatService->resetConversation((int) $me, $course, null, $providerKey);
 
-        return new JsonResponse(['ok' => true]);
+        return new JsonResponse(['ok' => true, 'mode' => 'course']);
     }
 
     private function normalizeAiSelectedTextContext(string $text): string
@@ -896,10 +901,16 @@ final class ChatController extends AbstractController
         $visible = (int) $req->query->get('visible_messages', '0');
 
         if (AiTutorChatService::FRIEND_AI === $peerId) {
-            // Course-only AI tutor history
             $course = $this->resolveCourseFromRequest($req, $doctrine);
+
             if (null === $course) {
-                return new JsonResponse([]);
+                if (!$this->aiFeatureAccessHelper->isFeatureEnabledAtPlatform('tutor_chatbot')) {
+                    return new JsonResponse([]);
+                }
+
+                return new JsonResponse(
+                    $this->getGlobalAiChatMessagesPage($doctrine, (int) $me, max(0, $visible), 20)
+                );
             }
 
             $courseSettingsManager->setCourse($course);
@@ -928,25 +939,9 @@ final class ChatController extends AbstractController
                     'recd' => 2,
                     'from_user_info' => ('user' === $role)
                         ? api_get_user_info((int) $me, true)
-                        : [
-                            'id' => AiTutorChatService::FRIEND_AI,
-                            'user_id' => AiTutorChatService::FRIEND_AI,
-                            'complete_name' => 'AI Tutor',
-                            'user_is_online_in_chat' => 1,
-                            'user_is_online' => 1,
-                            'online' => 1,
-                            'avatar_small' => '',
-                        ],
+                        : $this->getAiTutorUserInfo(),
                     'to_user_info' => ('user' === $role)
-                        ? [
-                            'id' => AiTutorChatService::FRIEND_AI,
-                            'user_id' => AiTutorChatService::FRIEND_AI,
-                            'complete_name' => 'AI Tutor',
-                            'user_is_online_in_chat' => 1,
-                            'user_is_online' => 1,
-                            'online' => 1,
-                            'avatar_small' => '',
-                        ]
+                        ? $this->getAiTutorUserInfo()
                         : api_get_user_info((int) $me, true),
                     'f' => $fromId,
                 ];
@@ -1031,17 +1026,26 @@ final class ChatController extends AbstractController
             return new JsonResponse(['ok' => false, 'error' => 'bad_params'], 400);
         }
 
-        // AI Tutor ack uses session last-seen (course-scoped)
         if (AiTutorChatService::FRIEND_AI === $peerId) {
             $course = $this->resolveCourseFromRequest($req, $doctrine);
             if (null === $course) {
-                return new JsonResponse(['ok' => false, 'error' => 'ai_requires_course'], 403);
+                if (!$this->aiFeatureAccessHelper->isFeatureEnabledAtPlatform('tutor_chatbot')) {
+                    return new JsonResponse(['ok' => false, 'error' => 'ai_not_enabled_at_platform'], 403);
+                }
+
+                $updated = $this->ackGlobalAiChatMessages($doctrine, (int) $me, $lastSeenId);
+
+                return new JsonResponse(['ok' => true, 'updated' => $updated, 'mode' => 'global']);
+            }
+
+            if (!$this->aiFeatureAccessHelper->isFeatureEnabledForCourse('tutor_chatbot', (int) $course->getId())) {
+                return new JsonResponse(['ok' => false, 'error' => 'ai_disabled_for_course'], 403);
             }
 
             $provider = trim((string) $req->request->get('ai_provider', ''));
             $updated = $aiTutorChatService->ackTutorReadUpTo((int) $me, $course, $provider, $lastSeenId);
 
-            return new JsonResponse(['ok' => true, 'updated' => $updated]);
+            return new JsonResponse(['ok' => true, 'updated' => $updated, 'mode' => 'course']);
         }
 
         if ($peerId <= 0) {
@@ -1069,7 +1073,9 @@ final class ChatController extends AbstractController
     )]
     public function globalTutorContext(
         Request $req,
+        AiTutorChatService $aiTutorChatService,
         AiProviderFactory $aiProviderFactory,
+        LanguageHelper $languageHelper,
         SettingsCourseManager $courseSettingsManager,
         ManagerRegistry $doctrine
     ): JsonResponse {
@@ -1081,7 +1087,6 @@ final class ChatController extends AbstractController
         $inTest = !empty($_SESSION['is_in_a_test']);
 
         if (!$this->isGlobalChatEnabled()) {
-            // Return 200 with a normalized payload to avoid frontend exceptions.
             return new JsonResponse([
                 'enabled' => false,
                 'in_test' => $inTest,
@@ -1093,66 +1098,74 @@ final class ChatController extends AbstractController
         }
 
         $providers = $aiProviderFactory->getProvidersForType('text');
-        $hasTextProvider = !empty($providers);
         $course = $this->resolveCourseFromRequest($req, $doctrine);
+        $mode = null === $course ? 'global' : 'course';
+        $coursePayload = null;
+        $contextLanguage = $languageHelper->getInterfaceIso() ?: $req->getLocale() ?: 'en';
+        $courseSettingValue = '';
+
+        if ($course instanceof Course) {
+            $courseLanguage = $this->resolveCourseLanguage($course);
+            if ('' !== $courseLanguage) {
+                $contextLanguage = $courseLanguage;
+            }
+
+            $coursePayload = [
+                'id' => (int) $course->getId(),
+                'title' => (string) $course->getTitle(),
+                'language' => $contextLanguage ?: 'en',
+            ];
+
+            $courseSettingsManager->setCourse($course);
+            $courseSettingValue = (string) $courseSettingsManager->getCourseSettingValue('tutor_chatbot');
+
+            if (!$this->aiFeatureAccessHelper->isFeatureEnabledForCourse(
+                'tutor_chatbot',
+                (int) $course->getId()
+            )) {
+                return new JsonResponse([
+                    'enabled' => false,
+                    'in_test' => $inTest,
+                    'course' => $coursePayload,
+                    'mode' => 'course',
+                    'provider' => null,
+                    'reason' => 'disabled_for_course',
+                ]);
+            }
+        } elseif (!$this->aiFeatureAccessHelper->isFeatureEnabledAtPlatform('tutor_chatbot')) {
+            $reason = AiFeatureAccessHelper::MODE_PLUGIN_DEFINED === $this->aiFeatureAccessHelper->getFeatureMode('tutor_chatbot')
+                ? 'plugin_defined_requires_course'
+                : 'not_enabled_at_platform';
+
+            return new JsonResponse([
+                'enabled' => false,
+                'in_test' => $inTest,
+                'course' => null,
+                'mode' => 'global',
+                'provider' => null,
+                'reason' => $reason,
+            ]);
+        }
 
         if ($this->isAiTutorTemporarilyUnavailable($req)) {
             return new JsonResponse([
                 'enabled' => false,
                 'in_test' => $inTest,
-                'course' => null !== $course ? [
-                    'id' => (int) $course->getId(),
-                    'title' => (string) $course->getTitle(),
-                    'language' => $this->resolveCourseLanguage($course) ?: 'en',
-                ] : null,
-                'mode' => null !== $course ? 'course' : null,
+                'course' => $coursePayload,
+                'mode' => $mode,
                 'provider' => null,
                 'reason' => 'temporarily_unavailable',
             ]);
         }
 
-        if (!$hasTextProvider) {
+        if (empty($providers)) {
             return new JsonResponse([
                 'enabled' => false,
                 'in_test' => $inTest,
-                'course' => null,
-                'mode' => null,
+                'course' => $coursePayload,
+                'mode' => $mode,
                 'provider' => null,
                 'reason' => 'no_text_provider',
-            ]);
-        }
-
-        if (null === $course) {
-            return new JsonResponse([
-                'enabled' => false,
-                'in_test' => $inTest,
-                'course' => null,
-                'mode' => null,
-                'provider' => null,
-                'reason' => 'not_in_course',
-            ]);
-        }
-
-        // Check course setting (teacher can disable it per course)
-        $courseSettingsManager->setCourse($course);
-        $courseSettingValue = (string) $courseSettingsManager->getCourseSettingValue('tutor_chatbot');
-
-        $courseTutorEnabled = $this->aiFeatureAccessHelper->isFeatureEnabledForCourse(
-            'tutor_chatbot',
-            (int) $course->getId()
-        );
-        if (!$courseTutorEnabled) {
-            return new JsonResponse([
-                'enabled' => false,
-                'in_test' => $inTest,
-                'course' => [
-                    'id' => (int) $course->getId(),
-                    'title' => (string) $course->getTitle(),
-                    'language' => $this->resolveCourseLanguage($course) ?: 'en',
-                ],
-                'mode' => 'course',
-                'provider' => null,
-                'reason' => 'disabled_by_course_setting',
             ]);
         }
 
@@ -1160,34 +1173,32 @@ final class ChatController extends AbstractController
             return new JsonResponse([
                 'enabled' => false,
                 'in_test' => true,
-                'course' => [
-                    'id' => (int) $course->getId(),
-                    'title' => (string) $course->getTitle(),
-                    'language' => $this->resolveCourseLanguage($course) ?: 'en',
-                ],
-                'mode' => 'course',
+                'course' => $coursePayload,
+                'mode' => $mode,
                 'provider' => null,
                 'reason' => 'disabled_in_exam',
             ]);
         }
 
-        // Use course setting as provider if possible, fallback to first available provider.
         $providerKey = $this->resolveTextProviderKey($courseSettingValue, $aiProviderFactory);
         if (null === $providerKey) {
             $providerKey = $providers[0] ?? null;
         }
 
         $ctx = [
-            'mode' => 'course',
-            'course_id' => (int) $course->getId(),
-            'title' => (string) $course->getTitle(),
-            'lang' => $this->resolveCourseLanguage($course) ?: 'en',
+            'mode' => $mode,
+            'course_id' => $course instanceof Course ? (int) $course->getId() : 0,
+            'title' => $course instanceof Course ? (string) $course->getTitle() : 'Chamilo',
+            'lang' => $contextLanguage ?: 'en',
         ];
 
         try {
             if ($req->hasSession()) {
                 $req->getSession()->set('ai_tutor_context', $ctx);
-                $req->getSession()->set('ai_tutor_system_prompt', $this->buildAiTutorSystemPrompt($ctx));
+                $req->getSession()->set(
+                    'ai_tutor_system_prompt',
+                    $aiTutorChatService->buildContextSystemPrompt($course, (string) $ctx['lang'])
+                );
             }
         } catch (Throwable) {
             // Best effort: ignore session storage failures.
@@ -1196,41 +1207,186 @@ final class ChatController extends AbstractController
         return new JsonResponse([
             'enabled' => true,
             'in_test' => false,
-            'course' => [
-                'id' => $ctx['course_id'],
-                'title' => $ctx['title'],
-                'language' => $ctx['lang'],
-            ],
-            'mode' => 'course',
+            'course' => $coursePayload,
+            'mode' => $mode,
             'provider' => $providerKey,
             'reason' => null,
         ]);
     }
 
-    private function buildAiTutorSystemPrompt(array $ctx): string
-    {
-        $title = (string) ($ctx['title'] ?? 'Global');
-        $lang = (string) ($ctx['lang'] ?? 'en');
-        $mode = (string) ($ctx['mode'] ?? 'global');
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    private function getGlobalAiChatMessagesPage(
+        ManagerRegistry $doctrine,
+        int $userId,
+        int $visible,
+        int $pageSize = 20
+    ): array {
+        $repository = $doctrine->getRepository(ChatEntity::class);
+        $total = (int) $repository->createQueryBuilder('chat')
+            ->select('COUNT(chat.id)')
+            ->andWhere(
+                '(chat.fromUser = :userId AND chat.toUser = :aiId) OR '
+                .'(chat.fromUser = :aiId AND chat.toUser = :userId)'
+            )
+            ->setParameter('userId', $userId)
+            ->setParameter('aiId', AiTutorChatService::FRIEND_AI)
+            ->getQuery()
+            ->getSingleScalarResult()
+        ;
 
-        if ('course' === $mode) {
-            return \sprintf(
-                "You are a digital tutor and mentor. You help the user understand topics related to their course '%s'. ".
-                "When greeting OR when the user asks what you are, you MUST mention the course title '%s'. ".
-                "The course is in '%s' but you must answer in whatever language the user speaks. ".
-                'This is educational use. Content that is not appropriate for minors is not acceptable. '.
-                'You are not available during exams.',
-                $title,
-                $title,
-                $lang
-            );
+        if ($total <= 0) {
+            return [];
         }
 
-        return
-            'You are a digital tutor and mentor inside Chamilo. You help the user with learning and studying in general. '.
-            'You must answer in whatever language the user speaks. '.
-            'This is educational use. Content that is not appropriate for minors is not acceptable. '.
-            'You are not available during exams.';
+        $visible = max(0, $visible);
+        $pageSize = max(1, $pageSize);
+        $end = max(0, $total - $visible);
+        $start = max(0, $end - $pageSize);
+        $length = max(0, $end - $start);
+
+        if ($length <= 0) {
+            return [];
+        }
+
+        /** @var ChatEntity[] $messages */
+        $messages = $repository->createQueryBuilder('chat')
+            ->andWhere(
+                '(chat.fromUser = :userId AND chat.toUser = :aiId) OR '
+                .'(chat.fromUser = :aiId AND chat.toUser = :userId)'
+            )
+            ->setParameter('userId', $userId)
+            ->setParameter('aiId', AiTutorChatService::FRIEND_AI)
+            ->orderBy('chat.id', 'ASC')
+            ->setFirstResult($start)
+            ->setMaxResults($length)
+            ->getQuery()
+            ->getResult()
+        ;
+
+        return array_map(
+            fn (ChatEntity $message): array => $this->mapGlobalAiChatMessage($message, $userId),
+            $messages
+        );
+    }
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    private function getGlobalAiChatMessagesSince(
+        ManagerRegistry $doctrine,
+        int $userId,
+        int $sinceId,
+        int $limit = 80
+    ): array {
+        /** @var ChatEntity[] $messages */
+        $messages = $doctrine->getRepository(ChatEntity::class)
+            ->createQueryBuilder('chat')
+            ->andWhere(
+                '((chat.fromUser = :userId AND chat.toUser = :aiId) OR '
+                .'(chat.fromUser = :aiId AND chat.toUser = :userId))'
+            )
+            ->andWhere('chat.id > :sinceId')
+            ->setParameter('userId', $userId)
+            ->setParameter('aiId', AiTutorChatService::FRIEND_AI)
+            ->setParameter('sinceId', max(0, $sinceId))
+            ->orderBy('chat.id', 'ASC')
+            ->setMaxResults(max(1, $limit))
+            ->getQuery()
+            ->getResult()
+        ;
+
+        return array_map(
+            fn (ChatEntity $message): array => $this->mapGlobalAiChatMessage($message, $userId),
+            $messages
+        );
+    }
+
+    private function ackGlobalAiChatMessages(ManagerRegistry $doctrine, int $userId, int $lastSeenId): int
+    {
+        $entityManager = $doctrine->getManagerForClass(ChatEntity::class);
+        if (!$entityManager instanceof EntityManagerInterface) {
+            return 0;
+        }
+
+        return (int) $entityManager
+            ->createQueryBuilder()
+            ->update(ChatEntity::class, 'chat')
+            ->set('chat.recd', ':readStatus')
+            ->andWhere('chat.fromUser = :aiId')
+            ->andWhere('chat.toUser = :userId')
+            ->andWhere('chat.id <= :lastSeenId')
+            ->andWhere('chat.recd < :readStatus')
+            ->setParameter('readStatus', 2)
+            ->setParameter('aiId', AiTutorChatService::FRIEND_AI)
+            ->setParameter('userId', $userId)
+            ->setParameter('lastSeenId', max(0, $lastSeenId))
+            ->getQuery()
+            ->execute()
+        ;
+    }
+
+    private function clearGlobalAiChatConversation(ManagerRegistry $doctrine, int $userId): int
+    {
+        $entityManager = $doctrine->getManagerForClass(ChatEntity::class);
+        if (!$entityManager instanceof EntityManagerInterface) {
+            return 0;
+        }
+
+        return (int) $entityManager
+            ->createQueryBuilder()
+            ->delete(ChatEntity::class, 'chat')
+            ->andWhere(
+                '(chat.fromUser = :userId AND chat.toUser = :aiId) OR '
+                .'(chat.fromUser = :aiId AND chat.toUser = :userId)'
+            )
+            ->setParameter('userId', $userId)
+            ->setParameter('aiId', AiTutorChatService::FRIEND_AI)
+            ->getQuery()
+            ->execute()
+        ;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function mapGlobalAiChatMessage(ChatEntity $message, int $userId): array
+    {
+        $fromId = (int) ($message->getFromUser() ?? 0);
+        $toId = (int) ($message->getToUser() ?? 0);
+        $fromUserInfo = AiTutorChatService::FRIEND_AI === $fromId
+            ? $this->getAiTutorUserInfo()
+            : api_get_user_info($userId, true);
+        $toUserInfo = AiTutorChatService::FRIEND_AI === $toId
+            ? $this->getAiTutorUserInfo()
+            : api_get_user_info($userId, true);
+
+        return [
+            'id' => (int) $message->getId(),
+            'message' => Security::remove_XSS((string) $message->getMessage()),
+            'date' => (int) $message->getSent()->getTimestamp(),
+            'recd' => (int) $message->getRecd(),
+            'from_user_info' => $fromUserInfo,
+            'to_user_info' => $toUserInfo,
+            'f' => $fromId,
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function getAiTutorUserInfo(): array
+    {
+        return [
+            'id' => AiTutorChatService::FRIEND_AI,
+            'user_id' => AiTutorChatService::FRIEND_AI,
+            'complete_name' => 'AI Tutor',
+            'user_is_online_in_chat' => 1,
+            'user_is_online' => 1,
+            'online' => 1,
+            'avatar_small' => '',
+        ];
     }
 
     /**
@@ -1456,7 +1612,8 @@ final class ChatController extends AbstractController
         ChatRepository $chatRepository,
         int $userId,
         int $userMessageId,
-        int $timestamp
+        int $timestamp,
+        string $mode = 'course'
     ): JsonResponse {
         $assistantSanitized = $chat->sanitize(self::AI_TUTOR_UNAVAILABLE_MESSAGE);
         $assistantId = $chatRepository->insertChatRow(
@@ -1485,7 +1642,7 @@ final class ChatController extends AbstractController
                 ],
                 'to_user_info' => api_get_user_info($userId, true),
             ],
-            'mode' => 'course',
+            'mode' => $mode,
             'degraded' => true,
             'temporarily_unavailable' => true,
         ]);

--- a/src/CoreBundle/Helpers/AiFeatureAccessHelper.php
+++ b/src/CoreBundle/Helpers/AiFeatureAccessHelper.php
@@ -41,6 +41,12 @@ final readonly class AiFeatureAccessHelper
 
         $mode = $this->getFeatureMode($feature);
 
+        // The tutor chatbot becomes platform-controlled when globally enabled.
+        // Keep the course switch only for plugin-defined (BuyCourses) mode.
+        if ('tutor_chatbot' === $feature && self::MODE_ENABLED === $mode) {
+            return false;
+        }
+
         if (self::MODE_ENABLED === $mode) {
             return true;
         }
@@ -54,6 +60,18 @@ final readonly class AiFeatureAccessHelper
 
     public function isFeatureEnabledForCourse(string $feature, int $courseId): bool
     {
+        if (!$this->isSupportedFeature($feature) || $courseId <= 0 || !$this->isMasterEnabled()) {
+            return false;
+        }
+
+        $mode = $this->getFeatureMode($feature);
+
+        // When the tutor is enabled at platform level, it is enabled in every course.
+        // plugin_defined intentionally keeps the existing per-course BuyCourses behavior.
+        if ('tutor_chatbot' === $feature && self::MODE_ENABLED === $mode) {
+            return true;
+        }
+
         if (!$this->isFeatureConfigurableForCourse($feature, $courseId)) {
             return false;
         }
@@ -63,6 +81,13 @@ final readonly class AiFeatureAccessHelper
             ['real_id' => $courseId],
             true
         );
+    }
+
+    public function isFeatureEnabledAtPlatform(string $feature): bool
+    {
+        return $this->isSupportedFeature($feature)
+            && $this->isMasterEnabled()
+            && self::MODE_ENABLED === $this->getFeatureMode($feature);
     }
 
     public function getFeatureMode(string $feature): string


### PR DESCRIPTION
Make the AI Tutor available globally when enabled at platform level, keep course tutor + Chamilo support mode inside courses, add support-only mode outside courses, preserve BuyCourses plugin-defined behavior, use the final course/global system prompts and course description context, and render AI Markdown responses safely.