### PR TITLE
Forum: Fix the deletion of a thread whose posts form a parent chain

### DIFF
--- a/src/CourseBundle/Repository/CForumThreadRepository.php
+++ b/src/CourseBundle/Repository/CForumThreadRepository.php
@@ -60,18 +60,22 @@ class CForumThreadRepository extends ResourceRepository
             $resource->setParent($forum);
         }
 
-        $posts = $resource->getPosts();
-        if (!empty($posts)) {
-            foreach ($posts as $post) {
-                $post->setParent($resource);
+        // Only repair the resource-node hierarchy here; do NOT delete post by post.
+        // parent::delete() already removes the whole descendant tree in a SINGLE flush,
+        // and that is deliberate — see ResourceRepository::scheduleForRemoval(). One
+        // flush per post re-enters ResourceDoctrineListener's own persist-and-flush
+        // cycle, and those interleaved flushes make the UnitOfWork report an
+        // already-removed post as a new entity through CForumPost::$postParent, so the
+        // delete aborted with a 500 on any thread whose posts form a parent chain
+        // (a reply, plus a quote of that reply).
+        foreach ($resource->getPosts() as $post) {
+            $post->setParent($resource);
 
-                foreach ($post->getAttachments() as $attachment) {
-                    $attachment->setParent($post);
-                }
-
-                parent::delete($post);
+            foreach ($post->getAttachments() as $attachment) {
+                $attachment->setParent($post);
             }
         }
+
         parent::delete($resource);
     }
 


### PR DESCRIPTION
## Problem

Deleting a forum thread returns **HTTP 500** when its posts form a parent chain — a reply, plus a quote of that reply. The UI reports "Could not delete thread" and the thread stays in place.

```
DELETE /api/forum_threads/{iid} -> 500

A new entity was found through the relationship
'Chamilo\CourseBundle\Entity\CForumPost#postParent' that was not configured
to cascade persist operations
```

Reproduced against a running instance. A thread with 0 or 1 replies deletes normally (`200`); only the chained shape fails.

## Cause

`CForumThreadRepository::delete()` removed the thread's posts one by one with `parent::delete($post)`. Each of those calls flushes, and `ResourceRepository::scheduleForRemoval()` documents exactly why that is a problem: a flush per child re-enters `ResourceDoctrineListener`'s own persist-and-flush cycle, and the interleaved flushes make the UnitOfWork report an already-removed post as a new entity through the `postParent` self-association.

That method was written to collect every removal and flush **once**. The thread repository was bypassing it.

## Fix

Keep only the resource-node repair in the loop, and let `parent::delete()` remove the whole descendant tree in its single flush. `CForumPostRepository::delete()` already follows this pattern; the thread repository was the outlier.

## Verification

- Reproduced the failure, applied the change, and confirmed `200 DELETE` with the thread gone on the same chained thread.
- `tests/playwright/features/toolForum.feature` — its "Delete a forum thread" scenario deletes a thread carrying a reply and a quote, so it fails without this change and passes with it (8/8).
- ECS clean on the changed file.
