### PR TITLE
Installer: Drop reliance on the deprecated chamilo_database_version value

### DIFF
--- a/public/main/install/index.php
+++ b/public/main/install/index.php
@@ -93,7 +93,6 @@ if (file_exists($envFile)) {
         ) === '1';
 
     if ($appInstalled && $installerVersion) {
-        $dbVersion = null;
         $dbLooksInitialized = false;
 
         try {
@@ -115,10 +114,6 @@ if (file_exists($envFile)) {
                 $hasAnySetting = $conn->fetchOne('SELECT 1 FROM settings_current LIMIT 1');
                 if ($hasAnySetting !== false && $hasAnySetting !== null) {
                     $dbLooksInitialized = true;
-
-                    $dbVersion = $conn->fetchOne(
-                        "SELECT selected_value FROM settings_current WHERE variable = 'chamilo_database_version' LIMIT 1"
-                    );
                 }
             } catch (\Throwable $e) {
                 // Ignore and try legacy table
@@ -129,10 +124,6 @@ if (file_exists($envFile)) {
                     $hasAnySetting = $conn->fetchOne('SELECT 1 FROM settings LIMIT 1');
                     if ($hasAnySetting !== false && $hasAnySetting !== null) {
                         $dbLooksInitialized = true;
-
-                        $dbVersion = $conn->fetchOne(
-                            "SELECT selected_value FROM settings WHERE variable = 'chamilo_database_version' LIMIT 1"
-                        );
                     }
                 } catch (\Throwable $e) {
                     // No settings tables -> DB is not initialized
@@ -141,17 +132,13 @@ if (file_exists($envFile)) {
         } catch (\Throwable $e) {
             // If we cannot connect, do not block the wizard
             $dbLooksInitialized = false;
-            $dbVersion = null;
         }
 
-        // Block whenever the database is already initialized. The previous
-        // version_compare() gate failed open on a stock install: a fresh 3.0.0
-        // seeds chamilo_database_version to 2.0.0 and never raises it, so
-        // version_compare('2.0.0', '3.0.0', '>=') is false and an anonymous
-        // caller could still drive the wizard's writing steps (rewrite .env,
-        // build a schema, create an administrator). Recovering a half-installed
-        // instance is unaffected: that path has $dbLooksInitialized === false.
-        $dbVersion = is_string($dbVersion) ? trim($dbVersion) : '';
+        // Block whenever the database is already initialized. Comparing a stored
+        // version is deliberately avoided: chamilo_database_version is deprecated
+        // and a fresh install seeds a stale value, which previously let the gate
+        // fail open for an anonymous caller. Recovering a half-installed instance
+        // is unaffected: that path has $dbLooksInitialized === false.
         if ($dbLooksInitialized) {
             header('HTTP/1.1 409 Conflict');
             echo '<!doctype html><meta charset="utf-8"><title>Chamilo already installed</title>';

--- a/public/main/install/install.lib.php
+++ b/public/main/install/install.lib.php
@@ -1996,32 +1996,14 @@ function isUpdateAvailable(): bool
         return false;
     }
 
-    // Compare versions (DB version vs installer version)
-    $versionInfo = require __DIR__ . '/version.php';
-    $installerVersion = $versionInfo['new_version'] ?? null;
-    if (!$installerVersion) {
-        // Cannot determine installer version -> do not assume update
-        error_log('Installer: Missing installer version info, update check disabled.');
-        return false;
-    }
-
-    $dbVersion = null;
-    try {
-        $dbVersion = get_config_param_from_db('chamilo_database_version');
-    } catch (\Throwable $e) {
-        // If we cannot read version, avoid false positives
-        error_log('Installer: Unable to read DB version, update check disabled. Reason: ' . $e->getMessage());
-        return false;
-    }
-
-    // If the DB looks like Chamilo (settings table exists) but version is missing,
-    // it is likely an old install (e.g., 1.11.x) -> update should be offered.
-    $dbVersion = is_string($dbVersion) ? trim($dbVersion) : '';
-    if ($dbVersion === '') {
-        return true;
-    }
-
-    return version_compare($dbVersion, $installerVersion, '<');
+    // The web installer no longer detects a pending update from a stored
+    // version. It used to compare the deprecated chamilo_database_version
+    // setting against the installer version, but that value is a hand-maintained
+    // literal that migrations never raise, so a fresh install was wrongly
+    // flagged as needing an update. Database upgrades run through
+    // doctrine:migrations:migrate; reaching this point only proves the platform
+    // is already installed, which is not an update.
+    return false;
 }
 
 /**

--- a/src/CoreBundle/Settings/PlatformSettingsSchema.php
+++ b/src/CoreBundle/Settings/PlatformSettingsSchema.php
@@ -48,6 +48,10 @@ class PlatformSettingsSchema extends AbstractSettingsSchema
                     'allow_my_files' => 'true',
                     'registered' => 'false',
                     'server_type' => 'prod',
+                    // Deprecated: the value is not maintained (migrations never
+                    // raise it) and must not be compared against the code version.
+                    // The row is kept only as a fresh-install presence marker for
+                    // InstallDbGuardSubscriber. Hidden from the UI (getHiddenSettings).
                     'chamilo_database_version' => '2.0.0',
                     'unoconv_binaries' => '/usr/bin/unoconv',
                     'pdf_img_dpi' => '96',


### PR DESCRIPTION
## What

Stops the web installer from using the value of the deprecated `chamilo_database_version` setting.

- `index.php`: removes the now-dead `$dbVersion` reads left by the already-installed gate (the gate blocks on `$dbLooksInitialized`, not on a version), and updates the comment.
- `install.lib.php`: `isUpdateAvailable()` no longer reads the setting or runs `version_compare` against it; it returns `false` after confirming the platform is installed. Database upgrades run through `doctrine:migrations:migrate`.
- `PlatformSettingsSchema.php`: documents the setting as deprecated at its default.

## Why

The value is a hand-maintained literal that migrations never raise, so comparing it was unreliable (a fresh install was flagged as "update available"). The `version` table is not a usable replacement because a fresh install does not create it. The setting's row is kept — its **presence** is still used by `InstallDbGuardSubscriber` as a fresh-install health marker — only its value is retired.

## Behavior

No reachable behavior changes: on an installed instance the gate already returns 409 before `isUpdateAvailable()` runs, and a platform without `.env` returns `false` early. The web installer's version-based update flow was already effectively gated off.

## Follow-up (not in this PR)

With `isUpdateAvailable()` now always `false`, the downstream update-flow branches in `index.php` (`$my_old_version`, `$isModernUpdate`, the update-only UI) are dead but harmless; removing them is a separate cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)