### PR TITLE
Settings: Remove the deprecated chamilo_database_version setting

### DIFF
--- a/config/packages/doctrine_migrations.yaml
+++ b/config/packages/doctrine_migrations.yaml
@@ -4,6 +4,7 @@ doctrine_migrations:
         'Chamilo\CoreBundle\Migrations\Schema\V200': '%kernel.project_dir%/src/CoreBundle/Migrations/Schema/V200'
         'Chamilo\CoreBundle\Migrations\Schema\V210': '%kernel.project_dir%/src/CoreBundle/Migrations/Schema/V210'
         'Chamilo\CoreBundle\Migrations\Schema\V300': '%kernel.project_dir%/src/CoreBundle/Migrations/Schema/V300'
+        'Chamilo\CoreBundle\Migrations\Schema\V400': '%kernel.project_dir%/src/CoreBundle/Migrations/Schema/V400'
 
     services:
         'Doctrine\Migrations\Version\MigrationFactory': 'Chamilo\CoreBundle\Migrations\MigrationFactory'

--- a/public/main/inc/lib/api.lib.php
+++ b/public/main/inc/lib/api.lib.php
@@ -6211,7 +6211,6 @@ function api_get_locked_settings()
         'languagePriority3',
         'languagePriority4',
         'login_is_email',
-        'chamilo_database_version',
     ];
 }
 

--- a/public/main/inc/lib/diagnoser.lib.php
+++ b/public/main/inc/lib/diagnoser.lib.php
@@ -353,18 +353,6 @@ class Diagnoser
             get_lang('The directory should be removed (it is no longer necessary)')
         );
 
-        $app_version = api_get_setting('platform.chamilo_database_version');
-        $array[] = $this->build_setting(
-            self::STATUS_INFORMATION,
-            '[DB]',
-            'chamilo_database_version',
-            '#',
-            $app_version,
-            0,
-            null,
-            'Chamilo DB version'
-        );
-
         $access_url_id = api_get_current_access_url_id();
 
         if (1 === $access_url_id) {

--- a/public/main/install/migrations.php
+++ b/public/main/install/migrations.php
@@ -14,6 +14,7 @@ return [
         'Chamilo\CoreBundle\Migrations\Schema\V200' => '../../../src/CoreBundle/Migrations/Schema/V200',
         'Chamilo\CoreBundle\Migrations\Schema\V210' => '../../../src/CoreBundle/Migrations/Schema/V210',
         'Chamilo\CoreBundle\Migrations\Schema\V300' => '../../../src/CoreBundle/Migrations/Schema/V300',
+        'Chamilo\CoreBundle\Migrations\Schema\V400' => '../../../src/CoreBundle/Migrations/Schema/V400',
     ],
     'all_or_nothing' => false,
     'check_database_platform' => true,

--- a/src/CoreBundle/DataFixtures/SettingsCurrentFixtures.php
+++ b/src/CoreBundle/DataFixtures/SettingsCurrentFixtures.php
@@ -30,7 +30,6 @@ class SettingsCurrentFixtures extends Fixture implements FixtureGroupInterface
         'cron_remind_course_expiration_activate',
         'donotlistcampus',
         'server_type',
-        'chamilo_database_version',
         'unoconv_binaries',
         'session_admin_access_to_all_users_on_all_urls',
         'split_users_upload_directory',
@@ -1096,11 +1095,6 @@ class SettingsCurrentFixtures extends Fixture implements FixtureGroupInterface
                     'name' => 'timezone',
                     'title' => 'Default timezone',
                     'comment' => 'Select the default timezone for this portal. This will help set the timezone (if the feature is enabled) for each new user or for any user that has not set a specific timezone yet. Timezones help show all time-related information on screen in the specific timezone of each user.',
-                ],
-                [
-                    'name' => 'chamilo_database_version',
-                    'title' => 'Current version of the database schema used by Chamilo',
-                    'comment' => 'Displays the current DB version to match the Chamilo core version.',
                 ],
                 [
                     'name' => 'notification_event',

--- a/src/CoreBundle/EventSubscriber/InstallDbGuardSubscriber.php
+++ b/src/CoreBundle/EventSubscriber/InstallDbGuardSubscriber.php
@@ -17,8 +17,6 @@ use const PHP_SAPI;
 
 final class InstallDbGuardSubscriber implements EventSubscriberInterface
 {
-    private const string VERSION_KEY = 'chamilo_database_version';
-
     public function __construct(
         private readonly Connection $connection
     ) {}
@@ -84,53 +82,14 @@ final class InstallDbGuardSubscriber implements EventSubscriberInterface
                 }
             }
 
