### PR TITLE
Security: Check course edit rights on AI document endpoints

### DIFF
--- a/src/CoreBundle/Controller/AiController.php
+++ b/src/CoreBundle/Controller/AiController.php
@@ -426,6 +426,17 @@ class AiController extends AbstractController
             ], 404);
         }
 
+        // Object-level check: the client-supplied cid must be a course the current
+        // user actually manages, not merely any course with the feature enabled.
+        try {
+            $this->denyAccessUnlessGranted(CourseVoter::EDIT, $course);
+        } catch (AccessDeniedException) {
+            return new JsonResponse([
+                'success' => false,
+                'text' => 'Access denied.',
+            ], 403);
+        }
+
         if (!$this->isAiFeatureEnabledForCourse('glossary_terms_generator', $cid)) {
             return $this->buildAiFeatureDisabledResponse();
         }
@@ -1378,6 +1389,17 @@ class AiController extends AbstractController
                 'success' => false,
                 'text' => 'Course not found.',
             ], 404);
+        }
+
+        // Object-level check: the client-supplied cid must be a course the current
+        // user actually manages, not merely any course with the feature enabled.
+        try {
+            $this->denyAccessUnlessGranted(CourseVoter::EDIT, $course);
+        } catch (AccessDeniedException) {
+            return new JsonResponse([
+                'success' => false,
+                'text' => 'Access denied.',
+            ], 403);
         }
 
         /** @var ResourceFile|null $resourceFile */
@@ -2824,6 +2846,14 @@ class AiController extends AbstractController
         $course = $this->em->getRepository(Course::class)->find($cid);
         if (null === $course) {
             return new JsonResponse(['success' => false, 'text' => 'Course not found.'], 404);
+        }
+
+        // Object-level check: the client-supplied cid must be a course the current
+        // user actually manages, not merely any course with the feature enabled.
+        try {
+            $this->denyAccessUnlessGranted(CourseVoter::EDIT, $course);
+        } catch (AccessDeniedException) {
+            return new JsonResponse(['success' => false, 'text' => 'Access denied.'], 403);
         }
 
         /** @var ResourceFile|null $resourceFile */


### PR DESCRIPTION
The three AI document endpoints resolved their target course from the request body and only checked a global teacher role, so a teacher of one course could reach another course's documents. They now require edit rights on the target course before reading the file, the same check `generate_course_picture` already performs.

Note for reviewers: `CourseVoter::EDIT` accepts base-course teachers and admins, so a session coach who is not also a base-course teacher now receives a 403 on these three endpoints. That matches the sibling AI endpoints.

Refs GHSA-vgw6-gj2j-5q3p
