### PR TITLE
Mobile: register message push Doctrine listener

### DIFF
--- a/src/CoreBundle/Resources/config/services.yml
+++ b/src/CoreBundle/Resources/config/services.yml
@@ -142,6 +142,8 @@ services:
         $registry: '@doctrine'
         $em: '@doctrine.orm.entity_manager'
 
+    Chamilo\CoreBundle\EventListener\MobileMessagePushListener: ~
+
     Chamilo\CoreBundle\EventListener\AccessUrlValidationListener:
       arguments:
         $accessUrlHelper: '@Chamilo\CoreBundle\Helpers\AccessUrlHelper'

--- a/tests/CoreBundle/EventListener/MobileMessagePushListenerContainerTest.php
+++ b/tests/CoreBundle/EventListener/MobileMessagePushListenerContainerTest.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+/* For licensing terms, see /license.txt */
+
+namespace Chamilo\Tests\CoreBundle\EventListener;
+
+use Chamilo\CoreBundle\EventListener\MobileMessagePushListener;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Events;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+final class MobileMessagePushListenerContainerTest extends KernelTestCase
+{
+    public function testListenerIsRegisteredForDoctrineEvents(): void
+    {
+        self::bootKernel();
+
+        $container = self::getContainer();
+
+        self::assertTrue($container->has(MobileMessagePushListener::class));
+        self::assertInstanceOf(
+            MobileMessagePushListener::class,
+            $container->get(MobileMessagePushListener::class)
+        );
+
+        $entityManager = $container->get('doctrine.orm.entity_manager');
+        self::assertInstanceOf(EntityManagerInterface::class, $entityManager);
+
+        foreach ([Events::postPersist, Events::postFlush] as $eventName) {
+            self::assertTrue(
+                $this->containsMobileMessagePushListener(
+                    $entityManager->getEventManager()->getListeners($eventName)
+                ),
+                \sprintf('MobileMessagePushListener is not registered for Doctrine event "%s".', $eventName)
+            );
+        }
+    }
+
+    /**
+     * @param array<int, object> $listeners
+     */
+    private function containsMobileMessagePushListener(array $listeners): bool
+    {
+        foreach ($listeners as $listener) {
+            if ($listener instanceof MobileMessagePushListener) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}


### PR DESCRIPTION
Register MobileMessagePushListener explicitly because CoreBundle/EventListener is excluded from automatic service discovery.

The listener already declares Doctrine postPersist and postFlush attributes, but it was not present in the Symfony container, so normal Chamilo messages did not trigger mobile push delivery.

Validation:
- service is present in the Symfony container
- postPersist and postFlush Doctrine listener tags are registered
- focused PHPUnit test passes