-            // Cheap proof: at least 1 row
+            // A populated settings table proves the install finished:
+            // installSchemas() seeds every platform setting in one pass, so at
+            // least one row means the schema build completed. This replaces the
+            // former chamilo_database_version presence check (that setting was
+            // removed) and stays correct on a fresh install, which never creates
+            // the Doctrine `version` table.
             $hasRow = $this->connection->fetchOne("SELECT 1 FROM {$settingsTable} LIMIT 1");
             if (false === $hasRow || null === $hasRow) {
-                $this->redirectToInstaller($event);
-
-                return;
-            }
-
-            // Read DB version (try common column names; only runs until first success)
-            $version = null;
-            foreach (['selected_value', 'value', 'c_value'] as $col) {
-                try {
-                    $version = $this->connection->fetchOne(
-                        "SELECT {$col} FROM {$settingsTable} WHERE variable = :var LIMIT 1",
-                        ['var' => self::VERSION_KEY]
-                    );
-                    if (!empty($version)) {
-                        break;
-                    }
-                } catch (Throwable) {
-                    // Try next column
-                }
-            }
-
-            if (empty($version)) {
-                // chamilo_database_version is missing. This can mean:
-                // a) Fresh Chamilo 1 DB before migration (should redirect)
-                // b) Migration started but not yet finished (should NOT redirect –
-                //    redirecting here creates an infinite loop because APP_INSTALLED=1
-                //    is written to .env at step 5, before the migration runs).
-                // Distinguish by checking whether the Doctrine migrations version
-                // table exists and has rows (= migration is in progress or failed).
-                try {
-                    $migrationCount = $this->connection->fetchOne(
-                        'SELECT COUNT(*) FROM version'
-                    );
-                    if ($migrationCount > 0) {
-                        // Migration has started (or is running) – allow the request
-                        // through so the installer can display progress / retry.
-                        $isHealthy = true;
-
-                        return;
-                    }
-                } catch (Throwable) {
-                    // version table does not exist yet – fall through to redirect.
-                }
-
                 $this->redirectToInstaller($event);
 
                 return;

--- a/src/CoreBundle/Migrations/Schema/V400/Version20260911000000.php
+++ b/src/CoreBundle/Migrations/Schema/V400/Version20260911000000.php
@@ -1,0 +1,38 @@
+<?php
+
+/* For licensing terms, see /license.txt */
+
+declare(strict_types=1);
+
+namespace Chamilo\CoreBundle\Migrations\Schema\V400;
+
+use Chamilo\CoreBundle\Migrations\AbstractMigrationChamilo;
+use Doctrine\DBAL\Schema\Schema;
+
+final class Version20260911000000 extends AbstractMigrationChamilo
+{
+    private const string VARIABLE = 'chamilo_database_version';
+
+    public function getDescription(): string
+    {
+        return 'Remove the deprecated chamilo_database_version setting from existing installations.';
+    }
+
+    public function up(Schema $schema): void
+    {
+        if (!$schema->hasTable('settings')) {
+            return;
+        }
+
+        $this->addSql(
+            'DELETE FROM settings WHERE variable = ?',
+            [self::VARIABLE],
+        );
+    }
+
+    public function down(Schema $schema): void
+    {
+        // Intentional one-way cleanup: the setting is deprecated and its value
+        // was never maintained, so there is nothing meaningful to restore.
+    }
+}

--- a/src/CoreBundle/Settings/PlatformSettingsSchema.php
+++ b/src/CoreBundle/Settings/PlatformSettingsSchema.php
@@ -48,7 +48,6 @@ class PlatformSettingsSchema extends AbstractSettingsSchema
                     'allow_my_files' => 'true',
                     'registered' => 'false',
                     'server_type' => 'prod',
-                    'chamilo_database_version' => '2.0.0',
                     'unoconv_binaries' => '/usr/bin/unoconv',
                     'pdf_img_dpi' => '96',
                     'hosting_limit_users_per_course' => '0',
@@ -146,7 +145,6 @@ class PlatformSettingsSchema extends AbstractSettingsSchema
     {
         return [
             'registered',
-            'chamilo_database_version',
         ];
     }
 }

--- a/src/CoreBundle/Settings/SettingsManager.php
+++ b/src/CoreBundle/Settings/SettingsManager.php
@@ -1191,7 +1191,6 @@ class SettingsManager implements SettingsManagerInterface
             'meta_image_path' => 'Tracking',
             'allow_teachers_to_create_sessions' => 'Session',
             'institution_address' => 'Platform',
-            'chamilo_database_version' => 'null',
             'cron_remind_course_finished_activate' => 'Crons',
             'cron_remind_course_expiration_frequency' => 'Crons',
             'cron_remind_course_expiration_activate' => 'Crons',


### PR DESCRIPTION
## What

Removes the deprecated `chamilo_database_version` setting entirely and reworks the install guard so its presence is no longer needed.

**Definition and consumers removed**
- `PlatformSettingsSchema`: default value + `getHiddenSettings()` entry.
- `SettingsCurrentFixtures`: the setting definition + the access-url-locked list entry.
- `SettingsManager`: the category-map entry.
- `diagnoser.lib.php`: the "Chamilo DB version" diagnostics row (it displayed the stale value).
- `api.lib.php`: the `api_get_locked_settings()` entry.

**Install guard reworked** — `InstallDbGuardSubscriber`
- Previously used the **presence** of `chamilo_database_version` to decide a fresh install was healthy, falling back to the Doctrine `version` table.
- Now treats a **populated `settings` table** as proof the install finished: `installSchemas()` seeds every setting in one pass, so at least one row means the schema build completed. This is version-independent and correct on a fresh install, which never creates the `version` table.

**Migration** — `V400/Version20260911000000`
- Deletes the row from `settings` on existing installations. Registered in `doctrine_migrations.yaml` and `public/main/install/migrations.php`.

## Why

The value was a hand-maintained literal that migrations never raise; it is no longer used for any logic after the installer stopped comparing it (#9061). Keeping it only invited stale-version bugs.

## Verification

- `php -l` clean on all changed files; ECS clean on the `src/` files.
- No remaining references except the V400 migration and the historical V200 migrations (immutable), plus the installer update-flow helpers noted below.

## Known remaining references (dead, safe)

The installer's web-upgrade helpers `getChamiloDatabaseVersion()` / `setChamiloDatabaseVersion()` and two writes in `install.lib.php` still name the setting. They live in the update flow that rprg (#9060, merged) gates off with a 409 and that #9061 neutralises (`isUpdateAvailable()` → false), so they are unreachable. `getChamiloDatabaseVersion()` returns `''` gracefully; `setChamiloDatabaseVersion()`'s throw cannot be reached. Best cleaned alongside #9061's update-flow work to avoid a cross-PR conflict on `install.lib.php` / `index.php`.

Complements #9061.

🤖 Generated with [Claude Code](https://claude.com/claude-code)