### PR TITLE
Security: Fix arbitrary file inclusion in the installer

### DIFF
--- a/public/main/install/index.php
+++ b/public/main/install/index.php
@@ -171,7 +171,15 @@ $langParam = $httpRequest->attributes->get('language_list')
     ?? $httpRequest->request->get('language_list');
 if ($langParam !== null && $langParam !== '') {
     $search = ['../', '\\0'];
-    $installationLanguage = str_replace($search, '', urldecode($langParam));
+    $candidate = str_replace($search, '', urldecode($langParam));
+    // Accept only a locale-shaped value. This value reaches the Symfony
+    // Translator, which throws Invalid "<value>" locale verbatim into the PHP
+    // error log for anything else; reflecting attacker text (e.g. inline PHP)
+    // there is the write half of a log-poisoning chain. Fall back to the
+    // default rather than pass an unvalidated locale through.
+    $installationLanguage = 1 === preg_match('/^[A-Za-z0-9_-]{1,32}$/', $candidate)
+        ? $candidate
+        : 'en_US';
     ChamiloSession::write('install_language', $installationLanguage);
 } elseif (ChamiloSession::has('install_language')) {
     $installationLanguage = ChamiloSession::read('install_language');

--- a/public/main/install/install.lib.php
+++ b/public/main/install/install.lib.php
@@ -361,16 +361,27 @@ function get_config_param($param, $updatePath = '')
         }
     }
 
-    if (file_exists($updatePath.$updateFromConfigFile) &&
-        !is_dir($updatePath.$updateFromConfigFile)
-    ) {
-        require $updatePath.$updateFromConfigFile;
+    // $updateFromConfigFile can arrive from the request (GET). Canonicalise the
+    // full path with realpath() so any ../ is collapsed, then require it only
+    // when it stays inside $updatePath and is the expected legacy config file.
+    // This blocks path traversal that would otherwise require an arbitrary file
+    // (e.g. the PHP error log for code execution, or .env for disclosure).
+    $configFilePath = realpath($updatePath.$updateFromConfigFile);
+    if (false !== $configFilePath) {
+        $configFilePath = str_replace('\\', '/', $configFilePath);
 
-        if (isset($_configuration) && array_key_exists($param, $_configuration)) {
-            return $_configuration[$param];
+        if (!is_dir($configFilePath)
+            && 'configuration.php' === basename($configFilePath)
+            && str_starts_with($configFilePath, $updatePath)
+        ) {
+            require $configFilePath;
+
+            if (isset($_configuration) && array_key_exists($param, $_configuration)) {
+                return $_configuration[$param];
+            }
+
+            return null;
         }
-
-        return null;
     }
 
     error_log('Config array could not be found in get_config_param()', 0);


### PR DESCRIPTION
The installer's `get_config_param()` did `require $updatePath.$updateFromConfigFile` where `updateFromConfigFile` is request-controlled, allowing `../` traversal to include any web-readable file (disclosing `.env`, or executing PHP planted in the error log). Separately, an unvalidated `language_list` reached the Symfony Translator, which reflects it verbatim into the PHP error log via an `Invalid "<value>" locale` exception — the write half of a log-poisoning chain.

This canonicalises the required path with `realpath()` and requires it only when it stays inside `$updatePath` and is the expected `configuration.php`, and validates `language_list` against a strict locale pattern (falling back to the default otherwise). Both fixes verified in isolation: traversal / error-log / .env targets are refused while the legitimate config path loads, and the locale filter rejects inline PHP and shell metacharacters.

Note: the fixes neutralise the inclusion and reflection primitives regardless of the wizard's exposure gate. The installer is still intentionally reachable on an installed instance whose database is unreachable (a documented recovery path); hardening that gate is a separate decision left to maintainers.

Refs GHSA-cv9j-vrjm-hg9r