### PR TITLE
Security: Block the installer once the database is initialized

### DIFF
--- a/public/main/install/index.php
+++ b/public/main/install/index.php
@@ -144,9 +144,15 @@ if (file_exists($envFile)) {
             $dbVersion = null;
         }
 
-        // Block ONLY if DB is initialized AND version is up-to-date.
+        // Block whenever the database is already initialized. The previous
+        // version_compare() gate failed open on a stock install: a fresh 3.0.0
+        // seeds chamilo_database_version to 2.0.0 and never raises it, so
+        // version_compare('2.0.0', '3.0.0', '>=') is false and an anonymous
+        // caller could still drive the wizard's writing steps (rewrite .env,
+        // build a schema, create an administrator). Recovering a half-installed
+        // instance is unaffected: that path has $dbLooksInitialized === false.
         $dbVersion = is_string($dbVersion) ? trim($dbVersion) : '';
-        if ($dbLooksInitialized && $dbVersion !== '' && version_compare($dbVersion, $installerVersion, '>=')) {
+        if ($dbLooksInitialized) {
             header('HTTP/1.1 409 Conflict');
             echo '<!doctype html><meta charset="utf-8"><title>Chamilo already installed</title>';
             echo '<div style="font-family:system-ui;max-width:760px;margin:64px auto;padding:24px;border:1px solid #e5e7eb;border-radius:12px">';


### PR DESCRIPTION
The installer's already-installed guard blocked the wizard only when the recorded `chamilo_database_version` was `>=` the installer version. A fresh install seeds that value to 2.0.0 and never raises it, so `version_compare('2.0.0', '3.0.0', '>=')` is false and the guard failed open: an anonymous caller could still drive the wizard's writing steps on an installed, serving instance (rewrite `.env`, build a schema in an attacker-named database, create a global administrator).

The gate now blocks whenever the database is already initialized, dropping the version comparison. Recovering a half-installed instance is unaffected — that path has `$dbLooksInitialized === false` and is intentionally still allowed.

Uncertainty flagged for review: a legitimate web-driven **upgrade** run against an already-initialized database is now refused with 409; upgrades go through `bin/console doctrine:migrations:migrate`. If a browser upgrade flow must stay, it needs to move behind authentication rather than reopen this anonymous path.

Refs GHSA-rprg-xh52-cfrq