### PR TITLE
Internal: Fix pre-Chamilo 3 content regressions

### DIFF
--- a/assets/vue/components/basecomponents/ChamiloIcons.js
+++ b/assets/vue/components/basecomponents/ChamiloIcons.js
@@ -49,6 +49,7 @@ export const chamiloIconToClass = {
   "download": "mdi mdi-download-box",
   "comment": "mdi mdi-comment-text-outline",
   "drawing": "mdi mdi-pencil-outline",
+  "shape": "mdi mdi-shape",
   "edit": "mdi mdi-pencil",
   "email-plus": "mdi mdi-email-plus-outline",
   "email-unread": "mdi mdi-email-mark-as-unread",

--- a/assets/vue/components/documents/FormNewDocument.vue
+++ b/assets/vue/components/documents/FormNewDocument.vue
@@ -21,10 +21,7 @@
       />
 
       <BaseTinyEditor
-        v-if="
-          (item.resourceNode && item.resourceNode.firstResourceFile && item.resourceNode.firstResourceFile.text) ||
-          ['file', 'certificate'].includes(item.filetype)
-        "
+        v-if="showContentEditor"
         id="item_content"
         v-model="item.contentFile"
         :full-page="fullPage"
@@ -34,7 +31,7 @@
       />
     </div>
     <div
-      v-if="editorDrafts.length > 0"
+      v-if="showContentEditor && editorDrafts.length > 0"
       class="mt-3 rounded-lg border border-gray-25 bg-gray-10 px-4 py-3"
     >
       <button
@@ -211,6 +208,7 @@ import { ref } from "vue"
 import { useI18n } from "vue-i18n"
 import { usePlatformConfig } from "../../store/platformConfig"
 import { useCourseSettings } from "../../store/courseSettingStore"
+import { looksLikeHtmlContent } from "../../composables/fileUtils"
 import { useSecurityStore } from "../../store/securityStore"
 import BaseButton from "../basecomponents/BaseButton.vue"
 import BaseCheckbox from "../basecomponents/BaseCheckbox.vue"
@@ -302,6 +300,47 @@ export default {
     },
     isCertificateDocument() {
       return "certificate" === String(this.item?.filetype || "").trim().toLowerCase()
+    },
+    showContentEditor() {
+      if (Boolean(this.item?.newDocument)) {
+        return true
+      }
+
+      const filetype = String(this.item?.filetype || "")
+        .trim()
+        .toLowerCase()
+
+      if (["certificate", "html"].includes(filetype)) {
+        return true
+      }
+
+      const resourceFile = this.item?.resourceNode?.firstResourceFile
+      if (!resourceFile || "file" !== filetype) {
+        return false
+      }
+
+      const mime = String(resourceFile.mimeType || "")
+        .split(";")[0]
+        .trim()
+        .toLowerCase()
+      const originalName = String(resourceFile.originalName || resourceFile.title || this.item?.title || "")
+        .trim()
+        .toLowerCase()
+      const extension = originalName.includes(".") ? originalName.split(".").pop() : ""
+
+      if (mime.includes("text/html") || mime.includes("application/xhtml") || ["html", "htm", "xhtml"].includes(extension)) {
+        return true
+      }
+
+      if (resourceFile.image || resourceFile.video || resourceFile.audio) {
+        return false
+      }
+
+      if (mime.startsWith("image/") || mime.startsWith("video/") || mime.startsWith("audio/")) {
+        return false
+      }
+
+      return looksLikeHtmlContent(this.item?.contentFile)
     },
     effectiveParentResourceNodeId() {
       const routeNode = this.normalizeNodeId(this.$route?.params?.node ?? this.$route?.params?.id)

--- a/assets/vue/components/lp/LpFinalItem.vue
+++ b/assets/vue/components/lp/LpFinalItem.vue
@@ -4,7 +4,7 @@
       v-if="data.preview"
       class="mb-6 flex items-center justify-center gap-2 rounded-lg bg-blue-10 px-4 py-3 text-sm font-semibold text-blue-90"
     >
-      <BaseIcon icon="eye-on" />
+      <BaseIcon icon="preview" />
       {{ t("Preview") }}
     </div>
 

--- a/assets/vue/components/lp/LpImpressRuntime.vue
+++ b/assets/vue/components/lp/LpImpressRuntime.vue
@@ -61,6 +61,18 @@
               class="min-h-0 flex-1 overflow-auto"
             />
 
+            <video
+              v-else-if="contentReady && isActiveVideo"
+              :key="`${activeItem.id}-${runtime.contentUrl}-${iframeReloadKey}`"
+              :src="runtime.contentUrl"
+              :title="activeItem.title"
+              class="lp-impress-frame"
+              controls
+              playsinline
+              preload="metadata"
+              @loadedmetadata="handleMediaLoad"
+            />
+
             <iframe
               v-else-if="contentReady"
               ref="contentFrame"
@@ -122,7 +134,7 @@ const props = defineProps({
   },
 })
 
-const emit = defineEmits(["active-change", "iframe-load", "open-item"])
+const emit = defineEmits(["active-change", "iframe-load", "media-load", "open-item"])
 const { t } = useI18n()
 
 const activeItemId = ref(0)
@@ -159,6 +171,7 @@ const contentReady = computed(
     Number(activeItem.value.id) === Number(props.runtime.currentItemId) &&
     Boolean(props.runtime.contentUrl),
 )
+const isActiveVideo = computed(() => "video" === String(activeItem.value?.itemType || "").trim().toLowerCase())
 
 watch(
   () => [props.runtime?.currentItemId, props.runtime?.items],
@@ -295,6 +308,12 @@ function handleTouchEnd(event) {
 function handleIframeLoad(event) {
   emit("iframe-load", event)
   attachFrameKeyboardNavigation()
+}
+
+function handleMediaLoad() {
+  contentFrame.value = null
+  detachFrameKeyboardNavigation()
+  emit("media-load")
 }
 
 function attachFrameKeyboardNavigation() {

--- a/assets/vue/composables/fileUtils.js
+++ b/assets/vue/composables/fileUtils.js
@@ -1,23 +1,38 @@
+export function looksLikeHtmlContent(content) {
+  const value = String(content || "").trim()
+
+  if (!value) {
+    return false
+  }
+
+  if (/^<!doctype\s+html[\s>]/i.test(value) || /^<html[\s>]/i.test(value)) {
+    return true
+  }
+
+  return /<(?:head|body|main|section|article|div|p|h[1-6]|table|thead|tbody|tr|td|ul|ol|li|figure|figcaption|style)\b[^>]*>/i.test(
+    value,
+  )
+}
+
 export function useFileUtils() {
   const isFile = (fileData) => {
     return !!fileData?.resourceNode?.firstResourceFile
   }
 
   const safeMime = (fileData) => {
-    // normalize: strip params like "; charset=UTF-8"
+    // Normalize MIME parameters such as "; charset=UTF-8".
     const raw = fileData?.resourceNode?.firstResourceFile?.mimeType || ""
     return String(raw).split(";")[0].trim()
   }
 
   const fileName = (fileData) => {
-    // prefer originalName; fallback to node title
     return fileData?.resourceNode?.firstResourceFile?.originalName || fileData?.resourceNode?.title || ""
   }
 
   const ext = (fileData) => {
     const name = fileName(fileData)
-    const m = /\.([A-Za-z0-9]+)$/.exec(name)
-    return m ? m[1].toLowerCase() : ""
+    const match = /\.([A-Za-z0-9]+)$/.exec(name)
+    return match ? match[1].toLowerCase() : ""
   }
 
   const isImage = (fileData) => {
@@ -38,13 +53,9 @@ export function useFileUtils() {
     if (!isFile(fileData)) return false
 
     const mime = safeMime(fileData).toLowerCase()
-    const e = ext(fileData)
-
-    // MIME-based detection
+    const extension = ext(fileData)
     const byMime = mime.includes("text/html") || mime.includes("application/html") || mime.includes("application/xhtml")
-
-    // Extension-based fallback when MIME is missing/wrong
-    const byExt = e === "html" || e === "htm" || e === "xhtml"
+    const byExt = extension === "html" || extension === "htm" || extension === "xhtml"
 
     return byMime || byExt
   }

--- a/assets/vue/composables/useDocumentUpdate.js
+++ b/assets/vue/composables/useDocumentUpdate.js
@@ -3,6 +3,7 @@ import { useStore } from "vuex"
 import { useRoute, useRouter } from "vue-router"
 import { isEmpty } from "lodash"
 import { useNotification } from "./notification"
+import documentsService from "../services/documents"
 
 const MODULE = "documents"
 
@@ -12,12 +13,17 @@ export function useDocumentUpdate() {
   const router = useRouter()
   const { showErrorNotification } = useNotification()
 
-  const isLoading = computed(() => store.state[MODULE].isLoading)
+  const storeIsLoading = computed(() => store.state[MODULE].isLoading)
   const error = computed(() => store.state[MODULE].error)
   const updated = computed(() => store.state[MODULE].updated)
   const violations = computed(() => store.state[MODULE].violations)
 
   const item = ref({})
+  const initialItem = ref({})
+  const isContentLoading = ref(false)
+  const contentLoadError = ref(null)
+  const isLoading = computed(() => storeIsLoading.value || isContentLoading.value)
+  let hydrationToken = 0
 
   const retrievedItem = computed(() => {
     let id = route.params.id
@@ -33,9 +39,37 @@ export function useDocumentUpdate() {
     return store.getters[`${MODULE}/find`](decodeURIComponent(id))
   })
 
-  watch(retrievedItem, (val) => {
-    if (!isEmpty(val)) {
+  watch(retrievedItem, async (val) => {
+    if (isEmpty(val)) {
+      return
+    }
+
+    const currentToken = ++hydrationToken
+    contentLoadError.value = null
+    isContentLoading.value = true
+
+    try {
+      const hydratedItem = await hydrateEditableContent(val)
+      if (currentToken !== hydrationToken) {
+        return
+      }
+
+      item.value = hydratedItem
+      initialItem.value = { ...hydratedItem }
+    } catch (loadError) {
+      if (currentToken !== hydrationToken) {
+        return
+      }
+
+      contentLoadError.value = loadError
+      console.error("[Documents] Unable to load editable document content.", loadError)
+      showErrorNotification(loadError?.message || String(loadError))
       item.value = { ...val }
+      initialItem.value = { ...val }
+    } finally {
+      if (currentToken === hydrationToken) {
+        isContentLoading.value = false
+      }
     }
   })
 
@@ -72,11 +106,16 @@ export function useDocumentUpdate() {
       return
     }
 
+    if (contentLoadError.value) {
+      showErrorNotification(contentLoadError.value?.message || String(contentLoadError.value))
+      return
+    }
+
     formRef.v$.$touch()
 
     if (!formRef.v$.$invalid) {
       updateWithFormData(formRef.v$.item.$model)
-      item.value = { ...(retrievedItem.value ?? {}) }
+      item.value = { ...initialItem.value }
     }
   }
 
@@ -85,7 +124,43 @@ export function useDocumentUpdate() {
       formRef.v$.$reset()
     }
 
-    item.value = { ...(retrievedItem.value ?? {}) }
+    item.value = { ...initialItem.value }
+  }
+
+  async function hydrateEditableContent(value) {
+    const hydratedItem = { ...value }
+    const filetype = String(hydratedItem.filetype || "")
+      .trim()
+      .toLowerCase()
+    const resourceFile = hydratedItem.resourceNode?.firstResourceFile
+    const isEditableText = Boolean(resourceFile?.text) || ["certificate", "html"].includes(filetype)
+
+    if (!isEditableText) {
+      return hydratedItem
+    }
+
+    const embeddedContent = String(hydratedItem.resourceNode?.content || "")
+    const contentUrl = String(hydratedItem.contentUrl || resourceFile?.contentUrl || "").trim()
+
+    if (!contentUrl) {
+      hydratedItem.contentFile = embeddedContent
+      return hydratedItem
+    }
+
+    try {
+      const rawContent = await documentsService.fetchTextContent(contentUrl)
+      hydratedItem.contentFile = String(rawContent ?? embeddedContent)
+    } catch (loadError) {
+      if (embeddedContent) {
+        console.warn("[Documents] Falling back to embedded document content after file loading failed.", loadError)
+        hydratedItem.contentFile = embeddedContent
+        return hydratedItem
+      }
+
+      throw loadError
+    }
+
+    return hydratedItem
   }
 
   onBeforeUnmount(() => {

--- a/assets/vue/views/documents/DocumentsList.vue
+++ b/assets/vue/views/documents/DocumentsList.vue
@@ -80,7 +80,7 @@
     <BaseButton
       v-if="showNewDrawingButton"
       :label="t('New drawing')"
-      icon="drawing"
+      icon="shape"
       only-icon
       type="success"
       @click="goToNewDrawing"
@@ -1596,9 +1596,71 @@ function btnChangeVisibilityOnClick(item) {
   })
 }
 
+function isEditableTextDocument(item) {
+  const filetype = String(item?.filetype || "")
+    .trim()
+    .toLowerCase()
+
+  if (["certificate", "html"].includes(filetype)) {
+    return true
+  }
+
+  if ("file" !== filetype) {
+    return false
+  }
+
+  const resourceFile = item?.resourceNode?.firstResourceFile
+  if (!resourceFile) {
+    return false
+  }
+
+  const mime = String(resourceFile.mimeType || "")
+    .split(";")[0]
+    .trim()
+    .toLowerCase()
+  const extension = getDocumentExtension(item)
+  const binaryExtensions = new Set([
+    "avif",
+    "bmp",
+    "gif",
+    "ico",
+    "jpeg",
+    "jpg",
+    "png",
+    "webp",
+    "mp3",
+    "ogg",
+    "wav",
+    "m4a",
+    "mp4",
+    "m4v",
+    "mov",
+    "webm",
+    "avi",
+    "pdf",
+  ])
+
+  if (
+    isImage(item) ||
+    resourceFile.video ||
+    resourceFile.audio ||
+    mime.startsWith("image/") ||
+    mime.startsWith("video/") ||
+    mime.startsWith("audio/") ||
+    "application/pdf" === mime ||
+    binaryExtensions.has(extension)
+  ) {
+    return false
+  }
+
+  return Boolean(resourceFile.text) || isHtml(item) || mime.startsWith("text/")
+}
+
 function btnEditOnClick(item) {
-  const folderParams = route.query
-  folderParams.id = item["@id"]
+  const folderParams = {
+    ...route.query,
+    id: item["@id"],
+  }
 
   if ("folder" === item.filetype || isEmpty(item.filetype)) {
     router.push({
@@ -1613,18 +1675,28 @@ function btnEditOnClick(item) {
     router.push({
       name: "DocumentsSvgEditor",
       params: { node: route.params.node },
+      query: folderParams,
+    })
+    return
+  }
+
+  if (isEditableTextDocument(item)) {
+    router.push({
+      name: "DocumentsUpdateFile",
+      params: { id: item["@id"] },
       query: {
         ...folderParams,
-        id: item["@id"],
+        getFile: true,
       },
     })
     return
   }
 
-  if ("file" === item.filetype || "certificate" === item.filetype || "html" === item.filetype) {
-    folderParams.getFile = true
-    router.push({ name: "DocumentsUpdateFile", params: { id: item["@id"] }, query: folderParams })
-  }
+  router.push({
+    name: "DocumentsUpdate",
+    params: { id: item["@id"] },
+    query: folderParams,
+  })
 }
 
 function showSlideShowWithFirstImage() {

--- a/assets/vue/views/documents/Update.vue
+++ b/assets/vue/views/documents/Update.vue
@@ -1,23 +1,42 @@
 <template>
-  <div v-if="item && canEditItem">
-    <DocumentsForm
-      v-model="item"
-      @submit="updateAndReturnToList"
-    >
-      <EditLinks
-        v-model="item"
-        :show-share-with-user="false"
-        :show-status="false"
-        links-type="users"
+  <div
+    v-if="item && canEditItem"
+    class="mx-auto w-full max-w-4xl px-4 pb-8"
+  >
+    <div class="mb-4 flex items-center">
+      <BaseButton
+        :label="t('Back')"
+        icon="back"
+        type="primary"
+        @click="handleBack"
       />
-    </DocumentsForm>
+    </div>
+
+    <div class="rounded-lg border border-gray-25 bg-white p-4 shadow-sm sm:p-6">
+      <DocumentsForm
+        v-model="item"
+        @submit="updateAndReturnToList"
+      >
+        <div class="mt-4">
+          <EditLinks
+            v-model="item"
+            :show-share-with-user="false"
+            :show-status="false"
+            links-type="users"
+          />
+        </div>
+      </DocumentsForm>
+    </div>
+
     <Loading :visible="isLoading" />
   </div>
 </template>
 
 <script setup>
 import { computed, onMounted } from "vue"
+import { useI18n } from "vue-i18n"
 import { useRoute, useRouter } from "vue-router"
+import BaseButton from "../../components/basecomponents/BaseButton.vue"
 import DocumentsForm from "../../components/documents/Form.vue"
 import Loading from "../../components/Loading.vue"
 import EditLinks from "../../components/resource_links/EditLinks.vue"
@@ -28,6 +47,7 @@ import { useIsAllowedToEdit } from "../../composables/userPermissions"
 const securityStore = useSecurityStore()
 const route = useRoute()
 const router = useRouter()
+const { t } = useI18n()
 const { isAllowedToEdit } = useIsAllowedToEdit({ tutor: true, coach: true, sessionCoach: true })
 const isCurrentTeacher = computed(() => securityStore.isCurrentTeacher || isAllowedToEdit.value)
 const { item, retrieve, updateItemWithFormData, isLoading } = useDatatableUpdate("Documents")
@@ -111,12 +131,36 @@ function getContainingNodeId(documentItem) {
   return null
 }
 
+async function handleBack() {
+  if (isLearningPathContext.value) {
+    await router.push(buildLearningPathBuilderRoute())
+    return
+  }
+
+  const containingNodeId = getContainingNodeId(item.value)
+  if (!containingNodeId) {
+    router.back()
+    return
+  }
+
+  await router.push({
+    name: "DocumentsList",
+    params: {
+      node: containingNodeId,
+    },
+    query: {
+      cid: route.query.cid,
+      sid: route.query.sid,
+      gid: route.query.gid,
+    },
+  })
+}
+
 async function updateAndReturnToList(payload) {
   await updateItemWithFormData(payload)
 
   if (isLearningPathContext.value) {
     await router.push(buildLearningPathBuilderRoute())
-
     return
   }
 
@@ -127,7 +171,7 @@ async function updateAndReturnToList(payload) {
     return
   }
 
-  router.push({
+  await router.push({
     name: "DocumentsList",
     params: {
       node: containingNodeId,

--- a/assets/vue/views/documents/UpdateFile.vue
+++ b/assets/vue/views/documents/UpdateFile.vue
@@ -105,6 +105,7 @@ import { useIsAllowedToEdit } from "../../composables/userPermissions"
 import { useDocumentUpdate } from "../../composables/useDocumentUpdate"
 import { useCertificateTags } from "../../composables/useCertificateTags"
 import { useDocumentTemplates } from "../../composables/useDocumentTemplates"
+import { looksLikeHtmlContent } from "../../composables/fileUtils"
 import DocumentsForm from "../../components/documents/FormNewDocument.vue"
 import Loading from "../../components/Loading.vue"
 import Toolbar from "../../components/Toolbar.vue"
@@ -165,6 +166,49 @@ const isCertificateDocument = computed(() =>
   "certificate" === String(item.value?.filetype || filetype).trim().toLowerCase(),
 )
 
+const isEditableTextDocument = computed(() => {
+  const document = item.value
+  const documentFiletype = String(document?.filetype || filetype)
+    .trim()
+    .toLowerCase()
+
+  if (["certificate", "html"].includes(documentFiletype)) {
+    return true
+  }
+
+  if ("file" !== documentFiletype) {
+    return false
+  }
+
+  const resourceFile = document?.resourceNode?.firstResourceFile
+  if (!resourceFile) {
+    return false
+  }
+
+  const mime = String(resourceFile.mimeType || "")
+    .split(";")[0]
+    .trim()
+    .toLowerCase()
+  const originalName = String(resourceFile.originalName || resourceFile.title || document?.title || "")
+    .trim()
+    .toLowerCase()
+  const extension = originalName.includes(".") ? originalName.split(".").pop() : ""
+
+  if (mime.includes("text/html") || mime.includes("application/xhtml") || ["html", "htm", "xhtml"].includes(extension)) {
+    return true
+  }
+
+  if (resourceFile.image || resourceFile.video || resourceFile.audio) {
+    return false
+  }
+
+  if (mime.startsWith("image/") || mime.startsWith("video/") || mime.startsWith("audio/")) {
+    return false
+  }
+
+  return looksLikeHtmlContent(document?.contentFile)
+})
+
 const { certificateTags, insertCertificateTag, copyAllCertificateTags } = useCertificateTags(item)
 const { templates, fetchTemplates, addTemplateToEditor } = useDocumentTemplates(item, updateForm)
 
@@ -184,7 +228,20 @@ const canEditItem = computed(() => {
 watch(
   item,
   (val) => {
-    if (!val || typeof val !== "object") return
+    if (!val || typeof val !== "object" || 0 === Object.keys(val).length) return
+
+    if (!isEditableTextDocument.value) {
+      const query = { ...route.query }
+      delete query.getFile
+
+      router.replace({
+        name: "DocumentsUpdate",
+        params: { node: route.params.node },
+        query,
+      })
+      return
+    }
+
     if ("certificate" === String(val.filetype || filetype).trim().toLowerCase()) {
       val.indexDocumentContent = false
       val.searchFieldValues = {}

--- a/assets/vue/views/gradebook/GradebookCertificatesView.vue
+++ b/assets/vue/views/gradebook/GradebookCertificatesView.vue
@@ -272,7 +272,7 @@
     <BaseDialog
       v-model:is-visible="isPreviewDialogVisible"
       :title="previewDialogTitle"
-      header-icon="eye-on"
+      header-icon="preview"
     >
       <div class="overflow-hidden rounded-lg border border-gray-20 bg-white">
         <iframe

--- a/assets/vue/views/lp/LpBuilder.vue
+++ b/assets/vue/views/lp/LpBuilder.vue
@@ -743,7 +743,7 @@ function goBack() {
       <BaseButton
         :label="t('Preview')"
         :to-url="previewUrl"
-        icon="eye-on"
+        icon="preview"
         only-icon
         type="primary-text"
       />

--- a/assets/vue/views/lp/LpRuntime.vue
+++ b/assets/vue/views/lp/LpRuntime.vue
@@ -338,6 +338,7 @@
           :runtime="runtime"
           @active-change="handleImpressActiveChange"
           @iframe-load="handleIframeLoad"
+          @media-load="handleMediaLoad"
           @open-item="openItem"
         />
 
@@ -353,6 +354,18 @@
             v-if="isFinalItem"
             :data="runtime.finalItem"
             class="h-full overflow-y-auto"
+          />
+
+          <video
+            v-else-if="runtime.contentUrl && isVideoItem"
+            :key="`${runtime.currentItemId}-${runtime.contentUrl}-${iframeReloadKey}`"
+            :src="runtime.contentUrl"
+            :title="currentItem?.title || runtime.title"
+            class="lp-runtime-video"
+            controls
+            playsinline
+            preload="metadata"
+            @loadedmetadata="handleMediaLoad"
           />
 
           <iframe
@@ -521,6 +534,7 @@ const currentItem = computed(
 const isFinalItem = computed(
   () => currentItem.value?.itemType === "final_item" && Boolean(runtime.value?.finalItem?.enabled),
 )
+const isVideoItem = computed(() => "video" === String(currentItem.value?.itemType || "").trim().toLowerCase())
 const previewImageUrl = computed(() => String(runtime.value?.previewImageUrl || ""))
 const shouldShowPreviewImage = computed(() => {
   const url = previewImageUrl.value.trim()
@@ -1121,6 +1135,12 @@ function handleIframeLoad(event) {
   scheduleRuntimeRefresh()
 }
 
+function handleMediaLoad() {
+  contentFrame.value = null
+  iframeLoading.value = false
+  scheduleRuntimeRefresh()
+}
+
 function handleImpressActiveChange(item) {
   const isSection = Boolean(item?.isSection)
   if (isSection && !impressActiveIsSection.value) {
@@ -1606,6 +1626,13 @@ body.lp-runtime-document {
   height: 100%;
   border: 0;
   background: #ffffff;
+}
+
+.lp-runtime-video {
+  display: block;
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
 }
 
 .lp-runtime-loader {

--- a/public/main/gradebook/certificate_template/template.html
+++ b/public/main/gradebook/certificate_template/template.html
@@ -100,7 +100,8 @@
                         </div>
                     </td>
                     <td style="width:45%;text-align:right;vertical-align:bottom;font-size:12px;color:#6b7280;">
-                        ((certificate_link_html))
+                        <div style="margin-bottom:8px;">((certificate_barcode))</div>
+                        <div>((certificate_link_html))</div>
                     </td>
                 </tr>
             </table>

--- a/src/CoreBundle/Controller/Api/BaseResourceFileAction.php
+++ b/src/CoreBundle/Controller/Api/BaseResourceFileAction.php
@@ -703,7 +703,17 @@ class BaseResourceFileAction
 
         if ($hasFile && null !== $content) {
             $content = $this->sanitizeContentFileForUpdate((string) $content, $request, $resourceNode);
-            $repo->updateResourceFileContent($resource, $content);
+
+            if ($resource instanceof CDocument && $repo instanceof CDocumentRepository) {
+                $repo->updateStoredFileContent(
+                    $resource,
+                    $content,
+                    $this->resolveUpdatedContentMimeType($request, $resourceNode, $content),
+                );
+            } else {
+                $repo->updateResourceFileContent($resource, $content);
+            }
+
             $resource->setResourceNode($resourceNode);
         }
 
@@ -809,6 +819,29 @@ class BaseResourceFileAction
         $resourceNode->setUpdatedAt(new DateTime());
 
         return $resource;
+    }
+
+    private function resolveUpdatedContentMimeType(Request $request, ResourceNode $resourceNode, string $content): string
+    {
+        $requestedMimeType = strtolower(trim((string) $request->request->get('contentFileMimeType', '')));
+        if ('' !== $requestedMimeType) {
+            return $requestedMimeType;
+        }
+
+        $resourceFile = $resourceNode->getFirstResourceFile();
+        $currentMimeType = $resourceFile instanceof ResourceFile
+            ? strtolower(trim((string) $resourceFile->getMimeType()))
+            : '';
+
+        if ('image/svg+xml' === $currentMimeType) {
+            return $currentMimeType;
+        }
+
+        if (1 === preg_match('/<(?:!doctype\s+html|html|head|body|main|section|article|div|p|h[1-6]|table|ul|ol|style)\b/i', $content)) {
+            return 'text/html';
+        }
+
+        return '' !== $currentMimeType ? $currentMimeType : 'text/plain';
     }
 
     private function getContentFileUploadInfo(Request $request, string $title): array

--- a/src/CoreBundle/Controller/ResourceController.php
+++ b/src/CoreBundle/Controller/ResourceController.php
@@ -719,7 +719,7 @@ class ResourceController extends AbstractResourceController implements CourseCon
         $fileName = $resourceFile->getOriginalName();
         $fileSize = $resourceFile->getSize();
         $mimeType = $resourceFile->getMimeType() ?: '';
-        [$start, $end, $length] = $this->getRange($request, $fileSize);
+        [$start, $end, $length, $isPartialContent] = $this->resolveFileRange($request, $fileSize);
         $resourceNodeRepo = $this->getResourceNodeRepository();
 
         // Convert the file name to ASCII using iconv
@@ -976,12 +976,75 @@ class ResourceController extends AbstractResourceController implements CourseCon
 
         $response->headers->set('Content-Length', (string) $length);
         $response->headers->set('Accept-Ranges', 'bytes');
-        $response->headers->set('Content-Range', "bytes $start-$end/$fileSize");
-        $response->setStatusCode(
-            $start > 0 || $end < $fileSize - 1 ? Response::HTTP_PARTIAL_CONTENT : Response::HTTP_OK
-        );
+
+        if ($isPartialContent) {
+            $response->headers->set('Content-Range', "bytes $start-$end/$fileSize");
+            $response->setStatusCode(Response::HTTP_PARTIAL_CONTENT);
+        } else {
+            $response->setStatusCode(Response::HTTP_OK);
+        }
 
         return $response;
+    }
+
+    /**
+     * Resolve one HTTP byte range for streamed resources.
+     *
+     * Malformed, unsupported multi-range, or out-of-bounds requests are intentionally ignored
+     * and fall back to the complete representation. This keeps the endpoint compatible with
+     * clients that retry media requests while still returning a correct 206 response for valid
+     * single ranges such as "bytes=0-", "bytes=1000-" and suffix ranges.
+     *
+     * @return array{0: int, 1: int, 2: int, 3: bool}
+     */
+    private function resolveFileRange(Request $request, int $fileSize): array
+    {
+        if ($fileSize <= 0) {
+            return [0, 0, 0, false];
+        }
+
+        $fullRange = [0, $fileSize - 1, $fileSize, false];
+        $rangeHeader = trim((string) $request->headers->get('Range', ''));
+
+        if ('' === $rangeHeader
+            || 1 !== preg_match('/^bytes=(\d*)-(\d*)$/', $rangeHeader, $matches)
+        ) {
+            return $fullRange;
+        }
+
+        $startValue = $matches[1];
+        $endValue = $matches[2];
+
+        if ('' === $startValue && '' === $endValue) {
+            return $fullRange;
+        }
+
+        if ('' === $startValue) {
+            $suffixLength = (int) $endValue;
+            if ($suffixLength <= 0) {
+                return $fullRange;
+            }
+
+            $length = min($suffixLength, $fileSize);
+            $start = $fileSize - $length;
+
+            return [$start, $fileSize - 1, $length, true];
+        }
+
+        $start = (int) $startValue;
+        if ($start >= $fileSize) {
+            return $fullRange;
+        }
+
+        $end = '' === $endValue
+            ? $fileSize - 1
+            : min((int) $endValue, $fileSize - 1);
+
+        if ($end < $start) {
+            return $fullRange;
+        }
+
+        return [$start, $end, $end - $start + 1, true];
     }
 
     /**

--- a/src/CoreBundle/Resources/views/Account/edit.html.twig
+++ b/src/CoreBundle/Resources/views/Account/edit.html.twig
@@ -231,6 +231,7 @@
                                                 <div
                                                     id="profile-picture-crop-viewport"
                                                     class="relative h-64 w-64 max-w-full overflow-hidden rounded-full border border-gray-25 bg-white shadow-inner"
+                                                    style="touch-action:none;"
                                                 >
                                                     <img
                                                         id="profile-picture-crop-image"
@@ -238,6 +239,7 @@
                                                         src=""
                                                         alt=""
                                                         draggable="false"
+                                                        style="max-width:none;"
                                                     />
                                                 </div>
                                             </div>
@@ -535,7 +537,7 @@
                 }
 
                 cropPanel.classList.remove('hidden');
-                initialiseCropper();
+                window.requestAnimationFrame(initialiseCropper);
 
                 setStatus(
                   '{{ 'New picture'|trans|e('js') }}',

--- a/src/CoreBundle/Service/Gradebook/GradebookCertificateGenerator.php
+++ b/src/CoreBundle/Service/Gradebook/GradebookCertificateGenerator.php
@@ -27,6 +27,10 @@ use DateTime;
 use DateTimeInterface;
 use DateTimeZone;
 use Doctrine\ORM\EntityManagerInterface;
+use Endroid\QrCode\Builder\Builder;
+use Endroid\QrCode\Encoding\Encoding;
+use Endroid\QrCode\ErrorCorrectionLevel\ErrorCorrectionLevelHigh;
+use Endroid\QrCode\Writer\PngWriter;
 use Psr\Log\LoggerInterface;
 use RuntimeException;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
@@ -329,7 +333,7 @@ final readonly class GradebookCertificateGenerator
         if ($systemTemplate instanceof SystemTemplate) {
             $content = trim((string) $systemTemplate->getContent());
             if ('' !== $content) {
-                return $content;
+                return $this->ensureDefaultCertificateQrPlaceholder($content);
             }
         }
 
@@ -344,6 +348,24 @@ final readonly class GradebookCertificateGenerator
         }
 
         return str_replace('{IMG_PATH}', '/main/gradebook/certificate_template/', $html);
+    }
+
+    private function ensureDefaultCertificateQrPlaceholder(string $template): string
+    {
+        if (str_contains($template, '((certificate_barcode))')) {
+            return $template;
+        }
+
+        $linkPlaceholder = '((certificate_link_html))';
+        if (!str_contains($template, $linkPlaceholder)) {
+            return $template;
+        }
+
+        return str_replace(
+            $linkPlaceholder,
+            '<div style="margin-bottom:8px;">((certificate_barcode))</div><div>'.$linkPlaceholder.'</div>',
+            $template,
+        );
     }
 
     private function getDocumentTemplateHtml(
@@ -392,6 +414,7 @@ final readonly class GradebookCertificateGenerator
         $teacher = $this->resolveTeacher($category, $course, $session);
         $scoreText = rtrim(rtrim(number_format($score, 2, '.', ''), '0'), '.');
         $escapedViewUrl = htmlspecialchars($viewUrl, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
+        $absoluteViewUrl = '' !== $viewUrl ? rtrim((string) api_get_path(WEB_PATH), '/').$viewUrl : '';
 
         $replacements = [
             '((user_firstname))' => $this->escape((string) $user->getFirstname()),
@@ -418,7 +441,7 @@ final readonly class GradebookCertificateGenerator
                     .$this->escape($this->translator->trans('Online link to certificate'))
                     .'</a>'
                 : '',
-            '((certificate_barcode))' => '',
+            '((certificate_barcode))' => $this->buildCertificateQrCodeHtml($absoluteViewUrl),
             '((external_style))' => '',
             '((time_in_course))' => '',
             '((time_in_course_in_all_sessions))' => '',
@@ -427,6 +450,35 @@ final readonly class GradebookCertificateGenerator
         ];
 
         return str_replace(array_keys($replacements), array_values($replacements), $template);
+    }
+
+    private function buildCertificateQrCodeHtml(string $certificateUrl): string
+    {
+        if ('' === trim($certificateUrl)) {
+            return '';
+        }
+
+        try {
+            $result = Builder::create()
+                ->writer(new PngWriter())
+                ->data($certificateUrl)
+                ->encoding(new Encoding('UTF-8'))
+                ->errorCorrectionLevel(new ErrorCorrectionLevelHigh())
+                ->size(180)
+                ->margin(5)
+                ->build()
+            ;
+
+            $encodedImage = base64_encode($result->getString());
+
+            return '<img src="data:image/png;base64,'.$encodedImage.'" alt="QR" style="width:96px;height:96px;" />';
+        } catch (Throwable $exception) {
+            $this->logger->warning('Unable to generate the Gradebook certificate QR code.', [
+                'exception' => $exception,
+            ]);
+
+            return '';
+        }
     }
 
     private function requiresLegacyTemplateCompatibility(string $template): bool

--- a/src/CourseBundle/Repository/CDocumentRepository.php
+++ b/src/CourseBundle/Repository/CDocumentRepository.php
@@ -50,6 +50,46 @@ final class CDocumentRepository extends ResourceRepository
         return null;
     }
 
+    public function updateStoredFileContent(CDocument $document, string $content, string $mimeType): bool
+    {
+        $resourceNode = $document->getResourceNode();
+        if (null === $resourceNode || !$resourceNode->hasResourceFile()) {
+            return false;
+        }
+
+        $resourceFile = $resourceNode->getFirstResourceFile();
+        if (!$resourceFile instanceof ResourceFile) {
+            return false;
+        }
+
+        $resourceNodeRepository = $this->getResourceNodeRepository();
+        $filename = $resourceNodeRepository->getFilename($resourceFile);
+        if (!\is_string($filename) || '' === trim($filename)) {
+            return false;
+        }
+
+        try {
+            // Do not re-apply storage visibility while replacing existing content.
+            // Some valid files live on filesystems where chmod is not supported.
+            $resourceNodeRepository->getFileSystem()->write($filename, $content, ['visibility' => null]);
+        } catch (Throwable $exception) {
+            throw new RuntimeException('Unable to update the stored document content.', 0, $exception);
+        }
+
+        $resourceNode->setContent($content);
+        $resourceFile
+            ->setSize(\strlen($content))
+            ->setMimeType($mimeType)
+        ;
+
+        $em = $this->getEntityManager();
+        $em->persist($document);
+        $em->persist($resourceNode);
+        $em->persist($resourceFile);
+
+        return true;
+    }
+
     public function getFolderSize(ResourceNode $resourceNode, Course $course, ?Session $session = null): int
     {
         return $this->getResourceNodeRepository()->getSize($resourceNode, $this->getResourceType(), $course, $session);
@@ -93,7 +133,7 @@ final class CDocumentRepository extends ResourceRepository
 
     /**
      * Register the original SCORM ZIP under:
-     *   Documents / Learning paths / SCORM - {lp_id} - {lp_title} / {lp_title}.zip
+     *   learning_path / SCORM - {lp_id} - {lp_title} / {lp_title}.zip
      */
     public function registerScormZip(
         Course $course,
@@ -104,7 +144,7 @@ final class CDocumentRepository extends ResourceRepository
     ): void {
         $em = $this->em();
 
-        // Ensure "Learning paths" under the course Documents root.
+        // Reuse the legacy-compatible learning_path root.
         $lpTop = $this->ensureLearningPathSystemFolder($course, $session, $group);
 
         // Subfolder per LP
@@ -149,6 +189,7 @@ final class CDocumentRepository extends ResourceRepository
         }
 
         $learningPathFolderTitles = array_values(array_unique(array_filter([
+            'learning_path',
             \function_exists('get_lang') ? get_lang('Learning paths') : null,
             \function_exists('get_lang') ? get_lang('Learning path') : null,
             'Learning paths',
@@ -210,7 +251,7 @@ final class CDocumentRepository extends ResourceRepository
     }
 
     /**
-     * Remove the LP subfolder "SCORM - {lp_id} - ..." under "Learning paths".
+     * Remove the LP subfolder "SCORM - {lp_id} - ..." under the learning path system folder.
      */
     public function purgeScormZip(Course $course, CLp $lp): void
     {
@@ -232,7 +273,8 @@ final class CDocumentRepository extends ResourceRepository
                     return;
                 }
 
-                $lpTop = $this->findChildNodeByTitle($parent, 'Learning paths');
+                $lpTop = $this->findChildNodeByTitle($parent, 'learning_path')
+                    ?? $this->findChildNodeByTitle($parent, 'Learning paths');
                 if ($lpTop instanceof ResourceNode && $this->tryDeleteFirstFolderByTitlePrefix($lpTop, $prefix)) {
                     $em->flush();
 
@@ -483,33 +525,29 @@ final class CDocumentRepository extends ResourceRepository
     }
 
     /**
-     * Ensure "Learning paths" exists under the course Documents root.
-     * Links are created for course (and optional session/group) context.
+     * Ensure the Learning Path system folder exists without creating a second
+     * translated/canonical root when the course already has one.
      */
     public function ensureLearningPathSystemFolder(
         Course $course,
         ?Session $session = null,
         ?CGroup $group = null,
     ): ResourceNode {
-        $documentsRoot = $this->ensureCourseDocumentsRootNode($course);
-        $candidates = array_values(array_unique(array_filter([
-            \function_exists('get_lang') ? get_lang('Learning paths') : null,
-            \function_exists('get_lang') ? get_lang('Learning path') : null,
-            'Learning paths',
-            'Learning path',
-        ])));
+        $courseRoot = $course->getResourceNode();
+        if (!$courseRoot instanceof ResourceNode) {
+            throw new RuntimeException('Course has no ResourceNode root.');
+        }
 
-        foreach ($candidates as $title) {
-            $child = $this->findChildNodeByTitle($documentsRoot, $title);
-            if ($child instanceof ResourceNode) {
-                return $child;
-            }
+        $existingFolders = $this->findLearningPathSystemFolders($course);
+        $existingFolder = $this->selectEstablishedDocumentFolder($existingFolders);
+        if ($existingFolder instanceof ResourceNode) {
+            return $existingFolder;
         }
 
         return $this->ensureFolder(
             $course,
-            $documentsRoot,
-            'Learning paths',
+            $courseRoot,
+            'learning_path',
             ResourceLink::VISIBILITY_DRAFT,
             $session,
             $group,
@@ -517,7 +555,11 @@ final class CDocumentRepository extends ResourceRepository
     }
 
     /**
-     * Ensure the legacy-compatible folder dedicated to one learning path exists.
+     * Ensure the folder dedicated to one Learning Path exists.
+     *
+     * If previous implementations created equivalent system roots such as
+     * "Learning paths" and "learning_path", reuse the LP folder that already
+     * contains the established content instead of creating another copy.
      */
     public function ensureLearningPathDocumentFolder(
         Course $course,
@@ -525,18 +567,123 @@ final class CDocumentRepository extends ResourceRepository
         CLp $lp,
         ?CGroup $group = null,
     ): ResourceNode {
-        $learningPathsFolder = $this->ensureLearningPathSystemFolder($course, $session, $group);
         $title = $this->safeTitle(html_entity_decode(strip_tags($lp->getTitle()), ENT_QUOTES | ENT_HTML5, 'UTF-8'));
         $title = mb_substr($title, 0, 80);
+        $folderTitle = '' !== $title ? $title : \sprintf('Learning path %d', (int) $lp->getIid());
+
+        $existingLpFolders = [];
+        foreach ($this->findLearningPathSystemFolders($course) as $systemFolder) {
+            $lpFolder = $this->findChildDocumentFolderByTitle($systemFolder, $folderTitle);
+            if ($lpFolder instanceof ResourceNode) {
+                $existingLpFolders[] = $lpFolder;
+            }
+        }
+
+        $existingLpFolder = $this->selectEstablishedDocumentFolder($existingLpFolders);
+        if ($existingLpFolder instanceof ResourceNode) {
+            return $existingLpFolder;
+        }
+
+        $learningPathsFolder = $this->ensureLearningPathSystemFolder($course, $session, $group);
 
         return $this->ensureFolder(
             $course,
             $learningPathsFolder,
-            '' !== $title ? $title : \sprintf('Learning path %d', (int) $lp->getIid()),
+            $folderTitle,
             ResourceLink::VISIBILITY_DRAFT,
             $session,
             $group,
         );
+    }
+
+    /**
+     * @return ResourceNode[]
+     */
+    private function findLearningPathSystemFolders(Course $course): array
+    {
+        $courseRoot = $course->getResourceNode();
+        if (!$courseRoot instanceof ResourceNode) {
+            return [];
+        }
+
+        $parents = [$courseRoot];
+        $documentsRoot = $this->getCourseDocumentsRootNode($course);
+        if ($documentsRoot instanceof ResourceNode && $documentsRoot->getId() !== $courseRoot->getId()) {
+            $parents[] = $documentsRoot;
+        }
+
+        $titles = array_values(array_unique(array_filter([
+            'learning_path',
+            \function_exists('get_lang') ? get_lang('Learning paths') : null,
+            \function_exists('get_lang') ? get_lang('Learning path') : null,
+            'Learning paths',
+            'Learning path',
+        ])));
+
+        $folders = [];
+        $seen = [];
+        foreach ($parents as $parent) {
+            foreach ($titles as $title) {
+                $folder = $this->findChildDocumentFolderByTitle($parent, $title);
+                if (!$folder instanceof ResourceNode) {
+                    continue;
+                }
+
+                $folderId = (int) $folder->getId();
+                if (isset($seen[$folderId])) {
+                    continue;
+                }
+
+                $seen[$folderId] = true;
+                $folders[] = $folder;
+            }
+        }
+
+        return $folders;
+    }
+
+    /**
+     * Prefer the folder that already contains the most direct document content.
+     * On ties, keep the oldest ResourceNode to avoid switching between duplicate roots.
+     *
+     * @param ResourceNode[] $folders
+     */
+    private function selectEstablishedDocumentFolder(array $folders): ?ResourceNode
+    {
+        if ([] === $folders) {
+            return null;
+        }
+
+        $rankedFolders = [];
+        foreach ($folders as $folder) {
+            $rankedFolders[] = [
+                'folder' => $folder,
+                'children' => $this->countDirectDocumentChildren($folder),
+                'id' => (int) $folder->getId(),
+            ];
+        }
+
+        usort(
+            $rankedFolders,
+            static fn (array $left, array $right): int => $right['children'] <=> $left['children']
+                ?: $left['id'] <=> $right['id']
+        );
+
+        return $rankedFolders[0]['folder'];
+    }
+
+    private function countDirectDocumentChildren(ResourceNode $parent): int
+    {
+        return (int) $this->em()
+            ->createQueryBuilder()
+            ->select('COUNT(d.iid)')
+            ->from(CDocument::class, 'd')
+            ->innerJoin('d.resourceNode', 'rn')
+            ->where('rn.parent = :parent')
+            ->setParameter('parent', $parent)
+            ->getQuery()
+            ->getSingleScalarResult()
+        ;
     }
 
     /**


### PR DESCRIPTION
Fix pre-Chamilo 3 content regressions affecting document editing and preview icons, HTML document persistence, Learning Path MP4 playback, duplicate Learning Path document folders, profile image cropping, SVG editor icon and certificate QR generation.