### PR TITLE
Security: Fix installer .env command injection

### DIFF
--- a/public/main/install/install.lib.php
+++ b/public/main/install/install.lib.php
@@ -1474,13 +1474,10 @@ function escapeInstallerEnvValue(mixed $value): string
         throw new \InvalidArgumentException('Installer .env values cannot contain line breaks.');
     }
 
-    // .env.dist wraps every value in single quotes: KEY='{{VALUE}}'. Symfony
-    // Dotenv's single-quote grammar has no backslash escape, so turning ' into
-    // \' would end the quoted region and let a trailing $(...) run as a shell
-    // command substitution. Use the POSIX '\'' idiom (close quote, escaped
-    // quote, reopen quote) so a single quote stays inside a quoted segment,
-    // where $ is literal. A backslash needs no escaping: it is literal inside
-    // single quotes and round-trips unchanged through Dotenv.
+    // .env.dist wraps values in single quotes, and Dotenv has no backslash
+    // escape inside them. Emit the POSIX '\'' idiom so a quote cannot end the
+    // value and let a trailing $(...) run as a shell command.
+    // Example: x'$(id) -> x'\''$(id) -> KEY='x'\''$(id)' (literal, not executed).
     return str_replace("'", "'\\''", $value);
 }
 

--- a/public/main/install/install.lib.php
+++ b/public/main/install/install.lib.php
@@ -1474,11 +1474,14 @@ function escapeInstallerEnvValue(mixed $value): string
         throw new \InvalidArgumentException('Installer .env values cannot contain line breaks.');
     }
 
-    return str_replace(
-        ['\\', "'"],
-        ['\\\\', "\\'"],
-        $value
-    );
+    // .env.dist wraps every value in single quotes: KEY='{{VALUE}}'. Symfony
+    // Dotenv's single-quote grammar has no backslash escape, so turning ' into
+    // \' would end the quoted region and let a trailing $(...) run as a shell
+    // command substitution. Use the POSIX '\'' idiom (close quote, escaped
+    // quote, reopen quote) so a single quote stays inside a quoted segment,
+    // where $ is literal. A backslash needs no escaping: it is literal inside
+    // single quotes and round-trips unchanged through Dotenv.
+    return str_replace("'", "'\\''", $value);
 }
 
 function updateEnvFile($distFile, $envFile, $params)


### PR DESCRIPTION
The web installer's `escapeInstallerEnvValue()` turned a single quote into `\'`, which does not match Symfony Dotenv's single-quote grammar (no backslash escape): the quote ended the value and a trailing `$(...)` ran as a shell command substitution when the freshly written `.env` was re-parsed. The escaper now uses the POSIX `'\''` idiom so a quote stays inside a quoted segment where `$` is literal. Verified against the real symfony/dotenv parser: the PoC payload round-trips as data and no command runs.

Refs GHSA-fwg9-c834-c9r5